### PR TITLE
Fix LLM agent protocol act version

### DIFF
--- a/reference-implementation/python/examples/llm_agent.py
+++ b/reference-implementation/python/examples/llm_agent.py
@@ -290,7 +290,7 @@ def _build_seller_counteroffer(
     exp = _expires_at()
     msg_id = str(uuid.uuid4())
     protocol_act = {
-        "protocol_version": "0.1",
+        "protocol_version": "0.2",
         "session_id": session_id,
         "round_number": round_number,
         "sequence_number": sequence_number,
@@ -333,7 +333,7 @@ def _build_seller_acceptance(
     exp = _expires_at()
     msg_id = str(uuid.uuid4())
     protocol_act = {
-        "protocol_version": "0.1",
+        "protocol_version": "0.2",
         "session_id": session_id,
         "round_number": round_number,
         "sequence_number": sequence_number,


### PR DESCRIPTION
## Summary
- update seller-side LLM agent protocol act hashing to use protocol version `0.2`
- aligns seller counteroffer and acceptance builders with the session verifier and client path

## Tests
- `uv run --extra dev python -m pytest tests/test_llm_agent.py`
- `uv run --extra dev python -m pytest`
