### PR TITLE
docs: add Concordia ecosystem section, update status table, add release notes v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,19 @@ Webhook callbacks on all terminal state transitions (`COMPLETED`, `REJECTED_FINA
 
 ---
 
+## Ecosystem
+
+A2CN coordinates with [Concordia Protocol](https://github.com/eriknewton/concordia-protocol) on a joint Agent Mandate Specification and joint A2A extension proposal. A2CN is the procurement-vertical layer; Concordia covers cross-domain negotiation semantics. Both compose cleanly on A2A transport.
+
+The joint work includes:
+- A shared Agent Mandate Specification covering delegation chains, DID-VC verification, and revocation semantics
+- A joint procurement patterns library (`concordia-a2cn/procurement-patterns`) with canonical RFQ, BAFO, and reverse auction patterns expressed in both protocol shapes
+- Coordinated A2A extension proposals filed simultaneously
+
+Neither protocol requires the other. Both remain independently usable.
+
+---
+
 ## Quickstart
 
 ```bash
@@ -260,7 +273,7 @@ A2CN/
 | Invitation flow demo | ✓ Working — Fairmarkit BID_CREATED pattern |
 | Security review | ✓ Passed — 0 critical, 0 high findings |
 | Deal type registry | ✓ Published — `a2cn.dev/registry/deal-types` |
-| A2A extension proposal | 🔄 In progress |
+| A2A extension proposal | 🔄 In progress — joint proposal with Concordia Protocol |
 | Meeting Place (neutral transaction hosting) | 📋 Planned — v0.3 |
 | TypeScript reference implementation | 📋 Planned |
 | SDK (pip + npm) | 📋 Planned |
@@ -274,6 +287,8 @@ A2CN/
 **Developers building on LangChain, CrewAI, Salesforce Agentforce, or Microsoft Copilot Studio** with agents that need to interact with counterparty agents across organizational boundaries.
 
 **Protocol and distributed systems engineers** interested in open standards work. The cryptographic design, session state machine, and deterministic record generation all have interesting problems. Open issues tagged [`help wanted`](https://github.com/A2CN-protocol/A2CN/issues?q=label%3A%22help+wanted%22) and [`good first issue`](https://github.com/A2CN-protocol/A2CN/issues?q=label%3A%22good+first+issue%22).
+
+**Protocol co-founders with enterprise GTM or BD background** — if you want to help build the standard and the business around it alongside the technical work, reach out at contact@a2cn.io.
 
 ---
 

--- a/RELEASE_NOTES_v0.2.0.md
+++ b/RELEASE_NOTES_v0.2.0.md
@@ -1,0 +1,68 @@
+# A2CN v0.2.0 Release Notes
+
+**Released:** April 2026  
+**Spec:** v0.2.0 (3,300+ lines)  
+**Tests:** 202 passing  
+**License:** Apache 2.0
+
+## What's new in v0.2.0
+
+### Session Invitation (Component 8)
+Solves the cold-start problem. A buyer agent can now invite a supplier who has no A2CN endpoint yet via a signed SessionInvitation delivered through existing webhook infrastructure (Fairmarkit BID_CREATED, email, or Meeting Place). The invitation is ES256-signed using the inviter's DID key. The supplier verifies authenticity before activating any endpoint.
+
+### Platform adapters
+- **Fairmarkit** — FairmakitEventParser translates BID_CREATED webhook payloads into A2CN goods_procurement terms and translates agreed terms back into Fairmarkit's response API format. Path B integration — zero Fairmarkit platform changes required.
+- **Salesforce Revenue Cloud** — RevenueCloudAdapter translates Revenue Cloud Pricing API responses into A2CN offer terms and translates agreed terms into Revenue Cloud order payloads.
+- **Keelvar** — SOURCING_EVENTS_FEED_UPDATED webhook → A2CN session translation.
+
+### Deal-type-specific terms schemas
+- `goods_procurement` — delivery_days, unit_of_measure, manufacturer and internal part numbers
+- `saas_renewal` — seat_count, subscription_tier, support_tier, auto_renew_terms, uptime_sla_percent
+
+### Impasse detection
+Configurable `impasse_threshold` in session_params. When N consecutive rounds show less than 0.5% movement in total_value, session transitions to IMPASSE. Default N=3, configurable 1-10.
+
+### LLM negotiation skills file
+Reference skills file for LLM agents participating in A2CN sessions. Covers warmth-dominance calibration, chain-of-thought reasoning patterns, and Inject+Voss prompt injection defense. Based on Vaccaro et al. (2026) arXiv:2503.06416v3 — 182,812 AI-to-AI negotiations.
+
+### Webhooks at Level 2
+Terminal state webhooks (COMPLETED, REJECTED_FINAL, WITHDRAWN, IMPASSE, TIMED_OUT) promoted from RECOMMENDED to REQUIRED for Level 2 conformance. Async delivery with exponential backoff retry.
+
+## Installation
+
+```bash
+git clone https://github.com/A2CN-protocol/A2CN.git
+cd A2CN/reference-implementation/python
+pip install -e .
+```
+
+## Run the demos
+
+```bash
+# SaaS renewal bilateral negotiation
+python examples/saas_renewal.py
+
+# Session Invitation / Fairmarkit integration pattern
+uvicorn server:app --port 8002  # Terminal 1
+python examples/invitation_flow.py  # Terminal 2
+
+# Keelvar sourcing event end-to-end
+python examples/keelvar_demo.py
+```
+
+## Run the tests
+
+```bash
+pip install -r requirements.txt
+pytest tests/ -v
+# 202 passed
+```
+
+## What's next (v0.3)
+
+- Meeting Place — neutral transaction hosting, mandate management, EU AI Act compliance export
+- Ed25519 as alternate signing suite (coordinated with Concordia Protocol)
+- Delegation chain support in mandate verification
+- Joint A2A extension proposal with Concordia Protocol
+- TypeScript reference implementation
+- pip install packaging


### PR DESCRIPTION
## Summary

- **README.md** — adds Ecosystem section after "What A2CN is not" describing A2CN/Concordia coordination (joint mandate spec, procurement patterns library, coordinated A2A proposals)
- **README.md** — updates A2A extension row in status table to note joint proposal with Concordia Protocol
- **README.md** — adds "Protocol co-founders with enterprise GTM or BD background" bullet to Who we are looking for
- **RELEASE_NOTES_v0.2.0.md** — new file with full v0.2.0 changelog (Session Invitation, platform adapters, deal-type schemas, impasse detection, LLM skills file, webhook Level 2 requirement)

## Test plan

- [x] No code files changed
- [x] Protocol stack diagram unchanged
- [x] Fairmarkit code example unchanged
- [x] Ecosystem section renders correctly in Markdown
- [x] Status table row updated
- [x] New bullet appears in Who we are looking for

## After merging

1. Cut the v0.2.0 release on GitHub using `RELEASE_NOTES_v0.2.0.md` as the release body (tag: `v0.2.0`)
2. Add GitHub topics via repo Settings → Topics: `procurement`, `negotiation-protocol`, `a2a`, `mcp`, `agent-negotiation`, `open-protocol`, `b2b`, `apache-2-0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)