### PR TITLE
feat: add DealHub CPQ and Nue.io Revenue Lifecycle seller-side adapters

### DIFF
--- a/reference-implementation/python/adapters/DEALHUB_INTEGRATION.md
+++ b/reference-implementation/python/adapters/DEALHUB_INTEGRATION.md
@@ -1,0 +1,135 @@
+# DealHub CPQ — A2CN Integration Guide
+
+DealHub is a seller-side CPQ platform. This adapter translates DealHub
+quoteReady webhook events and API responses into A2CN session terms, and
+translates A2CN agreed terms back into DealHub Actions API calls.
+
+---
+
+## Prerequisites
+
+- A DealHub account with API access enabled
+- An API Bearer token from **Control Panel → System Settings → API Settings**
+- A Headless Simulate Playbook ID (for Path B mandate bound calculation)
+- Network access from your A2CN server to your DealHub instance URL
+
+---
+
+## Environment Variables
+
+| Variable               | Description                                               |
+|------------------------|-----------------------------------------------------------|
+| `DEALHUB_AUTH_TOKEN`   | Bearer token from DealHub API Settings                    |
+| `DEALHUB_BASE_URL`     | Your DealHub instance URL (e.g. `https://yourdomain.dealhub.io`) |
+| `DEALHUB_PLAYBOOK_ID`  | API Playbook ID for headless quote simulation (Path B)    |
+
+---
+
+## Path A — Webhook-Driven Integration (Primary)
+
+```
+1. DealHub fires quoteReady webhook to your endpoint
+       ↓
+2. DealHubEventParser.quote_ready_webhook_to_session_params(payload)
+       → returns A2CN session_params (deal_type, currency, max_rounds, ...)
+       ↓
+3. DealHubEventParser.fetch_quote_details(payload["dealhub_quote_id"])
+       → returns full quote with line items
+       ↓
+4. DealHubEventParser.quote_to_a2cn_offer_terms(quote_response)
+       → returns A2CN offer terms dict (total_value in cents, line_items, ...)
+       ↓
+5. Initiate or join A2CN session — negotiation proceeds
+       ↓
+6. On COMPLETED: DealHubEventParser.agreed_terms_to_dealhub_action(
+       quote_id, a2cn_session_id, record_hash
+   )
+       → POST signExternally to DealHub Actions API
+       → DealHub quote is marked as won with A2CN audit trail in note field
+```
+
+Zero DealHub platform changes required.
+
+---
+
+## Path B — Headless Simulate (Secondary)
+
+Use before initiating a session to set agent mandate bounds from live pricing:
+
+```python
+from adapters.dealhub_adapter import DealHubEventParser
+
+bounds = DealHubEventParser.simulate_quote_for_mandate_bounds(
+    playbook_id=os.environ["DEALHUB_PLAYBOOK_ID"],
+    answers={
+        "product_id": "prod-enterprise",
+        "quantity": 100,
+        "customer_segment": "enterprise",
+    },
+    floor_discount_pct=0.15,   # 15% max authorised discount
+)
+
+mandate = {
+    "max_commitment_value": bounds["ceiling_value_cents"],
+    "min_acceptable_value": bounds["floor_value_cents"],
+    "currency": bounds["currency"],
+}
+```
+
+---
+
+## Field Map Configuration
+
+DealHub quote response field names vary by instance configuration. The
+default field map uses the most common names:
+
+```python
+DEFAULT_FIELD_MAP = {
+    "total_value_field":  "total_price",
+    "currency_field":     "currency",
+    "line_items_field":   "line_items",
+    "product_name_field": "product_name",
+    "quantity_field":     "quantity",
+    "unit_price_field":   "unit_price",
+}
+```
+
+Override individual keys when your instance uses different names:
+
+```python
+terms = DealHubEventParser.quote_to_a2cn_offer_terms(
+    quote_response,
+    field_map={"product_name_field": "name", "unit_price_field": "price"},
+)
+```
+
+---
+
+## Floor Discount Configuration
+
+`floor_discount_pct` in `simulate_quote_for_mandate_bounds` represents
+the maximum discount the seller's agent may offer without human approval.
+Configure per product category based on your actual sales policy:
+
+```python
+bounds = DealHubEventParser.simulate_quote_for_mandate_bounds(
+    playbook_id=playbook_id,
+    answers=answers,
+    floor_discount_pct=0.10,  # enterprise tier: 10% max
+)
+```
+
+---
+
+## Known Limitations
+
+- **Field names**: DealHub quote response field names (`total_price`,
+  `line_items`, `product_name`, etc.) are based on API conventions and
+  must be verified against a live DealHub instance. Use `field_map`
+  parameter to correct any mismatches.
+- **Simulate API schema**: The headless simulate response schema
+  (`total_price`, `line_items`, `currency`) must be verified against
+  a live DealHub sandbox. Contact DealHub support for the exact field names.
+- **Async HTTP**: The HTTP methods use synchronous `httpx`. Wrap in
+  `asyncio.to_thread()` or use `httpx.AsyncClient` if your server is
+  fully async.

--- a/reference-implementation/python/adapters/NUE_INTEGRATION.md
+++ b/reference-implementation/python/adapters/NUE_INTEGRATION.md
@@ -1,0 +1,113 @@
+# Nue.io Revenue Lifecycle — A2CN Integration Guide
+
+Nue.io is a seller-side CPQ and billing platform for SaaS companies,
+Salesforce-native with a REST API layer. This adapter translates Nue
+pricing and subscription data into A2CN session terms, and translates
+A2CN agreed terms back into Nue order creation.
+
+---
+
+## Prerequisites
+
+- A Nue.io account with API access
+- An API key from your Nue administrator
+- Access to the Nue production or sandbox environment
+
+---
+
+## Environment Variables
+
+| Variable        | Description                                                        |
+|-----------------|--------------------------------------------------------------------|
+| `NUE_API_KEY`   | API key from Nue administrator                                     |
+| `NUE_BASE_URL`  | `https://api.nue.io` (production) or `https://api.sandbox.nue.io` |
+
+---
+
+## Primary Flow — Pricing → Mandate Bounds → A2CN → Order
+
+```
+1. NueEventParser.fetch_pricing(price_book_id, product_id)
+       → GET /commerce/pricing from Nue
+       ↓
+2. NueEventParser.pricing_to_mandate_bounds(pricing_response)
+       → returns ceiling_value_cents, floor_value_cents, currency
+       → use to configure A2CN agent mandate
+       ↓
+3. A2CN negotiation session — buyer and seller agents negotiate
+       ↓
+4. On COMPLETED: NueEventParser.a2cn_terms_to_nue_order(
+       agreed_terms, customer_id, price_book_id, product_id,
+       a2cn_session_id, record_hash
+   )
+       → POST /orders to Nue
+       → Nue order created with A2CN audit trail in externalReference and notes
+```
+
+---
+
+## Renewal Flow — Subscription → Renewal Terms → A2CN
+
+```
+1. NueEventParser.fetch_customer_subscriptions(customer_id)
+       → GET /subscriptions?customerId={id} from Nue
+       → returns list of active subscription dicts
+       ↓
+2. NueEventParser.subscription_to_renewal_terms(subscription_response)
+       → returns A2CN saas_renewal terms with renewal markup applied
+       → seat_count, subscription_tier, auto_renew_terms, term_months
+       ↓
+3. A2CN saas_renewal session — negotiate renewal price and terms
+       ↓
+4. On COMPLETED: NueEventParser.a2cn_terms_to_nue_order(...)
+       → creates renewed Nue order
+```
+
+---
+
+## Audit Trail
+
+The `a2cn_terms_to_nue_order` method embeds the A2CN audit trail in every
+Nue order:
+
+- `externalReference`: `"a2cn-session-{a2cn_session_id}"` — links the Nue
+  order to the A2CN session in both systems.
+- `notes`: `"Agreed via A2CN. Record hash: {record_hash}"` — the record
+  hash is the content-addressed, dual-signed A2CN transaction record. This
+  is the cryptographic proof of agreement.
+
+These two fields create an immutable, auditable link between the Nue order
+and the A2CN transaction record. Retain both the record hash and session ID
+in your system of record.
+
+---
+
+## Floor Discount Configuration
+
+`floor_discount_pct` in `pricing_to_mandate_bounds` represents the maximum
+discount the seller's agent is authorised to offer without human approval.
+Configure per product tier in production:
+
+```python
+# Standard tier: 10% max discount
+std_bounds = NueEventParser.pricing_to_mandate_bounds(pricing, floor_discount_pct=0.10)
+
+# Enterprise tier: 20% max discount (higher authorisation level)
+ent_bounds = NueEventParser.pricing_to_mandate_bounds(pricing, floor_discount_pct=0.20)
+```
+
+---
+
+## Known Limitations
+
+- **Field names**: Nue API response field names (`listPrice`, `totalValue`,
+  `productTier`, `autoRenew`, `termMonths`, etc.) are based on public
+  documentation and API conventions. Verify against a live Nue sandbox
+  instance before production deployment. Contact Nue support for exact names.
+- **Pricing endpoint**: The Commerce Pricing API path (`/commerce/pricing`)
+  and its parameters should be confirmed against the latest Nue API docs.
+- **Subscription list key**: The top-level key in the subscriptions response
+  (`subscriptions` or `items`) is auto-detected; verify against sandbox.
+- **Async HTTP**: The HTTP methods use synchronous `httpx`. Wrap in
+  `asyncio.to_thread()` or use `httpx.AsyncClient` if your server is
+  fully async.

--- a/reference-implementation/python/adapters/dealhub_adapter.py
+++ b/reference-implementation/python/adapters/dealhub_adapter.py
@@ -1,0 +1,351 @@
+"""
+DealHub CPQ → A2CN translation layer.
+
+Translates DealHub quoteReady webhook events and API responses into A2CN
+session terms, and translates A2CN agreed terms back into DealHub Actions
+API calls.
+
+PATH A (primary):   DealHub fires quoteReady webhook
+                        → DealHubEventParser.quote_ready_webhook_to_session_params(payload)
+                        → DealHubEventParser.fetch_quote_details(quote_id)
+                        → DealHubEventParser.quote_to_a2cn_offer_terms(quote_response)
+                        → A2CN negotiation session
+                        → DealHubEventParser.agreed_terms_to_dealhub_action(...)
+
+PATH B (secondary): DealHubEventParser.simulate_quote_for_mandate_bounds(playbook_id, answers)
+                        → use ceiling / floor to configure agent mandate
+                        → A2CN negotiation session
+
+DealHub API reference:
+  Quote API:    {DEALHUB_BASE_URL}/api/v1/quotes/{quote_id}
+  Actions API:  {DEALHUB_BASE_URL}/api/v1/quotes/{quote_id}/actions
+  Simulate API: {DEALHUB_BASE_URL}/api/v1/headless/simulate
+
+Environment variables required:
+  DEALHUB_AUTH_TOKEN:  Bearer token from DealHub Control Panel → API Settings
+  DEALHUB_BASE_URL:    Your DealHub instance base URL
+  DEALHUB_PLAYBOOK_ID: API Playbook ID for headless quote simulation
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+
+
+_SUBSCRIPTION_KEYWORDS = frozenset({"license", "subscription", "seat"})
+
+
+class DealHubEventParser:
+    """
+    Translates DealHub CPQ webhook events and API responses into A2CN session
+    terms, and translates A2CN agreed terms back into DealHub Actions API calls.
+
+    Integration pattern: PATH A (webhook-driven) is primary for live seller-side
+    negotiation. PATH B (headless simulate) is used to set mandate bounds before
+    session initiation.
+
+    Environment variables required:
+        DEALHUB_AUTH_TOKEN: Bearer token from DealHub API Settings
+        DEALHUB_BASE_URL:   Your DealHub instance URL (e.g. https://yourdomain.dealhub.io)
+        DEALHUB_PLAYBOOK_ID: API Playbook ID for headless quotes
+    """
+
+    # Default field map for translating DealHub quote responses to A2CN terms.
+    # Override via the field_map parameter on quote_to_a2cn_offer_terms() if
+    # your DealHub instance uses different field names.
+    # FIELD NOTE: All field names should be verified against a live DealHub
+    # instance. Contact DealHub support or inspect sandbox responses for exact names.
+    DEFAULT_FIELD_MAP: dict[str, str] = {
+        "total_value_field":  "total_price",    # FIELD NOTE: Verify against live DealHub instance.
+        "currency_field":     "currency",        # FIELD NOTE: Verify against live DealHub instance.
+        "line_items_field":   "line_items",      # FIELD NOTE: Verify against live DealHub instance.
+        "product_name_field": "product_name",    # FIELD NOTE: Verify against live DealHub instance.
+        "quantity_field":     "quantity",        # FIELD NOTE: Verify against live DealHub instance.
+        "unit_price_field":   "unit_price",      # FIELD NOTE: Verify against live DealHub instance.
+    }
+
+    @staticmethod
+    def quote_ready_webhook_to_session_params(
+        payload: dict,
+        max_rounds: int = 5,
+    ) -> dict:
+        """
+        Translates a quoteReady webhook payload into A2CN session parameters.
+
+        Detects deal_type from product names in the optional ``items`` list:
+        if any product name contains 'license', 'subscription', or 'seat'
+        (case-insensitive) the deal is classified as 'saas_renewal', otherwise
+        'goods_procurement'.  In PATH A the caller typically enriches the payload
+        with line items returned by fetch_quote_details() before calling this
+        method.
+
+        Expected webhook payload fields:
+          event_info:              dict  (webhook_id, event_id, api_version)
+          dealhub_quote_id:        str
+          dealhub_opportunity_id:  str
+          execution_date:          str   (ISO 8601)
+          executed_by:             str
+          currency:                str   (ISO 4217, default "USD")
+          items:                   list  (optional — enriched from quote API)
+
+        Args:
+            payload:    DealHub quoteReady webhook payload dict.
+            max_rounds: Maximum negotiation rounds to propose (default 5).
+
+        Returns:
+            A2CN session_params dict suitable for SessionInit.
+        """
+        items = payload.get("items", [])
+        deal_type = "goods_procurement"
+        for item in items:
+            product_name = str(item.get("product_name", "")).lower()
+            if any(kw in product_name for kw in _SUBSCRIPTION_KEYWORDS):
+                deal_type = "saas_renewal"
+                break
+
+        return {
+            "deal_type": deal_type,
+            "currency": payload.get("currency", "USD"),
+            "max_rounds": max_rounds,
+            "session_timeout_seconds": 3600,
+            "round_timeout_seconds": 900,
+            "dealhub_quote_id": payload.get("dealhub_quote_id", ""),
+            "dealhub_opportunity_id": payload.get("dealhub_opportunity_id", ""),
+        }
+
+    @staticmethod
+    def fetch_quote_details(quote_id: str) -> dict:
+        """
+        Calls the DealHub Get Quote API and returns the full quote response.
+
+        GET {DEALHUB_BASE_URL}/api/v1/quotes/{quote_id}
+        Authorization: Bearer {DEALHUB_AUTH_TOKEN}
+
+        Args:
+            quote_id: DealHub quote ID (dealhub_quote_id from the webhook payload).
+
+        Returns:
+            Full quote response dict from DealHub.
+
+        Raises:
+            ValueError: If DEALHUB_AUTH_TOKEN or DEALHUB_BASE_URL is not set,
+                        or if the API returns 403 / 404.
+        """
+        auth_token = os.environ.get("DEALHUB_AUTH_TOKEN")
+        base_url = os.environ.get("DEALHUB_BASE_URL")
+        if not auth_token or not base_url:
+            raise ValueError(
+                "DEALHUB_AUTH_TOKEN and DEALHUB_BASE_URL environment variables are required."
+            )
+        url = f"{base_url.rstrip('/')}/api/v1/quotes/{quote_id}"
+        response = httpx.get(url, headers={"Authorization": f"Bearer {auth_token}"})
+        if response.status_code == 403:
+            raise ValueError(
+                "DealHub API returned 403 Forbidden — check DEALHUB_AUTH_TOKEN."
+            )
+        if response.status_code == 404:
+            raise ValueError(f"DealHub quote {quote_id!r} not found (404).")
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def quote_to_a2cn_offer_terms(
+        quote_response: dict,
+        field_map: dict | None = None,
+        delivery_days: int = 14,
+    ) -> dict:
+        """
+        Translates a DealHub quote response into A2CN offer terms.
+
+        Field names are resolved via field_map (or DEFAULT_FIELD_MAP if omitted).
+        Pass a custom field_map dict to override individual keys without replacing
+        the entire mapping.
+
+        Deal type is inferred from product names: any product name containing
+        'license', 'subscription', or 'seat' (case-insensitive) classifies the
+        quote as 'saas_renewal'; otherwise 'goods_procurement'.
+
+        Prices are converted from dollars to cents (A2CN integer format).
+
+        Args:
+            quote_response: Full DealHub quote response dict (from fetch_quote_details).
+            field_map:      Optional field name overrides merged with DEFAULT_FIELD_MAP.
+            delivery_days:  Delivery days for goods_procurement terms (default 14).
+
+        Returns:
+            A2CN offer terms dict with total_value in cents.
+        """
+        fm = {**DealHubEventParser.DEFAULT_FIELD_MAP, **(field_map or {})}
+
+        items_raw = quote_response.get(fm["line_items_field"], [])
+        line_items: list[dict] = []
+        total_cents = 0
+
+        for item in items_raw:
+            product_name = str(item.get(fm["product_name_field"], ""))
+            qty = int(float(item.get(fm["quantity_field"], 1)))
+            unit_price_cents = int(float(item.get(fm["unit_price_field"], 0)) * 100)
+            line_total = qty * unit_price_cents
+            total_cents += line_total
+
+            line_items.append({
+                "description": product_name,
+                "quantity": qty,
+                "unit_price": unit_price_cents,
+                "total": line_total,
+            })
+
+        # Fall back to top-level total_price when line items carry no prices
+        total_from_header = int(float(quote_response.get(fm["total_value_field"], 0)) * 100)
+        total_cents = total_cents or total_from_header
+
+        currency = str(quote_response.get(fm["currency_field"], "USD"))
+
+        # Detect deal type from product names
+        deal_type = "goods_procurement"
+        for item in items_raw:
+            name = str(item.get(fm["product_name_field"], "")).lower()
+            if any(kw in name for kw in _SUBSCRIPTION_KEYWORDS):
+                deal_type = "saas_renewal"
+                break
+
+        terms: dict = {
+            "total_value": total_cents,
+            "currency": currency,
+            "line_items": line_items,
+            "payment_terms": {"net_days": 30},
+        }
+
+        if deal_type == "saas_renewal" and items_raw:
+            first = items_raw[0]
+            terms["seat_count"] = int(float(first.get(fm["quantity_field"], 1)))
+            terms["subscription_tier"] = str(first.get(fm["product_name_field"], ""))
+        else:
+            terms["delivery_days"] = delivery_days
+
+        return terms
+
+    @staticmethod
+    def simulate_quote_for_mandate_bounds(
+        playbook_id: str,
+        answers: dict,
+        floor_discount_pct: float = 0.15,
+    ) -> dict:
+        """
+        Calls the DealHub Headless Simulate Quote API to derive mandate bounds.
+
+        POST {DEALHUB_BASE_URL}/api/v1/headless/simulate
+        Authorization: Bearer {DEALHUB_AUTH_TOKEN}
+
+        The ceiling is the full list price returned by the simulation.
+        The floor is ceiling * (1 - floor_discount_pct).
+
+        # floor_discount_pct should be configured per product category based on
+        # actual sales policy — the 15% default is illustrative only.
+
+        Args:
+            playbook_id:       DealHub API Playbook ID (DEALHUB_PLAYBOOK_ID env var).
+            answers:           Playbook answers dict (product_id, quantity,
+                               customer_segment, etc.).
+            floor_discount_pct: Maximum discount authorised without human approval
+                               (default 0.15 = 15%).
+
+        Returns:
+            Dict with ceiling_value_cents, floor_value_cents, currency,
+            and simulated_line_items.
+
+        Raises:
+            ValueError: If playbook_id is empty, or if required env vars are missing.
+        """
+        if not playbook_id:
+            raise ValueError(
+                "playbook_id is required for DealHub headless simulation."
+            )
+        auth_token = os.environ.get("DEALHUB_AUTH_TOKEN")
+        base_url = os.environ.get("DEALHUB_BASE_URL")
+        if not auth_token or not base_url:
+            raise ValueError(
+                "DEALHUB_AUTH_TOKEN and DEALHUB_BASE_URL environment variables are required."
+            )
+        url = f"{base_url.rstrip('/')}/api/v1/headless/simulate"
+        payload = {"playbook_id": playbook_id, "answers": answers}
+        response = httpx.post(
+            url,
+            json=payload,
+            headers={
+                "Authorization": f"Bearer {auth_token}",
+                "Content-Type": "application/json",
+            },
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        # FIELD NOTE: total_price field name should be verified against a live
+        # DealHub sandbox. Contact DealHub support for exact simulate response schema.
+        ceiling_cents = int(float(data.get("total_price", 0)) * 100)
+        floor_cents = int(ceiling_cents * (1.0 - floor_discount_pct))
+
+        return {
+            "ceiling_value_cents": ceiling_cents,
+            "floor_value_cents": floor_cents,
+            "currency": data.get("currency", "USD"),
+            "simulated_line_items": data.get("line_items", []),
+        }
+
+    @staticmethod
+    def agreed_terms_to_dealhub_action(
+        quote_id: str,
+        a2cn_session_id: str,
+        record_hash: str,
+    ) -> dict:
+        """
+        Calls the DealHub Actions API to mark the quote as signed externally.
+
+        POST {DEALHUB_BASE_URL}/api/v1/quotes/{quote_id}/actions
+        Authorization: Bearer {DEALHUB_AUTH_TOKEN}
+
+        The note field includes both the A2CN session_id and record_hash so the
+        DealHub record is traceable back to the A2CN transaction.
+
+        Args:
+            quote_id:          DealHub quote ID to update.
+            a2cn_session_id:   A2CN session ID from the completed session.
+            record_hash:       Record hash from the A2CN transaction record.
+
+        Returns:
+            Dict containing:
+              api_response:        Raw DealHub Actions API response.
+              action_payload_sent: The payload submitted to the API (for audit log).
+
+        Raises:
+            ValueError: If DEALHUB_AUTH_TOKEN or DEALHUB_BASE_URL is not set.
+        """
+        auth_token = os.environ.get("DEALHUB_AUTH_TOKEN")
+        base_url = os.environ.get("DEALHUB_BASE_URL")
+        if not auth_token or not base_url:
+            raise ValueError(
+                "DEALHUB_AUTH_TOKEN and DEALHUB_BASE_URL environment variables are required."
+            )
+        action_payload = {
+            "action": "signExternally",
+            "note": (
+                f"Agreed via A2CN session {a2cn_session_id}. "
+                f"Record hash: {record_hash}"
+            ),
+        }
+        url = f"{base_url.rstrip('/')}/api/v1/quotes/{quote_id}/actions"
+        response = httpx.post(
+            url,
+            json=action_payload,
+            headers={
+                "Authorization": f"Bearer {auth_token}",
+                "Content-Type": "application/json",
+            },
+        )
+        response.raise_for_status()
+        return {
+            "api_response": response.json(),
+            "action_payload_sent": action_payload,
+        }

--- a/reference-implementation/python/adapters/dealhub_adapter.py
+++ b/reference-implementation/python/adapters/dealhub_adapter.py
@@ -58,12 +58,13 @@ class DealHubEventParser:
     # FIELD NOTE: All field names should be verified against a live DealHub
     # instance. Contact DealHub support or inspect sandbox responses for exact names.
     DEFAULT_FIELD_MAP: dict[str, str] = {
-        "total_value_field":  "total_price",    # FIELD NOTE: Verify against live DealHub instance.
-        "currency_field":     "currency",        # FIELD NOTE: Verify against live DealHub instance.
-        "line_items_field":   "line_items",      # FIELD NOTE: Verify against live DealHub instance.
-        "product_name_field": "product_name",    # FIELD NOTE: Verify against live DealHub instance.
-        "quantity_field":     "quantity",        # FIELD NOTE: Verify against live DealHub instance.
-        "unit_price_field":   "unit_price",      # FIELD NOTE: Verify against live DealHub instance.
+        "total_value_field":    "total_price",    # FIELD NOTE: Verify against live DealHub instance.
+        "currency_field":       "currency",        # FIELD NOTE: Verify against live DealHub instance.
+        "line_items_field":     "line_items",      # FIELD NOTE: Verify against live DealHub instance.
+        "product_name_field":   "product_name",    # FIELD NOTE: Verify against live DealHub instance.
+        "quantity_field":       "quantity",        # FIELD NOTE: Verify against live DealHub instance.
+        "unit_price_field":     "unit_price",      # FIELD NOTE: Verify against live DealHub instance.
+        "unit_of_measure_field": "unit_of_measure", # FIELD NOTE: Verify against live DealHub instance.
     }
 
     @staticmethod
@@ -116,7 +117,7 @@ class DealHubEventParser:
         }
 
     @staticmethod
-    def fetch_quote_details(quote_id: str) -> dict:
+    async def fetch_quote_details(quote_id: str) -> dict:
         """
         Calls the DealHub Get Quote API and returns the full quote response.
 
@@ -140,7 +141,8 @@ class DealHubEventParser:
                 "DEALHUB_AUTH_TOKEN and DEALHUB_BASE_URL environment variables are required."
             )
         url = f"{base_url.rstrip('/')}/api/v1/quotes/{quote_id}"
-        response = httpx.get(url, headers={"Authorization": f"Bearer {auth_token}"})
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers={"Authorization": f"Bearer {auth_token}"})
         if response.status_code == 403:
             raise ValueError(
                 "DealHub API returned 403 Forbidden — check DEALHUB_AUTH_TOKEN."
@@ -190,12 +192,16 @@ class DealHubEventParser:
             line_total = qty * unit_price_cents
             total_cents += line_total
 
-            line_items.append({
+            entry: dict = {
                 "description": product_name,
                 "quantity": qty,
                 "unit_price": unit_price_cents,
                 "total": line_total,
-            })
+            }
+            uom = item.get(fm["unit_of_measure_field"])
+            if uom:
+                entry["unit_of_measure"] = str(uom)
+            line_items.append(entry)
 
         # Fall back to top-level total_price when line items carry no prices
         total_from_header = int(float(quote_response.get(fm["total_value_field"], 0)) * 100)
@@ -228,7 +234,7 @@ class DealHubEventParser:
         return terms
 
     @staticmethod
-    def simulate_quote_for_mandate_bounds(
+    async def simulate_quote_for_mandate_bounds(
         playbook_id: str,
         answers: dict,
         floor_discount_pct: float = 0.15,
@@ -271,14 +277,15 @@ class DealHubEventParser:
             )
         url = f"{base_url.rstrip('/')}/api/v1/headless/simulate"
         payload = {"playbook_id": playbook_id, "answers": answers}
-        response = httpx.post(
-            url,
-            json=payload,
-            headers={
-                "Authorization": f"Bearer {auth_token}",
-                "Content-Type": "application/json",
-            },
-        )
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                url,
+                json=payload,
+                headers={
+                    "Authorization": f"Bearer {auth_token}",
+                    "Content-Type": "application/json",
+                },
+            )
         response.raise_for_status()
         data = response.json()
 
@@ -295,7 +302,7 @@ class DealHubEventParser:
         }
 
     @staticmethod
-    def agreed_terms_to_dealhub_action(
+    async def agreed_terms_to_dealhub_action(
         quote_id: str,
         a2cn_session_id: str,
         record_hash: str,
@@ -336,14 +343,15 @@ class DealHubEventParser:
             ),
         }
         url = f"{base_url.rstrip('/')}/api/v1/quotes/{quote_id}/actions"
-        response = httpx.post(
-            url,
-            json=action_payload,
-            headers={
-                "Authorization": f"Bearer {auth_token}",
-                "Content-Type": "application/json",
-            },
-        )
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                url,
+                json=action_payload,
+                headers={
+                    "Authorization": f"Bearer {auth_token}",
+                    "Content-Type": "application/json",
+                },
+            )
         response.raise_for_status()
         return {
             "api_response": response.json(),

--- a/reference-implementation/python/adapters/nue_adapter.py
+++ b/reference-implementation/python/adapters/nue_adapter.py
@@ -1,0 +1,335 @@
+"""
+Nue.io Revenue Lifecycle → A2CN translation layer.
+
+Translates Nue pricing and subscription data into A2CN session terms, and
+translates A2CN agreed terms back into Nue order creation.
+
+Primary flow:
+  NueEventParser.fetch_pricing(price_book_id, product_id)
+      → NueEventParser.pricing_to_mandate_bounds(pricing_response)
+          → configure agent mandate bounds
+      → A2CN negotiation session
+      → NueEventParser.a2cn_terms_to_nue_order(agreed_terms, ...)
+
+Renewal flow:
+  NueEventParser.fetch_customer_subscriptions(customer_id)
+      → NueEventParser.subscription_to_renewal_terms(subscription_response)
+          → A2CN saas_renewal session
+      → NueEventParser.a2cn_terms_to_nue_order(agreed_terms, ...)
+
+Nue API reference (Revenue Lifecycle API):
+  Pricing:       GET  {NUE_BASE_URL}/commerce/pricing
+  Orders:        POST {NUE_BASE_URL}/orders
+  Subscriptions: GET  {NUE_BASE_URL}/subscriptions
+
+Environment variables required:
+  NUE_API_KEY:  API key from Nue administrator
+  NUE_BASE_URL: Base URL — production (https://api.nue.io) or
+                sandbox (https://api.sandbox.nue.io)
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date
+
+import httpx
+
+
+class NueEventParser:
+    """
+    Translates Nue.io pricing and subscription data into A2CN session terms,
+    and translates A2CN agreed terms back into Nue order creation.
+
+    Nue is a seller-side CPQ and billing platform for SaaS companies.
+    The primary A2CN use case is SaaS subscription negotiation — the seller's
+    Nue instance provides pricing, the buyer's agent negotiates via A2CN, and
+    agreed terms are written back as a Nue order.
+
+    Environment variables required:
+        NUE_API_KEY:  API key from Nue administrator
+        NUE_BASE_URL: Base URL (production or sandbox)
+    """
+
+    @staticmethod
+    def fetch_pricing(price_book_id: str, product_id: str) -> dict:
+        """
+        Calls the Nue Commerce API to get pricing for a specific product and
+        price book.
+
+        GET {NUE_BASE_URL}/commerce/pricing?priceBookId={id}&productId={id}
+        Nue-Api-Key: {NUE_API_KEY}
+
+        Args:
+            price_book_id: Nue price book ID.
+            product_id:    Nue product ID.
+
+        Returns:
+            Raw pricing response dict from Nue.
+
+        Raises:
+            ValueError: If NUE_API_KEY or NUE_BASE_URL is not set, or if the
+                        API returns 401 / 404.
+        """
+        api_key = os.environ.get("NUE_API_KEY")
+        base_url = os.environ.get("NUE_BASE_URL")
+        if not api_key or not base_url:
+            raise ValueError(
+                "NUE_API_KEY and NUE_BASE_URL environment variables are required."
+            )
+        url = f"{base_url.rstrip('/')}/commerce/pricing"
+        response = httpx.get(
+            url,
+            params={"priceBookId": price_book_id, "productId": product_id},
+            headers={"Nue-Api-Key": api_key},
+        )
+        if response.status_code == 401:
+            raise ValueError("Nue API returned 401 Unauthorized — check NUE_API_KEY.")
+        if response.status_code == 404:
+            raise ValueError(
+                f"Nue pricing not found for priceBookId={price_book_id!r}, "
+                f"productId={product_id!r}."
+            )
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def pricing_to_mandate_bounds(
+        pricing_response: dict,
+        floor_discount_pct: float = 0.10,
+        ceiling_markup_pct: float = 0.0,
+    ) -> dict:
+        """
+        Translates a Nue pricing response into A2CN mandate bounds.
+
+        The ceiling is the full list price (optionally marked up by
+        ceiling_markup_pct). The floor is ceiling * (1 - floor_discount_pct).
+
+        # floor_discount_pct represents the maximum discount the seller's agent
+        # is authorized to offer without human approval. Configure per product
+        # tier in production.
+
+        FIELD NOTE: listPrice, quantity, and currency field names should be
+        verified against a live Nue sandbox instance. Contact Nue support or
+        check sandbox responses for exact pricing response field names.
+
+        Args:
+            pricing_response:   Raw pricing response from fetch_pricing().
+            floor_discount_pct: Max authorised discount (default 0.10 = 10%).
+            ceiling_markup_pct: Markup above list price for ceiling (default 0).
+
+        Returns:
+            Dict with ceiling_value_cents, floor_value_cents, and currency.
+        """
+        # FIELD NOTE: Verify listPrice field name against live Nue sandbox instance.
+        # Contact Nue support or check sandbox response for exact name.
+        list_price = float(
+            pricing_response.get("listPrice",
+                pricing_response.get("list_price",
+                    pricing_response.get("unitPrice",
+                        pricing_response.get("price", 0))))
+        )
+        # FIELD NOTE: Verify quantity field name against live Nue sandbox instance.
+        quantity = int(pricing_response.get("quantity", 1))
+        total_list_price = list_price * quantity
+
+        ceiling_cents = int(total_list_price * 100 * (1.0 + ceiling_markup_pct))
+        floor_cents = int(ceiling_cents * (1.0 - floor_discount_pct))
+        currency = str(pricing_response.get("currency", "USD"))
+
+        return {
+            "ceiling_value_cents": ceiling_cents,
+            "floor_value_cents": floor_cents,
+            "currency": currency,
+        }
+
+    @staticmethod
+    def subscription_to_renewal_terms(
+        subscription_response: dict,
+        renewal_markup_pct: float = 0.05,
+    ) -> dict:
+        """
+        Translates an existing Nue subscription into A2CN saas_renewal offer
+        terms for a renewal negotiation.
+
+        The proposed renewal value is the current subscription total plus
+        renewal_markup_pct (default 5%).
+
+        FIELD NOTE: Field names (totalValue, productTier, autoRenew, termMonths,
+        quantity) should be verified against a live Nue sandbox instance.
+        Contact Nue support or check sandbox subscription responses.
+
+        Args:
+            subscription_response: Nue subscription dict (from fetch_customer_subscriptions).
+            renewal_markup_pct:    Annual price increase to apply (default 0.05 = 5%).
+
+        Returns:
+            A2CN saas_renewal offer terms dict with total_value in cents.
+        """
+        # FIELD NOTE: Verify all field names below against live Nue sandbox instance.
+        current_value = float(
+            subscription_response.get("totalValue",
+                subscription_response.get("total_value", 0))
+        )
+        renewal_value_cents = int(current_value * 100 * (1.0 + renewal_markup_pct))
+
+        seat_count = int(
+            subscription_response.get("quantity",
+                subscription_response.get("seats", 1))
+        )
+        tier = str(
+            subscription_response.get("productTier",
+                subscription_response.get("product_tier", "standard"))
+        )
+        auto_renew = bool(
+            subscription_response.get("autoRenew",
+                subscription_response.get("auto_renew", False))
+        )
+        term_months = int(
+            subscription_response.get("termMonths",
+                subscription_response.get("term_months", 12))
+        )
+        currency = str(subscription_response.get("currency", "USD"))
+
+        return {
+            "deal_type": "saas_renewal",
+            "total_value": renewal_value_cents,
+            "currency": currency,
+            "seat_count": seat_count,
+            "subscription_tier": tier,
+            "auto_renew_terms": {"auto_renew": auto_renew},
+            "term_months": term_months,
+        }
+
+    @staticmethod
+    def a2cn_terms_to_nue_order(
+        agreed_terms: dict,
+        customer_id: str,
+        price_book_id: str,
+        product_id: str,
+        a2cn_session_id: str,
+        record_hash: str,
+        start_date: str | None = None,
+    ) -> dict:
+        """
+        Translates A2CN agreed terms into a Nue order payload and calls the
+        Nue Orders API.
+
+        POST {NUE_BASE_URL}/orders
+        Nue-Api-Key: {NUE_API_KEY}
+
+        The externalReference field MUST include the A2CN session_id and the
+        notes field MUST include the record_hash. These two fields create the
+        audit link between the Nue order and the A2CN transaction record.
+
+        Args:
+            agreed_terms:      Terms dict from a completed A2CN transaction record.
+            customer_id:       Nue customer ID.
+            price_book_id:     Nue price book ID.
+            product_id:        Nue product ID.
+            a2cn_session_id:   A2CN session ID from the completed session.
+            record_hash:       Record hash from the A2CN transaction record.
+            start_date:        Order start date (YYYY-MM-DD). Defaults to today.
+
+        Returns:
+            Dict containing:
+              api_response:       Raw Nue Orders API response.
+              order_payload_sent: The payload submitted to the API (for audit log).
+
+        Raises:
+            ValueError: If NUE_API_KEY or NUE_BASE_URL is not set.
+        """
+        api_key = os.environ.get("NUE_API_KEY")
+        base_url = os.environ.get("NUE_BASE_URL")
+        if not api_key or not base_url:
+            raise ValueError(
+                "NUE_API_KEY and NUE_BASE_URL environment variables are required."
+            )
+        if start_date is None:
+            start_date = date.today().strftime("%Y-%m-%d")
+
+        line_items = agreed_terms.get("line_items", [])
+        term_months = int(agreed_terms.get("term_months", 12))
+
+        if line_items:
+            lines = [
+                {
+                    "productId": product_id,
+                    "quantity": item.get("quantity", 1),
+                    "unitPrice": item.get("unit_price", 0) / 100.0,
+                    "term": term_months,
+                }
+                for item in line_items
+            ]
+        else:
+            # No line items — build a single line from the total
+            lines = [
+                {
+                    "productId": product_id,
+                    "quantity": agreed_terms.get("seat_count", 1),
+                    "unitPrice": agreed_terms.get("total_value", 0) / 100.0,
+                    "term": term_months,
+                }
+            ]
+
+        order_payload = {
+            "customerId": customer_id,
+            "priceBookId": price_book_id,
+            "startDate": start_date,
+            "lines": lines,
+            "externalReference": f"a2cn-session-{a2cn_session_id}",
+            "notes": f"Agreed via A2CN. Record hash: {record_hash}",
+        }
+
+        url = f"{base_url.rstrip('/')}/orders"
+        response = httpx.post(
+            url,
+            json=order_payload,
+            headers={
+                "Nue-Api-Key": api_key,
+                "Content-Type": "application/json",
+            },
+        )
+        response.raise_for_status()
+        return {
+            "api_response": response.json(),
+            "order_payload_sent": order_payload,
+        }
+
+    @staticmethod
+    def fetch_customer_subscriptions(customer_id: str) -> list[dict]:
+        """
+        Fetches all active subscriptions for a customer from Nue.
+
+        GET {NUE_BASE_URL}/subscriptions?customerId={customer_id}
+        Nue-Api-Key: {NUE_API_KEY}
+
+        Used to establish renewal context before initiating an A2CN session.
+
+        Args:
+            customer_id: Nue customer ID.
+
+        Returns:
+            List of subscription dicts.
+
+        Raises:
+            ValueError: If NUE_API_KEY or NUE_BASE_URL is not set.
+        """
+        api_key = os.environ.get("NUE_API_KEY")
+        base_url = os.environ.get("NUE_BASE_URL")
+        if not api_key or not base_url:
+            raise ValueError(
+                "NUE_API_KEY and NUE_BASE_URL environment variables are required."
+            )
+        url = f"{base_url.rstrip('/')}/subscriptions"
+        response = httpx.get(
+            url,
+            params={"customerId": customer_id},
+            headers={"Nue-Api-Key": api_key},
+        )
+        response.raise_for_status()
+        data = response.json()
+        if isinstance(data, list):
+            return data
+        # FIELD NOTE: Verify top-level list key against live Nue sandbox instance.
+        return data.get("subscriptions", data.get("items", []))

--- a/reference-implementation/python/adapters/nue_adapter.py
+++ b/reference-implementation/python/adapters/nue_adapter.py
@@ -51,8 +51,31 @@ class NueEventParser:
         NUE_BASE_URL: Base URL (production or sandbox)
     """
 
+    # Default field map for Nue pricing API responses.
+    # Override via the field_map parameter on pricing_to_mandate_bounds() if
+    # your Nue instance uses different field names.
+    # FIELD NOTE: All names should be verified against a live Nue sandbox instance.
+    PRICING_FIELD_MAP: dict[str, str] = {
+        "list_price_field": "listPrice",    # FIELD NOTE: Verify against live Nue sandbox.
+        "quantity_field":   "quantity",      # FIELD NOTE: Verify against live Nue sandbox.
+        "currency_field":   "currency",      # FIELD NOTE: Verify against live Nue sandbox.
+    }
+
+    # Default field map for Nue subscription API responses.
+    # Override via the field_map parameter on subscription_to_renewal_terms() if
+    # your Nue instance uses different field names.
+    # FIELD NOTE: All names should be verified against a live Nue sandbox instance.
+    SUBSCRIPTION_FIELD_MAP: dict[str, str] = {
+        "total_value_field":  "totalValue",   # FIELD NOTE: Verify against live Nue sandbox.
+        "quantity_field":     "quantity",      # FIELD NOTE: Verify against live Nue sandbox.
+        "tier_field":         "productTier",   # FIELD NOTE: Verify against live Nue sandbox.
+        "auto_renew_field":   "autoRenew",     # FIELD NOTE: Verify against live Nue sandbox.
+        "term_months_field":  "termMonths",    # FIELD NOTE: Verify against live Nue sandbox.
+        "currency_field":     "currency",      # FIELD NOTE: Verify against live Nue sandbox.
+    }
+
     @staticmethod
-    def fetch_pricing(price_book_id: str, product_id: str) -> dict:
+    async def fetch_pricing(price_book_id: str, product_id: str) -> dict:
         """
         Calls the Nue Commerce API to get pricing for a specific product and
         price book.
@@ -78,11 +101,12 @@ class NueEventParser:
                 "NUE_API_KEY and NUE_BASE_URL environment variables are required."
             )
         url = f"{base_url.rstrip('/')}/commerce/pricing"
-        response = httpx.get(
-            url,
-            params={"priceBookId": price_book_id, "productId": product_id},
-            headers={"Nue-Api-Key": api_key},
-        )
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                url,
+                params={"priceBookId": price_book_id, "productId": product_id},
+                headers={"Nue-Api-Key": api_key},
+            )
         if response.status_code == 401:
             raise ValueError("Nue API returned 401 Unauthorized — check NUE_API_KEY.")
         if response.status_code == 404:
@@ -98,6 +122,7 @@ class NueEventParser:
         pricing_response: dict,
         floor_discount_pct: float = 0.10,
         ceiling_markup_pct: float = 0.0,
+        field_map: dict | None = None,
     ) -> dict:
         """
         Translates a Nue pricing response into A2CN mandate bounds.
@@ -117,25 +142,20 @@ class NueEventParser:
             pricing_response:   Raw pricing response from fetch_pricing().
             floor_discount_pct: Max authorised discount (default 0.10 = 10%).
             ceiling_markup_pct: Markup above list price for ceiling (default 0).
+            field_map:          Optional field name overrides merged with PRICING_FIELD_MAP.
 
         Returns:
             Dict with ceiling_value_cents, floor_value_cents, and currency.
         """
-        # FIELD NOTE: Verify listPrice field name against live Nue sandbox instance.
-        # Contact Nue support or check sandbox response for exact name.
-        list_price = float(
-            pricing_response.get("listPrice",
-                pricing_response.get("list_price",
-                    pricing_response.get("unitPrice",
-                        pricing_response.get("price", 0))))
-        )
-        # FIELD NOTE: Verify quantity field name against live Nue sandbox instance.
-        quantity = int(pricing_response.get("quantity", 1))
+        fm = {**NueEventParser.PRICING_FIELD_MAP, **(field_map or {})}
+
+        list_price = float(pricing_response.get(fm["list_price_field"], 0))
+        quantity = int(pricing_response.get(fm["quantity_field"], 1))
         total_list_price = list_price * quantity
 
         ceiling_cents = int(total_list_price * 100 * (1.0 + ceiling_markup_pct))
         floor_cents = int(ceiling_cents * (1.0 - floor_discount_pct))
-        currency = str(pricing_response.get("currency", "USD"))
+        currency = str(pricing_response.get(fm["currency_field"], "USD"))
 
         return {
             "ceiling_value_cents": ceiling_cents,
@@ -147,6 +167,7 @@ class NueEventParser:
     def subscription_to_renewal_terms(
         subscription_response: dict,
         renewal_markup_pct: float = 0.05,
+        field_map: dict | None = None,
     ) -> dict:
         """
         Translates an existing Nue subscription into A2CN saas_renewal offer
@@ -162,34 +183,21 @@ class NueEventParser:
         Args:
             subscription_response: Nue subscription dict (from fetch_customer_subscriptions).
             renewal_markup_pct:    Annual price increase to apply (default 0.05 = 5%).
+            field_map:             Optional field name overrides merged with SUBSCRIPTION_FIELD_MAP.
 
         Returns:
             A2CN saas_renewal offer terms dict with total_value in cents.
         """
-        # FIELD NOTE: Verify all field names below against live Nue sandbox instance.
-        current_value = float(
-            subscription_response.get("totalValue",
-                subscription_response.get("total_value", 0))
-        )
+        fm = {**NueEventParser.SUBSCRIPTION_FIELD_MAP, **(field_map or {})}
+
+        current_value = float(subscription_response.get(fm["total_value_field"], 0))
         renewal_value_cents = int(current_value * 100 * (1.0 + renewal_markup_pct))
 
-        seat_count = int(
-            subscription_response.get("quantity",
-                subscription_response.get("seats", 1))
-        )
-        tier = str(
-            subscription_response.get("productTier",
-                subscription_response.get("product_tier", "standard"))
-        )
-        auto_renew = bool(
-            subscription_response.get("autoRenew",
-                subscription_response.get("auto_renew", False))
-        )
-        term_months = int(
-            subscription_response.get("termMonths",
-                subscription_response.get("term_months", 12))
-        )
-        currency = str(subscription_response.get("currency", "USD"))
+        seat_count = int(subscription_response.get(fm["quantity_field"], 1))
+        tier = str(subscription_response.get(fm["tier_field"], "standard"))
+        auto_renew = bool(subscription_response.get(fm["auto_renew_field"], False))
+        term_months = int(subscription_response.get(fm["term_months_field"], 12))
+        currency = str(subscription_response.get(fm["currency_field"], "USD"))
 
         return {
             "deal_type": "saas_renewal",
@@ -202,7 +210,7 @@ class NueEventParser:
         }
 
     @staticmethod
-    def a2cn_terms_to_nue_order(
+    async def a2cn_terms_to_nue_order(
         agreed_terms: dict,
         customer_id: str,
         price_book_id: str,
@@ -262,12 +270,14 @@ class NueEventParser:
                 for item in line_items
             ]
         else:
-            # No line items — build a single line from the total
+            # No line items — build a single line from the total.
+            # unitPrice = per-seat price: divide total by seat count before converting cents→dollars.
+            seat_count = max(int(agreed_terms.get("seat_count", 1)), 1)
             lines = [
                 {
                     "productId": product_id,
-                    "quantity": agreed_terms.get("seat_count", 1),
-                    "unitPrice": agreed_terms.get("total_value", 0) / 100.0,
+                    "quantity": seat_count,
+                    "unitPrice": agreed_terms.get("total_value", 0) / seat_count / 100.0,
                     "term": term_months,
                 }
             ]
@@ -282,14 +292,15 @@ class NueEventParser:
         }
 
         url = f"{base_url.rstrip('/')}/orders"
-        response = httpx.post(
-            url,
-            json=order_payload,
-            headers={
-                "Nue-Api-Key": api_key,
-                "Content-Type": "application/json",
-            },
-        )
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                url,
+                json=order_payload,
+                headers={
+                    "Nue-Api-Key": api_key,
+                    "Content-Type": "application/json",
+                },
+            )
         response.raise_for_status()
         return {
             "api_response": response.json(),
@@ -297,7 +308,7 @@ class NueEventParser:
         }
 
     @staticmethod
-    def fetch_customer_subscriptions(customer_id: str) -> list[dict]:
+    async def fetch_customer_subscriptions(customer_id: str) -> list[dict]:
         """
         Fetches all active subscriptions for a customer from Nue.
 
@@ -322,11 +333,12 @@ class NueEventParser:
                 "NUE_API_KEY and NUE_BASE_URL environment variables are required."
             )
         url = f"{base_url.rstrip('/')}/subscriptions"
-        response = httpx.get(
-            url,
-            params={"customerId": customer_id},
-            headers={"Nue-Api-Key": api_key},
-        )
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                url,
+                params={"customerId": customer_id},
+                headers={"Nue-Api-Key": api_key},
+            )
         response.raise_for_status()
         data = response.json()
         if isinstance(data, list):

--- a/reference-implementation/python/tests/test_dealhub_adapter.py
+++ b/reference-implementation/python/tests/test_dealhub_adapter.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -56,6 +56,27 @@ SAMPLE_QUOTE_RESPONSE_GOODS = {
         {"product_name": "Hydraulic fluid 200L drums", "quantity": 50, "unit_price": 360.0},
     ],
 }
+
+
+# ---------------------------------------------------------------------------
+# Async HTTP mock helper
+# ---------------------------------------------------------------------------
+
+def _make_async_client_mock(json_data: dict, status_code: int = 200):
+    """Returns a context-manager mock for httpx.AsyncClient."""
+    mock_response = MagicMock()
+    mock_response.status_code = status_code
+    mock_response.json.return_value = json_data
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.post.return_value = mock_response
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+    return mock_cm
 
 
 # ---------------------------------------------------------------------------
@@ -167,27 +188,56 @@ class TestDealHubQuoteToOfferTerms:
         terms = DealHubEventParser.quote_to_a2cn_offer_terms(quote)
         assert terms["total_value"] == 750_000  # $7500 in cents
 
+    def test_unit_of_measure_included_when_present(self):
+        quote = {
+            "total_price": 5000.0,
+            "currency": "USD",
+            "line_items": [
+                {
+                    "product_name": "Industrial Hydraulic Pump",
+                    "quantity": 10,
+                    "unit_price": 500.0,
+                    "unit_of_measure": "EA",
+                },
+            ],
+        }
+        terms = DealHubEventParser.quote_to_a2cn_offer_terms(quote)
+        assert terms["line_items"][0]["unit_of_measure"] == "EA"
+
+    def test_unit_of_measure_omitted_when_absent(self):
+        terms = DealHubEventParser.quote_to_a2cn_offer_terms(SAMPLE_QUOTE_RESPONSE_GOODS)
+        assert "unit_of_measure" not in terms["line_items"][0]
+
+    def test_custom_unit_of_measure_field_name(self):
+        quote = {
+            "total_price": 1000.0,
+            "currency": "USD",
+            "line_items": [
+                {"product_name": "Widget", "quantity": 5, "unit_price": 200.0, "uom": "KG"},
+            ],
+        }
+        terms = DealHubEventParser.quote_to_a2cn_offer_terms(
+            quote, field_map={"unit_of_measure_field": "uom"}
+        )
+        assert terms["line_items"][0]["unit_of_measure"] == "KG"
+
 
 # ---------------------------------------------------------------------------
 # TestDealHubMandateBounds
 # ---------------------------------------------------------------------------
 
 class TestDealHubMandateBounds:
-    def test_floor_is_ceiling_minus_discount(self):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "total_price": 100000.0,
-            "currency": "USD",
-            "line_items": [],
-        }
-        mock_response.raise_for_status.return_value = None
-
-        with patch("adapters.dealhub_adapter.httpx.post", return_value=mock_response):
+    @pytest.mark.asyncio
+    async def test_floor_is_ceiling_minus_discount(self):
+        mock_cm = _make_async_client_mock(
+            {"total_price": 100000.0, "currency": "USD", "line_items": []}
+        )
+        with patch("adapters.dealhub_adapter.httpx.AsyncClient", return_value=mock_cm):
             with patch.dict(os.environ, {
                 "DEALHUB_AUTH_TOKEN": "test-token",
                 "DEALHUB_BASE_URL": "https://test.dealhub.io",
             }):
-                result = DealHubEventParser.simulate_quote_for_mandate_bounds(
+                result = await DealHubEventParser.simulate_quote_for_mandate_bounds(
                     playbook_id="pb-001",
                     answers={"product_id": "prod-001", "quantity": 1},
                     floor_discount_pct=0.15,
@@ -197,17 +247,17 @@ class TestDealHubMandateBounds:
         floor = result["floor_value_cents"]
         assert floor == int(ceiling * 0.85)
 
-    def test_floor_discount_pct_applied_correctly(self):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"total_price": 10000.0, "currency": "USD", "line_items": []}
-        mock_response.raise_for_status.return_value = None
-
-        with patch("adapters.dealhub_adapter.httpx.post", return_value=mock_response):
+    @pytest.mark.asyncio
+    async def test_floor_discount_pct_applied_correctly(self):
+        mock_cm = _make_async_client_mock(
+            {"total_price": 10000.0, "currency": "USD", "line_items": []}
+        )
+        with patch("adapters.dealhub_adapter.httpx.AsyncClient", return_value=mock_cm):
             with patch.dict(os.environ, {
                 "DEALHUB_AUTH_TOKEN": "tok",
                 "DEALHUB_BASE_URL": "https://test.dealhub.io",
             }):
-                result = DealHubEventParser.simulate_quote_for_mandate_bounds(
+                result = await DealHubEventParser.simulate_quote_for_mandate_bounds(
                     playbook_id="pb-001",
                     answers={},
                     floor_discount_pct=0.20,
@@ -219,9 +269,12 @@ class TestDealHubMandateBounds:
 
     def test_simulate_raises_on_empty_playbook_id(self):
         with pytest.raises(ValueError, match="playbook_id is required"):
-            DealHubEventParser.simulate_quote_for_mandate_bounds(
-                playbook_id="",
-                answers={},
+            import asyncio
+            asyncio.get_event_loop().run_until_complete(
+                DealHubEventParser.simulate_quote_for_mandate_bounds(
+                    playbook_id="",
+                    answers={},
+                )
             )
 
     def test_simulate_raises_on_missing_env_vars(self):
@@ -229,9 +282,12 @@ class TestDealHubMandateBounds:
                if k not in ("DEALHUB_AUTH_TOKEN", "DEALHUB_BASE_URL")}
         with patch.dict(os.environ, env, clear=True):
             with pytest.raises(ValueError, match="DEALHUB_AUTH_TOKEN"):
-                DealHubEventParser.simulate_quote_for_mandate_bounds(
-                    playbook_id="pb-001",
-                    answers={},
+                import asyncio
+                asyncio.get_event_loop().run_until_complete(
+                    DealHubEventParser.simulate_quote_for_mandate_bounds(
+                        playbook_id="pb-001",
+                        answers={},
+                    )
                 )
 
 
@@ -240,17 +296,15 @@ class TestDealHubMandateBounds:
 # ---------------------------------------------------------------------------
 
 class TestDealHubActionsApi:
-    def test_action_payload_includes_session_id(self):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"status": "success"}
-        mock_response.raise_for_status.return_value = None
-
-        with patch("adapters.dealhub_adapter.httpx.post", return_value=mock_response):
+    @pytest.mark.asyncio
+    async def test_action_payload_includes_session_id(self):
+        mock_cm = _make_async_client_mock({"status": "success"})
+        with patch("adapters.dealhub_adapter.httpx.AsyncClient", return_value=mock_cm):
             with patch.dict(os.environ, {
                 "DEALHUB_AUTH_TOKEN": "test-token",
                 "DEALHUB_BASE_URL": "https://test.dealhub.io",
             }):
-                result = DealHubEventParser.agreed_terms_to_dealhub_action(
+                result = await DealHubEventParser.agreed_terms_to_dealhub_action(
                     quote_id="dh-q-001",
                     a2cn_session_id="sess-abc-123",
                     record_hash="deadbeef" * 8,
@@ -258,17 +312,15 @@ class TestDealHubActionsApi:
 
         assert "sess-abc-123" in result["action_payload_sent"]["note"]
 
-    def test_action_payload_includes_record_hash(self):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"status": "success"}
-        mock_response.raise_for_status.return_value = None
-
-        with patch("adapters.dealhub_adapter.httpx.post", return_value=mock_response):
+    @pytest.mark.asyncio
+    async def test_action_payload_includes_record_hash(self):
+        mock_cm = _make_async_client_mock({"status": "success"})
+        with patch("adapters.dealhub_adapter.httpx.AsyncClient", return_value=mock_cm):
             with patch.dict(os.environ, {
                 "DEALHUB_AUTH_TOKEN": "test-token",
                 "DEALHUB_BASE_URL": "https://test.dealhub.io",
             }):
-                result = DealHubEventParser.agreed_terms_to_dealhub_action(
+                result = await DealHubEventParser.agreed_terms_to_dealhub_action(
                     quote_id="dh-q-001",
                     a2cn_session_id="sess-abc-123",
                     record_hash="cafebabe" * 8,
@@ -276,17 +328,15 @@ class TestDealHubActionsApi:
 
         assert "cafebabe" * 8 in result["action_payload_sent"]["note"]
 
-    def test_action_uses_sign_externally_action(self):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {}
-        mock_response.raise_for_status.return_value = None
-
-        with patch("adapters.dealhub_adapter.httpx.post", return_value=mock_response):
+    @pytest.mark.asyncio
+    async def test_action_uses_sign_externally_action(self):
+        mock_cm = _make_async_client_mock({})
+        with patch("adapters.dealhub_adapter.httpx.AsyncClient", return_value=mock_cm):
             with patch.dict(os.environ, {
                 "DEALHUB_AUTH_TOKEN": "tok",
                 "DEALHUB_BASE_URL": "https://test.dealhub.io",
             }):
-                result = DealHubEventParser.agreed_terms_to_dealhub_action(
+                result = await DealHubEventParser.agreed_terms_to_dealhub_action(
                     "dh-q-001", "sess-001", "hash-001"
                 )
 
@@ -303,19 +353,19 @@ class TestDealHubFetchQuoteDetails:
                if k not in ("DEALHUB_AUTH_TOKEN", "DEALHUB_BASE_URL")}
         with patch.dict(os.environ, env, clear=True):
             with pytest.raises(ValueError, match="DEALHUB_AUTH_TOKEN"):
-                DealHubEventParser.fetch_quote_details("dh-q-001")
+                import asyncio
+                asyncio.get_event_loop().run_until_complete(
+                    DealHubEventParser.fetch_quote_details("dh-q-001")
+                )
 
-    def test_returns_json_on_success(self):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"dealhub_quote_id": "dh-q-001"}
-        mock_response.raise_for_status.return_value = None
-
-        with patch("adapters.dealhub_adapter.httpx.get", return_value=mock_response):
+    @pytest.mark.asyncio
+    async def test_returns_json_on_success(self):
+        mock_cm = _make_async_client_mock({"dealhub_quote_id": "dh-q-001"}, status_code=200)
+        with patch("adapters.dealhub_adapter.httpx.AsyncClient", return_value=mock_cm):
             with patch.dict(os.environ, {
                 "DEALHUB_AUTH_TOKEN": "tok",
                 "DEALHUB_BASE_URL": "https://test.dealhub.io",
             }):
-                result = DealHubEventParser.fetch_quote_details("dh-q-001")
+                result = await DealHubEventParser.fetch_quote_details("dh-q-001")
 
         assert result["dealhub_quote_id"] == "dh-q-001"

--- a/reference-implementation/python/tests/test_dealhub_adapter.py
+++ b/reference-implementation/python/tests/test_dealhub_adapter.py
@@ -1,0 +1,321 @@
+"""Tests for DealHub CPQ platform adapter."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from adapters.dealhub_adapter import DealHubEventParser
+
+
+# ---------------------------------------------------------------------------
+# Sample payloads
+# ---------------------------------------------------------------------------
+
+SAMPLE_QUOTE_READY_SAAS = {
+    "event_info": {"webhook_id": "wh-001", "event_id": "evt-001", "api_version": "1.0"},
+    "dealhub_quote_id": "dh-q-001",
+    "dealhub_opportunity_id": "dh-opp-001",
+    "execution_date": "2026-04-28T10:00:00Z",
+    "executed_by": "rep@company.com",
+    "currency": "USD",
+    # items enriched from quote API (PATH A)
+    "items": [
+        {"product_name": "Enterprise Subscription 500 seats", "quantity": 500, "unit_price": 200.0},
+    ],
+}
+
+SAMPLE_QUOTE_READY_GOODS = {
+    "event_info": {"webhook_id": "wh-002", "event_id": "evt-002", "api_version": "1.0"},
+    "dealhub_quote_id": "dh-q-002",
+    "dealhub_opportunity_id": "dh-opp-002",
+    "execution_date": "2026-04-28T11:00:00Z",
+    "executed_by": "rep@company.com",
+    "currency": "USD",
+    "items": [
+        {"product_name": "Industrial Hydraulic Pump", "quantity": 10, "unit_price": 1500.0},
+        {"product_name": "O-Ring Seal Kit", "quantity": 50, "unit_price": 25.0},
+    ],
+}
+
+SAMPLE_QUOTE_RESPONSE = {
+    "total_price": 100000.0,
+    "currency": "USD",
+    "line_items": [
+        {"product_name": "Analytics Platform License", "quantity": 100, "unit_price": 950.0},
+        {"product_name": "Support Package", "quantity": 1, "unit_price": 5000.0},
+    ],
+}
+
+SAMPLE_QUOTE_RESPONSE_GOODS = {
+    "total_price": 18000.0,
+    "currency": "EUR",
+    "line_items": [
+        {"product_name": "Hydraulic fluid 200L drums", "quantity": 50, "unit_price": 360.0},
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# TestDealHubWebhookToSessionParams
+# ---------------------------------------------------------------------------
+
+class TestDealHubWebhookToSessionParams:
+    def test_subscription_products_yield_saas_renewal(self):
+        params = DealHubEventParser.quote_ready_webhook_to_session_params(
+            SAMPLE_QUOTE_READY_SAAS
+        )
+        assert params["deal_type"] == "saas_renewal"
+
+    def test_physical_goods_yield_goods_procurement(self):
+        params = DealHubEventParser.quote_ready_webhook_to_session_params(
+            SAMPLE_QUOTE_READY_GOODS
+        )
+        assert params["deal_type"] == "goods_procurement"
+
+    def test_session_params_include_quote_and_opportunity_ids(self):
+        params = DealHubEventParser.quote_ready_webhook_to_session_params(
+            SAMPLE_QUOTE_READY_SAAS
+        )
+        assert params["dealhub_quote_id"] == "dh-q-001"
+        assert params["dealhub_opportunity_id"] == "dh-opp-001"
+
+    def test_session_params_currency_passthrough(self):
+        params = DealHubEventParser.quote_ready_webhook_to_session_params(
+            SAMPLE_QUOTE_READY_GOODS
+        )
+        assert params["currency"] == "USD"
+
+    def test_no_items_defaults_to_goods_procurement(self):
+        payload = {
+            "dealhub_quote_id": "dh-q-003",
+            "dealhub_opportunity_id": "dh-opp-003",
+        }
+        params = DealHubEventParser.quote_ready_webhook_to_session_params(payload)
+        assert params["deal_type"] == "goods_procurement"
+
+    def test_max_rounds_default_is_five(self):
+        params = DealHubEventParser.quote_ready_webhook_to_session_params(
+            SAMPLE_QUOTE_READY_SAAS
+        )
+        assert params["max_rounds"] == 5
+
+    def test_max_rounds_configurable(self):
+        params = DealHubEventParser.quote_ready_webhook_to_session_params(
+            SAMPLE_QUOTE_READY_SAAS, max_rounds=3
+        )
+        assert params["max_rounds"] == 3
+
+
+# ---------------------------------------------------------------------------
+# TestDealHubQuoteToOfferTerms
+# ---------------------------------------------------------------------------
+
+class TestDealHubQuoteToOfferTerms:
+    def test_default_field_map_extracts_total_value_in_cents(self):
+        # 100 * $950 + 1 * $5000 = $100,000 = 10,000,000 cents
+        terms = DealHubEventParser.quote_to_a2cn_offer_terms(SAMPLE_QUOTE_RESPONSE)
+        assert terms["total_value"] == 10_000_000
+
+    def test_default_field_map_extracts_currency(self):
+        terms = DealHubEventParser.quote_to_a2cn_offer_terms(SAMPLE_QUOTE_RESPONSE)
+        assert terms["currency"] == "USD"
+
+    def test_saas_renewal_terms_include_seat_count(self):
+        # "Analytics Platform License" contains "license" → saas_renewal → seat_count included
+        terms = DealHubEventParser.quote_to_a2cn_offer_terms(SAMPLE_QUOTE_RESPONSE)
+        assert "seat_count" in terms
+        assert terms["seat_count"] == 100  # quantity from first line item
+
+    def test_goods_procurement_terms_include_delivery_days(self):
+        terms = DealHubEventParser.quote_to_a2cn_offer_terms(SAMPLE_QUOTE_RESPONSE_GOODS)
+        assert "delivery_days" in terms
+        assert terms["delivery_days"] == 14
+
+    def test_custom_field_map_overrides_product_name_field(self):
+        quote = {
+            "grand_total": 5000.0,
+            "ccy": "GBP",
+            "items": [
+                {"name": "Widget Pro", "qty": 10, "price": 500.0},
+            ],
+        }
+        custom_map = {
+            "total_value_field":  "grand_total",
+            "currency_field":     "ccy",
+            "line_items_field":   "items",
+            "product_name_field": "name",
+            "quantity_field":     "qty",
+            "unit_price_field":   "price",
+        }
+        terms = DealHubEventParser.quote_to_a2cn_offer_terms(quote, field_map=custom_map)
+        assert terms["currency"] == "GBP"
+        assert terms["line_items"][0]["description"] == "Widget Pro"
+        assert terms["line_items"][0]["quantity"] == 10
+        # $500 → 50000 cents
+        assert terms["line_items"][0]["unit_price"] == 50_000
+
+    def test_line_items_prices_converted_to_cents(self):
+        terms = DealHubEventParser.quote_to_a2cn_offer_terms(SAMPLE_QUOTE_RESPONSE_GOODS)
+        # $360.0 → 36000 cents
+        assert terms["line_items"][0]["unit_price"] == 36_000
+
+    def test_total_fallback_to_header_when_line_items_empty(self):
+        quote = {"total_price": 7500.0, "currency": "USD", "line_items": []}
+        terms = DealHubEventParser.quote_to_a2cn_offer_terms(quote)
+        assert terms["total_value"] == 750_000  # $7500 in cents
+
+
+# ---------------------------------------------------------------------------
+# TestDealHubMandateBounds
+# ---------------------------------------------------------------------------
+
+class TestDealHubMandateBounds:
+    def test_floor_is_ceiling_minus_discount(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "total_price": 100000.0,
+            "currency": "USD",
+            "line_items": [],
+        }
+        mock_response.raise_for_status.return_value = None
+
+        with patch("adapters.dealhub_adapter.httpx.post", return_value=mock_response):
+            with patch.dict(os.environ, {
+                "DEALHUB_AUTH_TOKEN": "test-token",
+                "DEALHUB_BASE_URL": "https://test.dealhub.io",
+            }):
+                result = DealHubEventParser.simulate_quote_for_mandate_bounds(
+                    playbook_id="pb-001",
+                    answers={"product_id": "prod-001", "quantity": 1},
+                    floor_discount_pct=0.15,
+                )
+
+        ceiling = result["ceiling_value_cents"]
+        floor = result["floor_value_cents"]
+        assert floor == int(ceiling * 0.85)
+
+    def test_floor_discount_pct_applied_correctly(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"total_price": 10000.0, "currency": "USD", "line_items": []}
+        mock_response.raise_for_status.return_value = None
+
+        with patch("adapters.dealhub_adapter.httpx.post", return_value=mock_response):
+            with patch.dict(os.environ, {
+                "DEALHUB_AUTH_TOKEN": "tok",
+                "DEALHUB_BASE_URL": "https://test.dealhub.io",
+            }):
+                result = DealHubEventParser.simulate_quote_for_mandate_bounds(
+                    playbook_id="pb-001",
+                    answers={},
+                    floor_discount_pct=0.20,
+                )
+
+        # $10,000 → 1,000,000 cents ceiling; 80% of ceiling = 800,000 floor
+        assert result["ceiling_value_cents"] == 1_000_000
+        assert result["floor_value_cents"] == 800_000
+
+    def test_simulate_raises_on_empty_playbook_id(self):
+        with pytest.raises(ValueError, match="playbook_id is required"):
+            DealHubEventParser.simulate_quote_for_mandate_bounds(
+                playbook_id="",
+                answers={},
+            )
+
+    def test_simulate_raises_on_missing_env_vars(self):
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("DEALHUB_AUTH_TOKEN", "DEALHUB_BASE_URL")}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValueError, match="DEALHUB_AUTH_TOKEN"):
+                DealHubEventParser.simulate_quote_for_mandate_bounds(
+                    playbook_id="pb-001",
+                    answers={},
+                )
+
+
+# ---------------------------------------------------------------------------
+# TestDealHubActionsApi
+# ---------------------------------------------------------------------------
+
+class TestDealHubActionsApi:
+    def test_action_payload_includes_session_id(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "success"}
+        mock_response.raise_for_status.return_value = None
+
+        with patch("adapters.dealhub_adapter.httpx.post", return_value=mock_response):
+            with patch.dict(os.environ, {
+                "DEALHUB_AUTH_TOKEN": "test-token",
+                "DEALHUB_BASE_URL": "https://test.dealhub.io",
+            }):
+                result = DealHubEventParser.agreed_terms_to_dealhub_action(
+                    quote_id="dh-q-001",
+                    a2cn_session_id="sess-abc-123",
+                    record_hash="deadbeef" * 8,
+                )
+
+        assert "sess-abc-123" in result["action_payload_sent"]["note"]
+
+    def test_action_payload_includes_record_hash(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "success"}
+        mock_response.raise_for_status.return_value = None
+
+        with patch("adapters.dealhub_adapter.httpx.post", return_value=mock_response):
+            with patch.dict(os.environ, {
+                "DEALHUB_AUTH_TOKEN": "test-token",
+                "DEALHUB_BASE_URL": "https://test.dealhub.io",
+            }):
+                result = DealHubEventParser.agreed_terms_to_dealhub_action(
+                    quote_id="dh-q-001",
+                    a2cn_session_id="sess-abc-123",
+                    record_hash="cafebabe" * 8,
+                )
+
+        assert "cafebabe" * 8 in result["action_payload_sent"]["note"]
+
+    def test_action_uses_sign_externally_action(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {}
+        mock_response.raise_for_status.return_value = None
+
+        with patch("adapters.dealhub_adapter.httpx.post", return_value=mock_response):
+            with patch.dict(os.environ, {
+                "DEALHUB_AUTH_TOKEN": "tok",
+                "DEALHUB_BASE_URL": "https://test.dealhub.io",
+            }):
+                result = DealHubEventParser.agreed_terms_to_dealhub_action(
+                    "dh-q-001", "sess-001", "hash-001"
+                )
+
+        assert result["action_payload_sent"]["action"] == "signExternally"
+
+
+# ---------------------------------------------------------------------------
+# TestDealHubFetchQuoteDetails
+# ---------------------------------------------------------------------------
+
+class TestDealHubFetchQuoteDetails:
+    def test_raises_on_missing_env_vars(self):
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("DEALHUB_AUTH_TOKEN", "DEALHUB_BASE_URL")}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValueError, match="DEALHUB_AUTH_TOKEN"):
+                DealHubEventParser.fetch_quote_details("dh-q-001")
+
+    def test_returns_json_on_success(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"dealhub_quote_id": "dh-q-001"}
+        mock_response.raise_for_status.return_value = None
+
+        with patch("adapters.dealhub_adapter.httpx.get", return_value=mock_response):
+            with patch.dict(os.environ, {
+                "DEALHUB_AUTH_TOKEN": "tok",
+                "DEALHUB_BASE_URL": "https://test.dealhub.io",
+            }):
+                result = DealHubEventParser.fetch_quote_details("dh-q-001")
+
+        assert result["dealhub_quote_id"] == "dh-q-001"

--- a/reference-implementation/python/tests/test_nue_adapter.py
+++ b/reference-implementation/python/tests/test_nue_adapter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from datetime import date
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -56,6 +56,27 @@ SAMPLE_A2CN_AGREED_TERMS = {
 
 
 # ---------------------------------------------------------------------------
+# Async HTTP mock helper
+# ---------------------------------------------------------------------------
+
+def _make_async_client_mock(json_data, status_code: int = 200):
+    """Returns a context-manager mock for httpx.AsyncClient."""
+    mock_response = MagicMock()
+    mock_response.status_code = status_code
+    mock_response.json.return_value = json_data
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.post.return_value = mock_response
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+    return mock_cm
+
+
+# ---------------------------------------------------------------------------
 # TestNuePricingToMandateBounds
 # ---------------------------------------------------------------------------
 
@@ -88,6 +109,24 @@ class TestNuePricingToMandateBounds:
         bounds = NueEventParser.pricing_to_mandate_bounds(pricing, floor_discount_pct=0.15)
         assert bounds["ceiling_value_cents"] == 200_000
         assert bounds["floor_value_cents"] == int(200_000 * 0.85)
+
+    def test_custom_field_map_list_price_field(self):
+        pricing = {"unitListPrice": 500.0, "currency": "GBP", "qty": 10}
+        bounds = NueEventParser.pricing_to_mandate_bounds(
+            pricing,
+            field_map={"list_price_field": "unitListPrice", "quantity_field": "qty"},
+        )
+        # 10 × $500 = $5000 = 500,000 cents
+        assert bounds["ceiling_value_cents"] == 500_000
+        assert bounds["currency"] == "GBP"
+
+    def test_custom_field_map_currency_field(self):
+        pricing = {"listPrice": 100.0, "ccy": "JPY"}
+        bounds = NueEventParser.pricing_to_mandate_bounds(
+            pricing,
+            field_map={"currency_field": "ccy"},
+        )
+        assert bounds["currency"] == "JPY"
 
 
 # ---------------------------------------------------------------------------
@@ -128,25 +167,46 @@ class TestNueSubscriptionToRenewalTerms:
         )
         assert terms["total_value"] == int(100_000.0 * 100)
 
+    def test_custom_field_map_total_value_field(self):
+        sub = {
+            "contractValue": 50000.0,
+            "seats": 50,
+            "tier": "standard",
+            "renew": False,
+            "months": 24,
+            "currency": "EUR",
+        }
+        terms = NueEventParser.subscription_to_renewal_terms(
+            sub,
+            renewal_markup_pct=0.0,
+            field_map={
+                "total_value_field": "contractValue",
+                "quantity_field":    "seats",
+                "tier_field":        "tier",
+                "auto_renew_field":  "renew",
+                "term_months_field": "months",
+            },
+        )
+        assert terms["seat_count"] == 50
+        assert terms["subscription_tier"] == "standard"
+        assert terms["term_months"] == 24
+        assert terms["total_value"] == int(50_000.0 * 100)
+
 
 # ---------------------------------------------------------------------------
 # TestNueOrderCreation
 # ---------------------------------------------------------------------------
 
 class TestNueOrderCreation:
-    def _mock_post(self):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"orderId": "nue-order-001", "status": "created"}
-        mock_response.raise_for_status.return_value = None
-        return mock_response
-
-    def test_external_reference_contains_session_id(self):
-        with patch("adapters.nue_adapter.httpx.post", return_value=self._mock_post()):
+    @pytest.mark.asyncio
+    async def test_external_reference_contains_session_id(self):
+        mock_cm = _make_async_client_mock({"orderId": "nue-order-001", "status": "created"})
+        with patch("adapters.nue_adapter.httpx.AsyncClient", return_value=mock_cm):
             with patch.dict(os.environ, {
                 "NUE_API_KEY": "test-api-key",
                 "NUE_BASE_URL": "https://api.nue.io",
             }):
-                result = NueEventParser.a2cn_terms_to_nue_order(
+                result = await NueEventParser.a2cn_terms_to_nue_order(
                     agreed_terms=SAMPLE_A2CN_AGREED_TERMS,
                     customer_id="cust-techcorp",
                     price_book_id="pb-enterprise-2026",
@@ -157,14 +217,16 @@ class TestNueOrderCreation:
 
         assert "sess-xyz-789" in result["order_payload_sent"]["externalReference"]
 
-    def test_notes_contain_record_hash(self):
+    @pytest.mark.asyncio
+    async def test_notes_contain_record_hash(self):
         record_hash = "feedcafe" * 8
-        with patch("adapters.nue_adapter.httpx.post", return_value=self._mock_post()):
+        mock_cm = _make_async_client_mock({"orderId": "nue-order-001", "status": "created"})
+        with patch("adapters.nue_adapter.httpx.AsyncClient", return_value=mock_cm):
             with patch.dict(os.environ, {
                 "NUE_API_KEY": "test-api-key",
                 "NUE_BASE_URL": "https://api.nue.io",
             }):
-                result = NueEventParser.a2cn_terms_to_nue_order(
+                result = await NueEventParser.a2cn_terms_to_nue_order(
                     agreed_terms=SAMPLE_A2CN_AGREED_TERMS,
                     customer_id="cust-001",
                     price_book_id="pb-001",
@@ -175,14 +237,16 @@ class TestNueOrderCreation:
 
         assert record_hash in result["order_payload_sent"]["notes"]
 
-    def test_start_date_defaults_to_today(self):
+    @pytest.mark.asyncio
+    async def test_start_date_defaults_to_today(self):
         today = date.today().strftime("%Y-%m-%d")
-        with patch("adapters.nue_adapter.httpx.post", return_value=self._mock_post()):
+        mock_cm = _make_async_client_mock({"orderId": "nue-order-001", "status": "created"})
+        with patch("adapters.nue_adapter.httpx.AsyncClient", return_value=mock_cm):
             with patch.dict(os.environ, {
                 "NUE_API_KEY": "test-api-key",
                 "NUE_BASE_URL": "https://api.nue.io",
             }):
-                result = NueEventParser.a2cn_terms_to_nue_order(
+                result = await NueEventParser.a2cn_terms_to_nue_order(
                     agreed_terms=SAMPLE_A2CN_AGREED_TERMS,
                     customer_id="cust-001",
                     price_book_id="pb-001",
@@ -194,13 +258,15 @@ class TestNueOrderCreation:
 
         assert result["order_payload_sent"]["startDate"] == today
 
-    def test_explicit_start_date_honoured(self):
-        with patch("adapters.nue_adapter.httpx.post", return_value=self._mock_post()):
+    @pytest.mark.asyncio
+    async def test_explicit_start_date_honoured(self):
+        mock_cm = _make_async_client_mock({"orderId": "nue-order-001", "status": "created"})
+        with patch("adapters.nue_adapter.httpx.AsyncClient", return_value=mock_cm):
             with patch.dict(os.environ, {
                 "NUE_API_KEY": "test-api-key",
                 "NUE_BASE_URL": "https://api.nue.io",
             }):
-                result = NueEventParser.a2cn_terms_to_nue_order(
+                result = await NueEventParser.a2cn_terms_to_nue_order(
                     agreed_terms=SAMPLE_A2CN_AGREED_TERMS,
                     customer_id="cust-001",
                     price_book_id="pb-001",
@@ -212,13 +278,15 @@ class TestNueOrderCreation:
 
         assert result["order_payload_sent"]["startDate"] == "2026-07-01"
 
-    def test_line_item_prices_converted_to_dollars(self):
-        with patch("adapters.nue_adapter.httpx.post", return_value=self._mock_post()):
+    @pytest.mark.asyncio
+    async def test_line_item_prices_converted_to_dollars(self):
+        mock_cm = _make_async_client_mock({"orderId": "nue-order-001", "status": "created"})
+        with patch("adapters.nue_adapter.httpx.AsyncClient", return_value=mock_cm):
             with patch.dict(os.environ, {
                 "NUE_API_KEY": "test-api-key",
                 "NUE_BASE_URL": "https://api.nue.io",
             }):
-                result = NueEventParser.a2cn_terms_to_nue_order(
+                result = await NueEventParser.a2cn_terms_to_nue_order(
                     agreed_terms=SAMPLE_A2CN_AGREED_TERMS,
                     customer_id="cust-001",
                     price_book_id="pb-001",
@@ -229,6 +297,63 @@ class TestNueOrderCreation:
 
         # 105_000 cents → $1050.00
         assert result["order_payload_sent"]["lines"][0]["unitPrice"] == pytest.approx(1050.0)
+
+    @pytest.mark.asyncio
+    async def test_fallback_unit_price_is_per_seat_not_total(self):
+        # $105,000 total / 100 seats = $1050.00 per seat
+        terms_no_line_items = {
+            "deal_type": "saas_renewal",
+            "total_value": 10_500_000,  # cents
+            "seat_count": 100,
+            "term_months": 12,
+            "line_items": [],
+        }
+        mock_cm = _make_async_client_mock({"orderId": "nue-order-002", "status": "created"})
+        with patch("adapters.nue_adapter.httpx.AsyncClient", return_value=mock_cm):
+            with patch.dict(os.environ, {
+                "NUE_API_KEY": "test-api-key",
+                "NUE_BASE_URL": "https://api.nue.io",
+            }):
+                result = await NueEventParser.a2cn_terms_to_nue_order(
+                    agreed_terms=terms_no_line_items,
+                    customer_id="cust-001",
+                    price_book_id="pb-001",
+                    product_id="prod-001",
+                    a2cn_session_id="sess-002",
+                    record_hash="hash-002",
+                )
+
+        line = result["order_payload_sent"]["lines"][0]
+        assert line["quantity"] == 100
+        # $105,000 / 100 seats = $1050.00 per seat
+        assert line["unitPrice"] == pytest.approx(1050.0)
+
+    @pytest.mark.asyncio
+    async def test_fallback_single_seat_unit_price_equals_total(self):
+        terms_single = {
+            "total_value": 50_000,  # $500 in cents
+            "seat_count": 1,
+            "term_months": 12,
+            "line_items": [],
+        }
+        mock_cm = _make_async_client_mock({"orderId": "nue-order-003", "status": "created"})
+        with patch("adapters.nue_adapter.httpx.AsyncClient", return_value=mock_cm):
+            with patch.dict(os.environ, {
+                "NUE_API_KEY": "test-api-key",
+                "NUE_BASE_URL": "https://api.nue.io",
+            }):
+                result = await NueEventParser.a2cn_terms_to_nue_order(
+                    agreed_terms=terms_single,
+                    customer_id="cust-001",
+                    price_book_id="pb-001",
+                    product_id="prod-001",
+                    a2cn_session_id="sess-003",
+                    record_hash="hash-003",
+                )
+
+        line = result["order_payload_sent"]["lines"][0]
+        assert line["quantity"] == 1
+        assert line["unitPrice"] == pytest.approx(500.0)
 
 
 # ---------------------------------------------------------------------------
@@ -241,36 +366,33 @@ class TestNueFetchCustomerSubscriptions:
                if k not in ("NUE_API_KEY", "NUE_BASE_URL")}
         with patch.dict(os.environ, env, clear=True):
             with pytest.raises(ValueError, match="NUE_API_KEY"):
-                NueEventParser.fetch_customer_subscriptions("cust-001")
+                import asyncio
+                asyncio.get_event_loop().run_until_complete(
+                    NueEventParser.fetch_customer_subscriptions("cust-001")
+                )
 
-    def test_returns_list_when_api_returns_list(self):
+    @pytest.mark.asyncio
+    async def test_returns_list_when_api_returns_list(self):
         subs = [{"subscriptionId": "sub-001"}, {"subscriptionId": "sub-002"}]
-        mock_response = MagicMock()
-        mock_response.json.return_value = subs
-        mock_response.raise_for_status.return_value = None
-
-        with patch("adapters.nue_adapter.httpx.get", return_value=mock_response):
+        mock_cm = _make_async_client_mock(subs)
+        with patch("adapters.nue_adapter.httpx.AsyncClient", return_value=mock_cm):
             with patch.dict(os.environ, {
                 "NUE_API_KEY": "test-key",
                 "NUE_BASE_URL": "https://api.nue.io",
             }):
-                result = NueEventParser.fetch_customer_subscriptions("cust-001")
+                result = await NueEventParser.fetch_customer_subscriptions("cust-001")
 
         assert len(result) == 2
         assert result[0]["subscriptionId"] == "sub-001"
 
-    def test_returns_list_when_api_wraps_in_dict(self):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "subscriptions": [{"subscriptionId": "sub-003"}]
-        }
-        mock_response.raise_for_status.return_value = None
-
-        with patch("adapters.nue_adapter.httpx.get", return_value=mock_response):
+    @pytest.mark.asyncio
+    async def test_returns_list_when_api_wraps_in_dict(self):
+        mock_cm = _make_async_client_mock({"subscriptions": [{"subscriptionId": "sub-003"}]})
+        with patch("adapters.nue_adapter.httpx.AsyncClient", return_value=mock_cm):
             with patch.dict(os.environ, {
                 "NUE_API_KEY": "test-key",
                 "NUE_BASE_URL": "https://api.nue.io",
             }):
-                result = NueEventParser.fetch_customer_subscriptions("cust-001")
+                result = await NueEventParser.fetch_customer_subscriptions("cust-001")
 
         assert result[0]["subscriptionId"] == "sub-003"

--- a/reference-implementation/python/tests/test_nue_adapter.py
+++ b/reference-implementation/python/tests/test_nue_adapter.py
@@ -1,0 +1,276 @@
+"""Tests for Nue.io Revenue Lifecycle platform adapter."""
+
+from __future__ import annotations
+
+import os
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from adapters.nue_adapter import NueEventParser
+
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+SAMPLE_NUE_PRICING = {
+    "productId": "prod-analytics-001",
+    "priceBookId": "pb-enterprise-2026",
+    # FIELD NOTE: listPrice field name verified against Nue sandbox
+    "listPrice": 1000.0,
+    "currency": "USD",
+    "quantity": 50,
+}
+
+SAMPLE_NUE_SUBSCRIPTION = {
+    "subscriptionId": "sub-001",
+    "customerId": "cust-techcorp",
+    "productId": "prod-analytics-001",
+    # FIELD NOTE: productTier, quantity, totalValue, autoRenew, termMonths
+    # should be verified against live Nue sandbox instance.
+    "productTier": "enterprise",
+    "quantity": 100,
+    "totalValue": 100000.0,
+    "currency": "USD",
+    "termMonths": 12,
+    "autoRenew": True,
+}
+
+SAMPLE_A2CN_AGREED_TERMS = {
+    "deal_type": "saas_renewal",
+    "total_value": 10_500_000,   # $105,000 in cents
+    "currency": "USD",
+    "seat_count": 100,
+    "term_months": 12,
+    "line_items": [
+        {
+            "description": "Analytics Platform Enterprise",
+            "quantity": 100,
+            "unit_price": 105_000,   # cents per seat per year
+            "total": 10_500_000,
+        }
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# TestNuePricingToMandateBounds
+# ---------------------------------------------------------------------------
+
+class TestNuePricingToMandateBounds:
+    def test_floor_is_less_than_ceiling(self):
+        bounds = NueEventParser.pricing_to_mandate_bounds(SAMPLE_NUE_PRICING)
+        assert bounds["floor_value_cents"] < bounds["ceiling_value_cents"]
+
+    def test_ceiling_equals_list_price_in_cents(self):
+        # 50 seats × $1000 = $50,000 = 5,000,000 cents
+        bounds = NueEventParser.pricing_to_mandate_bounds(SAMPLE_NUE_PRICING)
+        assert bounds["ceiling_value_cents"] == 5_000_000
+
+    def test_default_floor_discount_ten_percent(self):
+        bounds = NueEventParser.pricing_to_mandate_bounds(SAMPLE_NUE_PRICING)
+        assert bounds["floor_value_cents"] == int(5_000_000 * 0.90)
+
+    def test_custom_floor_discount_pct(self):
+        bounds = NueEventParser.pricing_to_mandate_bounds(
+            SAMPLE_NUE_PRICING, floor_discount_pct=0.20
+        )
+        assert bounds["floor_value_cents"] == int(5_000_000 * 0.80)
+
+    def test_currency_passthrough(self):
+        bounds = NueEventParser.pricing_to_mandate_bounds(SAMPLE_NUE_PRICING)
+        assert bounds["currency"] == "USD"
+
+    def test_single_unit_pricing(self):
+        pricing = {"listPrice": 2000.0, "currency": "EUR"}
+        bounds = NueEventParser.pricing_to_mandate_bounds(pricing, floor_discount_pct=0.15)
+        assert bounds["ceiling_value_cents"] == 200_000
+        assert bounds["floor_value_cents"] == int(200_000 * 0.85)
+
+
+# ---------------------------------------------------------------------------
+# TestNueSubscriptionToRenewalTerms
+# ---------------------------------------------------------------------------
+
+class TestNueSubscriptionToRenewalTerms:
+    def test_deal_type_is_saas_renewal(self):
+        terms = NueEventParser.subscription_to_renewal_terms(SAMPLE_NUE_SUBSCRIPTION)
+        assert terms["deal_type"] == "saas_renewal"
+
+    def test_renewal_markup_applied_correctly(self):
+        # $100,000 * 100 cents * 1.05 = 10,500,000 cents
+        terms = NueEventParser.subscription_to_renewal_terms(
+            SAMPLE_NUE_SUBSCRIPTION, renewal_markup_pct=0.05
+        )
+        assert terms["total_value"] == int(100_000.0 * 100 * 1.05)
+
+    def test_seat_count_from_subscription_quantity(self):
+        terms = NueEventParser.subscription_to_renewal_terms(SAMPLE_NUE_SUBSCRIPTION)
+        assert terms["seat_count"] == 100
+
+    def test_subscription_tier_extracted(self):
+        terms = NueEventParser.subscription_to_renewal_terms(SAMPLE_NUE_SUBSCRIPTION)
+        assert terms["subscription_tier"] == "enterprise"
+
+    def test_auto_renew_terms_included(self):
+        terms = NueEventParser.subscription_to_renewal_terms(SAMPLE_NUE_SUBSCRIPTION)
+        assert terms["auto_renew_terms"]["auto_renew"] is True
+
+    def test_term_months_included(self):
+        terms = NueEventParser.subscription_to_renewal_terms(SAMPLE_NUE_SUBSCRIPTION)
+        assert terms["term_months"] == 12
+
+    def test_zero_markup_preserves_current_value(self):
+        terms = NueEventParser.subscription_to_renewal_terms(
+            SAMPLE_NUE_SUBSCRIPTION, renewal_markup_pct=0.0
+        )
+        assert terms["total_value"] == int(100_000.0 * 100)
+
+
+# ---------------------------------------------------------------------------
+# TestNueOrderCreation
+# ---------------------------------------------------------------------------
+
+class TestNueOrderCreation:
+    def _mock_post(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"orderId": "nue-order-001", "status": "created"}
+        mock_response.raise_for_status.return_value = None
+        return mock_response
+
+    def test_external_reference_contains_session_id(self):
+        with patch("adapters.nue_adapter.httpx.post", return_value=self._mock_post()):
+            with patch.dict(os.environ, {
+                "NUE_API_KEY": "test-api-key",
+                "NUE_BASE_URL": "https://api.nue.io",
+            }):
+                result = NueEventParser.a2cn_terms_to_nue_order(
+                    agreed_terms=SAMPLE_A2CN_AGREED_TERMS,
+                    customer_id="cust-techcorp",
+                    price_book_id="pb-enterprise-2026",
+                    product_id="prod-analytics-001",
+                    a2cn_session_id="sess-xyz-789",
+                    record_hash="abc123" * 10,
+                )
+
+        assert "sess-xyz-789" in result["order_payload_sent"]["externalReference"]
+
+    def test_notes_contain_record_hash(self):
+        record_hash = "feedcafe" * 8
+        with patch("adapters.nue_adapter.httpx.post", return_value=self._mock_post()):
+            with patch.dict(os.environ, {
+                "NUE_API_KEY": "test-api-key",
+                "NUE_BASE_URL": "https://api.nue.io",
+            }):
+                result = NueEventParser.a2cn_terms_to_nue_order(
+                    agreed_terms=SAMPLE_A2CN_AGREED_TERMS,
+                    customer_id="cust-001",
+                    price_book_id="pb-001",
+                    product_id="prod-001",
+                    a2cn_session_id="sess-001",
+                    record_hash=record_hash,
+                )
+
+        assert record_hash in result["order_payload_sent"]["notes"]
+
+    def test_start_date_defaults_to_today(self):
+        today = date.today().strftime("%Y-%m-%d")
+        with patch("adapters.nue_adapter.httpx.post", return_value=self._mock_post()):
+            with patch.dict(os.environ, {
+                "NUE_API_KEY": "test-api-key",
+                "NUE_BASE_URL": "https://api.nue.io",
+            }):
+                result = NueEventParser.a2cn_terms_to_nue_order(
+                    agreed_terms=SAMPLE_A2CN_AGREED_TERMS,
+                    customer_id="cust-001",
+                    price_book_id="pb-001",
+                    product_id="prod-001",
+                    a2cn_session_id="sess-001",
+                    record_hash="hash-001",
+                    start_date=None,
+                )
+
+        assert result["order_payload_sent"]["startDate"] == today
+
+    def test_explicit_start_date_honoured(self):
+        with patch("adapters.nue_adapter.httpx.post", return_value=self._mock_post()):
+            with patch.dict(os.environ, {
+                "NUE_API_KEY": "test-api-key",
+                "NUE_BASE_URL": "https://api.nue.io",
+            }):
+                result = NueEventParser.a2cn_terms_to_nue_order(
+                    agreed_terms=SAMPLE_A2CN_AGREED_TERMS,
+                    customer_id="cust-001",
+                    price_book_id="pb-001",
+                    product_id="prod-001",
+                    a2cn_session_id="sess-001",
+                    record_hash="hash-001",
+                    start_date="2026-07-01",
+                )
+
+        assert result["order_payload_sent"]["startDate"] == "2026-07-01"
+
+    def test_line_item_prices_converted_to_dollars(self):
+        with patch("adapters.nue_adapter.httpx.post", return_value=self._mock_post()):
+            with patch.dict(os.environ, {
+                "NUE_API_KEY": "test-api-key",
+                "NUE_BASE_URL": "https://api.nue.io",
+            }):
+                result = NueEventParser.a2cn_terms_to_nue_order(
+                    agreed_terms=SAMPLE_A2CN_AGREED_TERMS,
+                    customer_id="cust-001",
+                    price_book_id="pb-001",
+                    product_id="prod-001",
+                    a2cn_session_id="sess-001",
+                    record_hash="hash-001",
+                )
+
+        # 105_000 cents → $1050.00
+        assert result["order_payload_sent"]["lines"][0]["unitPrice"] == pytest.approx(1050.0)
+
+
+# ---------------------------------------------------------------------------
+# TestNueFetchCustomerSubscriptions
+# ---------------------------------------------------------------------------
+
+class TestNueFetchCustomerSubscriptions:
+    def test_raises_on_missing_api_key(self):
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("NUE_API_KEY", "NUE_BASE_URL")}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValueError, match="NUE_API_KEY"):
+                NueEventParser.fetch_customer_subscriptions("cust-001")
+
+    def test_returns_list_when_api_returns_list(self):
+        subs = [{"subscriptionId": "sub-001"}, {"subscriptionId": "sub-002"}]
+        mock_response = MagicMock()
+        mock_response.json.return_value = subs
+        mock_response.raise_for_status.return_value = None
+
+        with patch("adapters.nue_adapter.httpx.get", return_value=mock_response):
+            with patch.dict(os.environ, {
+                "NUE_API_KEY": "test-key",
+                "NUE_BASE_URL": "https://api.nue.io",
+            }):
+                result = NueEventParser.fetch_customer_subscriptions("cust-001")
+
+        assert len(result) == 2
+        assert result[0]["subscriptionId"] == "sub-001"
+
+    def test_returns_list_when_api_wraps_in_dict(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "subscriptions": [{"subscriptionId": "sub-003"}]
+        }
+        mock_response.raise_for_status.return_value = None
+
+        with patch("adapters.nue_adapter.httpx.get", return_value=mock_response):
+            with patch.dict(os.environ, {
+                "NUE_API_KEY": "test-key",
+                "NUE_BASE_URL": "https://api.nue.io",
+            }):
+                result = NueEventParser.fetch_customer_subscriptions("cust-001")
+
+        assert result[0]["subscriptionId"] == "sub-003"


### PR DESCRIPTION
## Summary

- **DealHub CPQ adapter** (`adapters/dealhub_adapter.py`): PATH A (quoteReady webhook → offer terms → Actions API win) + PATH B (headless simulate → mandate bounds). Deal type inferred from product names. Field names configurable via `DEFAULT_FIELD_MAP`. `DEALHUB_INTEGRATION.md` integration guide.
- **Nue.io adapter** (`adapters/nue_adapter.py`): Pricing → mandate bounds, subscription → renewal terms, agreed terms → Nue order with A2CN audit trail in `externalReference` + `notes`. `NUE_INTEGRATION.md` integration guide.
- 44 new tests (22 DealHub + 22 Nue) — all unit tests, no real HTTP, using `unittest.mock.patch`

Both adapters follow the exact patterns of `fairmarkit_adapter.py`, `keelvar_adapter.py`, and `revenue_cloud_adapter.py`.

## Test plan

- [ ] `pytest tests/test_dealhub_adapter.py tests/test_nue_adapter.py -v` — all 44 new tests pass
- [ ] `pytest tests/test_adapters.py -v` — all 38 existing adapter tests still pass
- [ ] No changes to existing adapters, session logic, or message types

**Note:** 13 pre-existing test failures exist from PR #10's Fix 1 (`SENDER_DID_MISMATCH` check now intercepts before turn-taking in test helpers that send `RESPONDER_DID` body with `INITIATOR_DID` JWT). These failures are not caused by this PR — they are in `test_post_commitment.py`, `test_conformance.py`, and `test_server.py` and require updating those test helpers to use a responder-side JWT fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)