### PR TITLE
Verify protocol act signatures

### DIFF
--- a/reference-implementation/python/a2cn/server.py
+++ b/reference-implementation/python/a2cn/server.py
@@ -50,6 +50,7 @@ from a2cn.messages import (
 )
 from a2cn.crypto import (
     hash_bytes,
+    public_key_to_jwk,
     sign_jws,
     verify_jwt,
     verify_invitation_signature,
@@ -84,6 +85,27 @@ def configure_responder(config: dict, session_store: "SessionStore | None" = Non
     """Set responder identity info (DID, agent info, mandate, private key, etc.)."""
     global _responder_config, _session_store
     _responder_config = config
+    agent_info = config.get("agent_info", {})
+    private_key = config.get("private_key")
+    did = agent_info.get("did")
+    verification_method = agent_info.get("verification_method")
+    if did and verification_method and private_key is not None:
+        manager.register_did_document(
+            did,
+            {
+                "id": did,
+                "verificationMethod": [
+                    {
+                        "id": verification_method,
+                        "type": "JsonWebKey2020",
+                        "controller": did,
+                        "publicKeyJwk": public_key_to_jwk(private_key.public_key()),
+                    }
+                ],
+                "authentication": [verification_method],
+                "assertionMethod": [verification_method],
+            },
+        )
     if session_store is not None:
         _session_store = session_store
 
@@ -164,6 +186,7 @@ _did_doc_override: dict[str, dict] = {}
 def register_did_document(did: str, did_document: dict) -> None:
     """Pre-register a DID document so JWT verification skips HTTP resolution."""
     _did_doc_override[did] = did_document
+    manager.register_did_document(did, did_document)
 
 
 def _clean_expired_jtis() -> None:
@@ -210,6 +233,7 @@ async def verify_jwt_auth(request: Request) -> dict:
             try:
                 async with httpx.AsyncClient() as http:
                     did_doc = await resolve_did_web(iss, http)
+                manager.register_did_document(iss, did_doc)
             except Exception as exc:
                 raise A2CNError("INVALID_JWT", f"Could not resolve issuer DID: {exc}", 401)
 

--- a/reference-implementation/python/a2cn/session.py
+++ b/reference-implementation/python/a2cn/session.py
@@ -15,7 +15,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
-from a2cn.crypto import hash_object
+from a2cn.crypto import hash_object, verify_jws
+from a2cn.did import get_public_key, get_verification_method
 
 
 # ---------------------------------------------------------------------------
@@ -144,6 +145,11 @@ class SessionManager:
         self._sessions: dict[str, Session] = {}
         # Pre-session idempotency: message_id → response dict
         self._init_responses: dict[str, dict] = {}
+        self._did_documents: dict[str, dict] = {}
+
+    def register_did_document(self, did: str, did_document: dict) -> None:
+        """Register a resolved DID document for protocol-act signature checks."""
+        self._did_documents[did] = did_document
 
     # ------------------------------------------------------------------
     # Session creation (on SessionInit)
@@ -366,6 +372,72 @@ class SessionManager:
             session_id=session.session_id,
         )
 
+    def _verify_sender_signature(
+        self,
+        session: Session,
+        message: dict,
+        *,
+        payload_hash: str,
+        signature_field: str,
+    ) -> None:
+        sender_did = message.get("sender_did", "")
+        message_id = message.get("message_id")
+        verification_method = message.get("sender_verification_method", "")
+        signature = message.get(signature_field, "")
+
+        if not verification_method or not signature:
+            raise A2CNError(
+                "INVALID_SIGNATURE",
+                f"Missing sender_verification_method or {signature_field}",
+                400,
+                session_id=session.session_id,
+                message_id=message_id,
+            )
+        if not (
+            verification_method == sender_did
+            or verification_method.startswith(f"{sender_did}#")
+        ):
+            raise A2CNError(
+                "INVALID_SIGNATURE",
+                "sender_verification_method is not controlled by sender_did",
+                400,
+                session_id=session.session_id,
+                message_id=message_id,
+            )
+
+        did_document = self._did_documents.get(sender_did)
+        if did_document is None:
+            raise A2CNError(
+                "INVALID_SIGNATURE",
+                f"No DID document registered for sender {sender_did!r}",
+                400,
+                session_id=session.session_id,
+                message_id=message_id,
+            )
+
+        try:
+            vm = get_verification_method(did_document, verification_method)
+            public_key = get_public_key(vm)
+            signed_payload_hash = verify_jws(signature, public_key)
+        except Exception as exc:
+            raise A2CNError(
+                "INVALID_SIGNATURE",
+                f"{signature_field} verification failed",
+                400,
+                detail=str(exc),
+                session_id=session.session_id,
+                message_id=message_id,
+            ) from exc
+
+        if signed_payload_hash != payload_hash:
+            raise A2CNError(
+                "INVALID_SIGNATURE",
+                f"{signature_field} payload does not match message fields",
+                400,
+                session_id=session.session_id,
+                message_id=message_id,
+            )
+
     def _handle_offer(self, session: Session, message: dict) -> dict:
         message_id = message.get("message_id", "")
         message_type = message.get("message_type", "")
@@ -383,30 +455,43 @@ class SessionManager:
 
         # Protocol act hash verification (finding 4.3)
         claimed_hash = message.get("protocol_act_hash")
-        if claimed_hash:
-            terms = message.get("terms", {})
-            timestamp = message.get("timestamp", "")
-            expires_at = message.get("expires_at", "")
-            protocol_act = {
-                "protocol_version": "0.2",  # Section 7.3.1
-                "session_id": message.get("session_id", ""),
-                "round_number": message.get("round_number"),
-                "sequence_number": message.get("sequence_number"),
-                "message_type": message_type,
-                "sender_did": sender_did,
-                "timestamp": timestamp,
-                "expires_at": expires_at,
-                "terms": terms,
-            }
-            expected_hash = hash_object(protocol_act)
-            if claimed_hash != expected_hash:
-                raise A2CNError(
-                    "INVALID_SIGNATURE",
-                    "Protocol act hash does not match message fields",
-                    400,
-                    session_id=session.session_id,
-                    message_id=message_id,
-                )
+        if not claimed_hash:
+            raise A2CNError(
+                "INVALID_SIGNATURE",
+                "Missing protocol_act_hash",
+                400,
+                session_id=session.session_id,
+                message_id=message_id,
+            )
+        terms = message.get("terms", {})
+        timestamp = message.get("timestamp", "")
+        expires_at = message.get("expires_at", "")
+        protocol_act = {
+            "protocol_version": "0.2",  # Section 7.3.1
+            "session_id": message.get("session_id", ""),
+            "round_number": message.get("round_number"),
+            "sequence_number": message.get("sequence_number"),
+            "message_type": message_type,
+            "sender_did": sender_did,
+            "timestamp": timestamp,
+            "expires_at": expires_at,
+            "terms": terms,
+        }
+        expected_hash = hash_object(protocol_act)
+        if claimed_hash != expected_hash:
+            raise A2CNError(
+                "INVALID_SIGNATURE",
+                "Protocol act hash does not match message fields",
+                400,
+                session_id=session.session_id,
+                message_id=message_id,
+            )
+        self._verify_sender_signature(
+            session,
+            message,
+            payload_hash=expected_hash,
+            signature_field="protocol_act_signature",
+        )
 
         # Message type check: round 1 must be "offer", round 2+ must be "counteroffer"
         if round_number == 1:
@@ -672,6 +757,20 @@ class SessionManager:
 
         # Sequence check
         self._check_sequence(session, message)
+
+        acceptance_payload = {
+            "session_id": message.get("session_id", ""),
+            "round_number": message.get("round_number"),
+            "sequence_number": message.get("sequence_number"),
+            "accepted_offer_id": accepted_offer_id,
+            "accepted_protocol_act_hash": accepted_hash,
+        }
+        self._verify_sender_signature(
+            session,
+            message,
+            payload_hash=hash_object(acceptance_payload),
+            signature_field="acceptance_signature",
+        )
 
         # Offer hash match
         if accepted_offer_id != session.latest_offer_id:

--- a/reference-implementation/python/tests/conformance/test_conformance.py
+++ b/reference-implementation/python/tests/conformance/test_conformance.py
@@ -20,6 +20,9 @@ from a2cn.crypto import public_key_to_jwk
 
 HEADERS_CT = {"Content-Type": "application/a2cn+json"}
 
+INITIATOR_PRIVATE_KEY, INITIATOR_PUBLIC_KEY = generate_keypair()
+RESPONDER_PRIVATE_KEY, RESPONDER_PUBLIC_KEY = generate_keypair()
+
 
 def init_headers(message_id: str) -> dict:
     return {"Content-Type": "application/a2cn+json", "Idempotency-Key": message_id}
@@ -36,7 +39,7 @@ async def _create_session(client) -> str:
     return r.json()["session_id"]
 
 
-def _offer(session_id, seq, rnd, sender_did, msg_type="offer", in_reply_to=None,
+def _offer(session_id, seq, rnd, sender_did, private_key, msg_type="offer", in_reply_to=None,
            msg_id=None):
     msg_id = msg_id or str(uuid.uuid4())
     timestamp = "2026-03-24T10:00:00Z"
@@ -54,6 +57,11 @@ def _offer(session_id, seq, rnd, sender_did, msg_type="offer", in_reply_to=None,
         "terms": terms,
     }
     pah = hash_object(protocol_act)
+    verification_method = (
+        f"{INITIATOR_DID}#key-1"
+        if sender_did == INITIATOR_DID
+        else f"{RESPONDER_DID}#key-2026-01"
+    )
     msg = {
         "message_type": msg_type,
         "message_id": msg_id,
@@ -62,12 +70,12 @@ def _offer(session_id, seq, rnd, sender_did, msg_type="offer", in_reply_to=None,
         "sequence_number": seq,
         "sender_did": sender_did,
         "sender_agent_id": "conformance-agent",
-        "sender_verification_method": f"{sender_did}#key-1",
+        "sender_verification_method": verification_method,
         "timestamp": timestamp,
         "expires_at": expires_at,
         "terms": terms,
         "protocol_act_hash": pah,
-        "protocol_act_signature": "eyJ...",
+        "protocol_act_signature": sign_jws(pah, private_key, kid=verification_method),
     }
     if in_reply_to:
         msg["in_reply_to"] = in_reply_to
@@ -97,12 +105,12 @@ async def test_session_init_idempotency(test_client):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_turn_taking_enforced(test_client, responder_test_client):
+async def test_turn_taking_enforced(test_client, responder_test_client, responder_keypair):
     """NOT_YOUR_TURN returned for out-of-turn message."""
     session_id = await _create_session(test_client)
 
     # Responder tries to send before initiator — must fail
-    offer = _offer(session_id, 1, 1, RESPONDER_DID)
+    offer = _offer(session_id, 1, 1, RESPONDER_DID, responder_keypair[0])
     r = await responder_test_client.post(
         f"/sessions/{session_id}/messages", json=offer, headers=init_headers(offer["message_id"])
     )
@@ -209,6 +217,14 @@ async def test_jwt_valid_token_accepted(raw_test_client, initiator_keypair, init
 def test_transaction_record_deterministic():
     """Both sides generate identical record_hash independently."""
     mgr = SessionManager()
+    mgr.register_did_document(
+        INITIATOR_DID,
+        make_did_document(INITIATOR_DID, "key-1", public_key_to_jwk(INITIATOR_PUBLIC_KEY)),
+    )
+    mgr.register_did_document(
+        RESPONDER_DID,
+        make_did_document(RESPONDER_DID, "key-2026-01", public_key_to_jwk(RESPONDER_PUBLIC_KEY)),
+    )
     session_id = str(uuid.uuid4())
 
     init_msg = {
@@ -290,9 +306,20 @@ def test_transaction_record_deterministic():
         "expires_at": _offer_expires,
         "terms": _offer_terms,
         "protocol_act_hash": _offer_pah,
-        "protocol_act_signature": "eyJ...",
+        "protocol_act_signature": sign_jws(
+            _offer_pah,
+            INITIATOR_PRIVATE_KEY,
+            kid=f"{INITIATOR_DID}#key-1",
+        ),
     }
 
+    acceptance_payload = {
+        "session_id": session_id,
+        "round_number": 1,
+        "sequence_number": 2,
+        "accepted_offer_id": "offer-1",
+        "accepted_protocol_act_hash": _offer_pah,
+    }
     acceptance_msg = {
         "message_type": "acceptance",
         "message_id": "acc-1",
@@ -306,7 +333,11 @@ def test_transaction_record_deterministic():
         "sender_agent_id": "seller-agent",
         "sender_verification_method": f"{RESPONDER_DID}#key-2026-01",
         "timestamp": "2026-03-24T10:03:00Z",
-        "acceptance_signature": "eyJ...",
+        "acceptance_signature": sign_jws(
+            hash_object(acceptance_payload),
+            RESPONDER_PRIVATE_KEY,
+            kid=f"{RESPONDER_DID}#key-2026-01",
+        ),
     }
 
     mgr.process_message(sess, offer_msg)
@@ -329,19 +360,19 @@ def test_transaction_record_deterministic():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_sequence_ordering_strict(test_client, responder_test_client):
+async def test_sequence_ordering_strict(test_client, responder_test_client, initiator_keypair, responder_keypair):
     """Gap in sequence_number rejected with SEQUENCE_ERROR."""
     session_id = await _create_session(test_client)
 
     # Send seq=1 OK
-    offer = _offer(session_id, 1, 1, INITIATOR_DID)
+    offer = _offer(session_id, 1, 1, INITIATOR_DID, initiator_keypair[0])
     r = await test_client.post(
         f"/sessions/{session_id}/messages", json=offer, headers=init_headers(offer["message_id"])
     )
     assert r.status_code == 200
 
     # Now send seq=3 (skipping 2) — must fail
-    bad_offer = _offer(session_id, 3, 2, RESPONDER_DID, msg_type="counteroffer",
+    bad_offer = _offer(session_id, 3, 2, RESPONDER_DID, responder_keypair[0], msg_type="counteroffer",
                        in_reply_to=offer["message_id"])
     r2 = await responder_test_client.post(
         f"/sessions/{session_id}/messages", json=bad_offer, headers=init_headers(bad_offer["message_id"])
@@ -355,7 +386,7 @@ async def test_sequence_ordering_strict(test_client, responder_test_client):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_terminal_state_reentry(test_client):
+async def test_terminal_state_reentry(test_client, initiator_keypair):
     """SESSION_WRONG_STATE returned for messages on completed/terminal session."""
     session_id = await _create_session(test_client)
 
@@ -375,7 +406,7 @@ async def test_terminal_state_reentry(test_client):
     )
 
     # Try to send another offer
-    offer = _offer(session_id, 2, 1, INITIATOR_DID)
+    offer = _offer(session_id, 2, 1, INITIATOR_DID, initiator_keypair[0])
     r = await test_client.post(
         f"/sessions/{session_id}/messages", json=offer, headers=init_headers(offer["message_id"])
     )

--- a/reference-implementation/python/tests/test_post_commitment.py
+++ b/reference-implementation/python/tests/test_post_commitment.py
@@ -14,7 +14,7 @@ import json
 import uuid
 import pytest
 
-from a2cn.crypto import hash_object
+from a2cn.crypto import hash_object, sign_jws
 from a2cn.messages import (
     DeliveryNoticeMessage,
     DeliveryAcknowledgedMessage,
@@ -434,6 +434,7 @@ async def _complete_session(
         "terms": terms,
     }
     pah = hash_object(protocol_act)
+    initiator_private_key = initiator_client.auth._private_key
     offer = {
         "message_type": "offer",
         "message_id": offer_id,
@@ -447,7 +448,11 @@ async def _complete_session(
         "expires_at": expires_at,
         "terms": terms,
         "protocol_act_hash": pah,
-        "protocol_act_signature": "eyJ...",
+        "protocol_act_signature": sign_jws(
+            pah,
+            initiator_private_key,
+            kid=f"{INITIATOR_DID}#key-1",
+        ),
     }
     r = await initiator_client.post(
         f"/sessions/{session_id}/messages", json=offer, headers=_h(offer_id)
@@ -455,6 +460,14 @@ async def _complete_session(
     assert r.status_code == 200, r.text
 
     acc_id = str(uuid.uuid4())
+    acceptance_payload = {
+        "session_id": session_id,
+        "round_number": 1,
+        "sequence_number": 2,
+        "accepted_offer_id": offer_id,
+        "accepted_protocol_act_hash": pah,
+    }
+    responder_private_key = responder_client.auth._private_key
     acceptance = {
         "message_type": "acceptance",
         "message_id": acc_id,
@@ -468,7 +481,11 @@ async def _complete_session(
         "sender_agent_id": "test-agent",
         "sender_verification_method": f"{RESPONDER_DID}#key-2026-01",
         "timestamp": "2026-04-01T10:01:00Z",
-        "acceptance_signature": "eyJ...",
+        "acceptance_signature": sign_jws(
+            hash_object(acceptance_payload),
+            responder_private_key,
+            kid=f"{RESPONDER_DID}#key-2026-01",
+        ),
     }
     r = await responder_client.post(
         f"/sessions/{session_id}/messages", json=acceptance, headers=_h(acc_id)

--- a/reference-implementation/python/tests/test_server.py
+++ b/reference-implementation/python/tests/test_server.py
@@ -13,6 +13,7 @@ from a2cn.crypto import (
     hash_bytes,
     hash_object,
     public_key_to_jwk,
+    sign_jws,
     verify_jws,
 )
 from tests.conftest import (
@@ -216,7 +217,7 @@ async def _create_session(client) -> str:
     return r.json()["session_id"]
 
 
-def _make_offer_msg(session_id, seq, rnd, sender_did, msg_type="offer",
+def _make_offer_msg(session_id, seq, rnd, sender_did, private_key, msg_type="offer",
                     in_reply_to=None, msg_id=None):
     msg_id = msg_id or str(uuid.uuid4())
     timestamp = "2026-03-24T10:01:00Z"
@@ -234,6 +235,11 @@ def _make_offer_msg(session_id, seq, rnd, sender_did, msg_type="offer",
         "terms": terms,
     }
     pah = hash_object(protocol_act)
+    verification_method = (
+        f"{INITIATOR_DID}#key-1"
+        if sender_did == INITIATOR_DID
+        else f"{RESPONDER_DID}#key-2026-01"
+    )
     msg = {
         "message_type": msg_type,
         "message_id": msg_id,
@@ -242,12 +248,12 @@ def _make_offer_msg(session_id, seq, rnd, sender_did, msg_type="offer",
         "sequence_number": seq,
         "sender_did": sender_did,
         "sender_agent_id": "test-agent",
-        "sender_verification_method": f"{sender_did}#key-1",
+        "sender_verification_method": verification_method,
         "timestamp": timestamp,
         "expires_at": expires_at,
         "terms": terms,
         "protocol_act_hash": pah,
-        "protocol_act_signature": "eyJ...",
+        "protocol_act_signature": sign_jws(pah, private_key, kid=verification_method),
     }
     if in_reply_to:
         msg["in_reply_to"] = in_reply_to
@@ -255,9 +261,9 @@ def _make_offer_msg(session_id, seq, rnd, sender_did, msg_type="offer",
 
 
 @pytest.mark.asyncio
-async def test_send_offer_succeeds(test_client):
+async def test_send_offer_succeeds(test_client, initiator_keypair):
     session_id = await _create_session(test_client)
-    offer = _make_offer_msg(session_id, 1, 1, INITIATOR_DID)
+    offer = _make_offer_msg(session_id, 1, 1, INITIATOR_DID, initiator_keypair[0])
     r = await test_client.post(
         f"/sessions/{session_id}/messages",
         json=offer,
@@ -267,10 +273,10 @@ async def test_send_offer_succeeds(test_client):
 
 
 @pytest.mark.asyncio
-async def test_not_your_turn(test_client, responder_test_client):
+async def test_not_your_turn(test_client, responder_test_client, responder_keypair):
     session_id = await _create_session(test_client)
     # Responder tries to send before initiator
-    offer = _make_offer_msg(session_id, 1, 1, RESPONDER_DID)
+    offer = _make_offer_msg(session_id, 1, 1, RESPONDER_DID, responder_keypair[0])
     r = await responder_test_client.post(
         f"/sessions/{session_id}/messages",
         json=offer,
@@ -281,9 +287,9 @@ async def test_not_your_turn(test_client, responder_test_client):
 
 
 @pytest.mark.asyncio
-async def test_sequence_error(test_client):
+async def test_sequence_error(test_client, initiator_keypair):
     session_id = await _create_session(test_client)
-    offer = _make_offer_msg(session_id, 5, 1, INITIATOR_DID)  # wrong seq
+    offer = _make_offer_msg(session_id, 5, 1, INITIATOR_DID, initiator_keypair[0])  # wrong seq
     r = await test_client.post(
         f"/sessions/{session_id}/messages",
         json=offer,
@@ -294,9 +300,9 @@ async def test_sequence_error(test_client):
 
 
 @pytest.mark.asyncio
-async def test_message_idempotency(test_client):
+async def test_message_idempotency(test_client, initiator_keypair):
     session_id = await _create_session(test_client)
-    offer = _make_offer_msg(session_id, 1, 1, INITIATOR_DID)
+    offer = _make_offer_msg(session_id, 1, 1, INITIATOR_DID, initiator_keypair[0])
     h = init_headers(offer["message_id"])
     r1 = await test_client.post(f"/sessions/{session_id}/messages", json=offer, headers=h)
     r2 = await test_client.post(f"/sessions/{session_id}/messages", json=offer, headers=h)
@@ -304,13 +310,13 @@ async def test_message_idempotency(test_client):
 
 
 @pytest.mark.asyncio
-async def test_approval_receipt_endpoint_releases_human_approval_pause(test_client):
+async def test_approval_receipt_endpoint_releases_human_approval_pause(test_client, initiator_keypair):
     body = make_session_init()
     body["initiator_mandate"]["requires_human_approval_above"] = 9_000_000
     r = await test_client.post("/sessions", json=body, headers=init_headers(body["message_id"]))
     session_id = r.json()["session_id"]
 
-    offer = _make_offer_msg(session_id, 1, 1, INITIATOR_DID)
+    offer = _make_offer_msg(session_id, 1, 1, INITIATOR_DID, initiator_keypair[0])
     offer_r = await test_client.post(
         f"/sessions/{session_id}/messages",
         json=offer,

--- a/reference-implementation/python/tests/test_session.py
+++ b/reference-implementation/python/tests/test_session.py
@@ -4,7 +4,8 @@ import uuid
 import pytest
 
 from a2cn.session import Session, SessionManager, SessionState, A2CNError
-from a2cn.crypto import generate_keypair, hash_object, sign_jws
+from a2cn.crypto import generate_keypair, hash_object, public_key_to_jwk, sign_jws
+from tests.conftest import make_did_document
 
 
 INITIATOR_DID = "did:web:techcorp.example"
@@ -57,6 +58,9 @@ SESSION_ACK = {
     "current_turn": "initiator",
 }
 
+INITIATOR_PRIVATE_KEY, INITIATOR_PUBLIC_KEY = generate_keypair()
+RESPONDER_PRIVATE_KEY, RESPONDER_PUBLIC_KEY = generate_keypair()
+
 
 def _make_offer(session_id, seq, rnd, sender_did, msg_type="offer", in_reply_to=None):
     timestamp = "2026-03-24T10:01:00Z"
@@ -74,6 +78,12 @@ def _make_offer(session_id, seq, rnd, sender_did, msg_type="offer", in_reply_to=
         "terms": terms,
     }
     pah = hash_object(protocol_act)
+    private_key = INITIATOR_PRIVATE_KEY if sender_did == INITIATOR_DID else RESPONDER_PRIVATE_KEY
+    verification_method = (
+        f"{INITIATOR_DID}#key-1"
+        if sender_did == INITIATOR_DID
+        else f"{RESPONDER_DID}#key-2026-01"
+    )
     msg = {
         "message_type": msg_type,
         "message_id": str(uuid.uuid4()),
@@ -82,20 +92,81 @@ def _make_offer(session_id, seq, rnd, sender_did, msg_type="offer", in_reply_to=
         "sequence_number": seq,
         "sender_did": sender_did,
         "sender_agent_id": "agent",
-        "sender_verification_method": f"{sender_did}#key-1",
+        "sender_verification_method": verification_method,
         "timestamp": timestamp,
         "expires_at": expires_at,
         "terms": terms,
         "protocol_act_hash": pah,
-        "protocol_act_signature": "eyJ...",
+        "protocol_act_signature": sign_jws(pah, private_key, kid=verification_method),
     }
     if in_reply_to:
         msg["in_reply_to"] = in_reply_to
     return msg
 
 
+def _resign_offer(offer: dict) -> None:
+    protocol_act = {
+        "protocol_version": "0.2",
+        "session_id": offer["session_id"],
+        "round_number": offer["round_number"],
+        "sequence_number": offer["sequence_number"],
+        "message_type": offer["message_type"],
+        "sender_did": offer["sender_did"],
+        "timestamp": offer["timestamp"],
+        "expires_at": offer["expires_at"],
+        "terms": offer["terms"],
+    }
+    offer["protocol_act_hash"] = hash_object(protocol_act)
+    private_key = INITIATOR_PRIVATE_KEY if offer["sender_did"] == INITIATOR_DID else RESPONDER_PRIVATE_KEY
+    offer["protocol_act_signature"] = sign_jws(
+        offer["protocol_act_hash"],
+        private_key,
+        kid=offer["sender_verification_method"],
+    )
+
+
+def _make_acceptance(sess: Session, offer: dict, *, msg_id="acc-1") -> dict:
+    sender_did = RESPONDER_DID
+    verification_method = f"{RESPONDER_DID}#key-2026-01"
+    acceptance = {
+        "message_type": "acceptance",
+        "message_id": msg_id,
+        "session_id": sess.session_id,
+        "in_reply_to": offer["message_id"],
+        "round_number": offer["round_number"],
+        "sequence_number": sess.sequence_number + 1,
+        "accepted_offer_id": offer["message_id"],
+        "accepted_protocol_act_hash": offer["protocol_act_hash"],
+        "sender_did": sender_did,
+        "sender_agent_id": "acme-agent",
+        "sender_verification_method": verification_method,
+        "timestamp": "2026-03-24T10:05:00Z",
+    }
+    payload = {
+        "session_id": acceptance["session_id"],
+        "round_number": acceptance["round_number"],
+        "sequence_number": acceptance["sequence_number"],
+        "accepted_offer_id": acceptance["accepted_offer_id"],
+        "accepted_protocol_act_hash": acceptance["accepted_protocol_act_hash"],
+    }
+    acceptance["acceptance_signature"] = sign_jws(
+        hash_object(payload),
+        RESPONDER_PRIVATE_KEY,
+        kid=verification_method,
+    )
+    return acceptance
+
+
 def _new_session(session_id="sess-001") -> tuple[SessionManager, Session]:
     mgr = SessionManager()
+    mgr.register_did_document(
+        INITIATOR_DID,
+        make_did_document(INITIATOR_DID, "key-1", public_key_to_jwk(INITIATOR_PUBLIC_KEY)),
+    )
+    mgr.register_did_document(
+        RESPONDER_DID,
+        make_did_document(RESPONDER_DID, "key-2026-01", public_key_to_jwk(RESPONDER_PUBLIC_KEY)),
+    )
     sess = mgr.create_session(session_id, SESSION_INIT, SESSION_ACK, "2026-03-24T10:00:00Z")
     # Tests use a historical created_at; give them a large timeout so they never expire
     sess.session_timeout_seconds = 86400 * 365 * 100
@@ -222,21 +293,7 @@ def test_acceptance_transitions_to_completed():
     o1 = _make_offer(sess.session_id, 1, 1, INITIATOR_DID)
     mgr.process_message(sess, o1)
 
-    acceptance = {
-        "message_type": "acceptance",
-        "message_id": "acc-1",
-        "session_id": sess.session_id,
-        "in_reply_to": o1["message_id"],
-        "round_number": 1,
-        "sequence_number": 2,
-        "accepted_offer_id": o1["message_id"],
-        "accepted_protocol_act_hash": o1["protocol_act_hash"],
-        "sender_did": RESPONDER_DID,
-        "sender_agent_id": "acme-agent",
-        "sender_verification_method": f"{RESPONDER_DID}#key-2026-01",
-        "timestamp": "2026-03-24T10:05:00Z",
-        "acceptance_signature": "eyJ...",
-    }
+    acceptance = _make_acceptance(sess, o1)
     mgr.process_message(sess, acceptance)
     assert sess.state == SessionState.COMPLETED
     assert sess.current_turn == "none"
@@ -350,6 +407,43 @@ def test_protocol_act_hash_mismatch_rejected():
     assert exc_info.value.http_status == 400
 
 
+def test_protocol_act_signature_mismatch_rejected():
+    mgr, sess = _new_session()
+    o = _make_offer(sess.session_id, 1, 1, INITIATOR_DID)
+    o["protocol_act_signature"] = sign_jws(
+        o["protocol_act_hash"],
+        RESPONDER_PRIVATE_KEY,
+        kid=f"{RESPONDER_DID}#key-2026-01",
+    )
+    with pytest.raises(A2CNError) as exc_info:
+        mgr.process_message(sess, o)
+    assert exc_info.value.code == "INVALID_SIGNATURE"
+    assert exc_info.value.http_status == 400
+
+
+def test_acceptance_signature_mismatch_rejected():
+    mgr, sess = _new_session()
+    o1 = _make_offer(sess.session_id, 1, 1, INITIATOR_DID)
+    mgr.process_message(sess, o1)
+
+    acceptance = _make_acceptance(sess, o1)
+    acceptance["acceptance_signature"] = sign_jws(
+        hash_object({
+            "session_id": acceptance["session_id"],
+            "round_number": acceptance["round_number"],
+            "sequence_number": acceptance["sequence_number"],
+            "accepted_offer_id": acceptance["accepted_offer_id"],
+            "accepted_protocol_act_hash": acceptance["accepted_protocol_act_hash"],
+        }),
+        INITIATOR_PRIVATE_KEY,
+        kid=f"{INITIATOR_DID}#key-1",
+    )
+    with pytest.raises(A2CNError) as exc_info:
+        mgr.process_message(sess, acceptance)
+    assert exc_info.value.code == "INVALID_SIGNATURE"
+    assert exc_info.value.http_status == 400
+
+
 def test_acceptance_in_active_state_raises():
     """Finding 2.8: acceptance in ACTIVE state (before any offer) raises SESSION_WRONG_STATE."""
     mgr, sess = _new_session()
@@ -379,40 +473,14 @@ def test_offer_expiry_check():
     o1 = _make_offer(sess.session_id, 1, 1, INITIATOR_DID)
     # Backdate expiry to force expiration
     o1["expires_at"] = "2020-01-01T00:00:00Z"
-    # Recompute hash with the new expires_at (otherwise hash mismatch fires first)
-    from a2cn.crypto import hash_object as _ho
-    protocol_act = {
-        "protocol_version": "0.2",
-        "session_id": o1["session_id"],
-        "round_number": o1["round_number"],
-        "sequence_number": o1["sequence_number"],
-        "message_type": o1["message_type"],
-        "sender_did": o1["sender_did"],
-        "timestamp": o1["timestamp"],
-        "expires_at": o1["expires_at"],
-        "terms": o1["terms"],
-    }
-    o1["protocol_act_hash"] = _ho(protocol_act)
+    # Recompute hash/signature with the new expires_at (otherwise signature mismatch fires first)
+    _resign_offer(o1)
     mgr.process_message(sess, o1)
 
     # Update session hash tracker
     sess.latest_offer_hash = o1["protocol_act_hash"]
 
-    acceptance = {
-        "message_type": "acceptance",
-        "message_id": str(uuid.uuid4()),
-        "session_id": sess.session_id,
-        "in_reply_to": o1["message_id"],
-        "round_number": 1,
-        "sequence_number": 2,
-        "accepted_offer_id": o1["message_id"],
-        "accepted_protocol_act_hash": o1["protocol_act_hash"],
-        "sender_did": RESPONDER_DID,
-        "sender_agent_id": "acme-agent",
-        "sender_verification_method": f"{RESPONDER_DID}#key-2026-01",
-        "timestamp": "2026-03-24T10:05:00Z",
-        "acceptance_signature": "eyJ...",
-    }
+    acceptance = _make_acceptance(sess, o1, msg_id=str(uuid.uuid4()))
     with pytest.raises(A2CNError) as exc_info:
         mgr.process_message(sess, acceptance)
     assert exc_info.value.code == "OFFER_EXPIRED"
@@ -592,21 +660,7 @@ def test_threshold_crossing_acceptance_enters_awaiting_human_approval_then_compl
     offer = _make_offer(sess.session_id, 1, 1, INITIATOR_DID)
     mgr.process_message(sess, offer)
 
-    acceptance = {
-        "message_type": "acceptance",
-        "message_id": "acc-requires-approval",
-        "session_id": sess.session_id,
-        "in_reply_to": offer["message_id"],
-        "round_number": 1,
-        "sequence_number": 2,
-        "accepted_offer_id": offer["message_id"],
-        "accepted_protocol_act_hash": offer["protocol_act_hash"],
-        "sender_did": RESPONDER_DID,
-        "sender_agent_id": "acme-agent",
-        "sender_verification_method": f"{RESPONDER_DID}#key-2026-01",
-        "timestamp": "2026-03-24T10:05:00Z",
-        "acceptance_signature": "eyJ...",
-    }
+    acceptance = _make_acceptance(sess, offer, msg_id="acc-requires-approval")
 
     result = mgr.process_message(sess, acceptance)
     assert result["state"] == SessionState.AWAITING_HUMAN_APPROVAL


### PR DESCRIPTION
## Summary

Fixes A2C-62 by enforcing DID-backed JWS verification for incoming negotiation messages before session state is mutated.

## What changed

- Added a DID-document registry to `SessionManager` and use it to resolve `sender_verification_method` keys.
- Verify `protocol_act_signature` on every incoming `offer` and `counteroffer` against the reconstructed protocol act hash.
- Verify `acceptance_signature` over the canonical Section 7.4 acceptance payload: `{session_id, round_number, sequence_number, accepted_offer_id, accepted_protocol_act_hash}`.
- Reject missing hashes/signatures, wrong-key signatures, payload mismatches, and malformed JWS tokens with `INVALID_SIGNATURE`.
- Feed the same DID documents used by JWT auth into the session manager through `register_did_document`, HTTP DID resolution, and responder self-registration.
- Updated tests and fixtures to use real signatures instead of placeholder `eyJ...` values, with forged-signature regression coverage.

## Review note

Claude Code review verdict: GO. It confirmed the signature verification order, VM ownership check, DID registration coverage, acceptance payload binding, and missing-hash rejection behavior.

## Validation

- `uv run pytest tests/test_session.py tests/test_server.py -q` -> 48 passed
- Previously also ran: `uv run pytest tests/conformance/test_conformance.py tests/test_post_commitment.py tests/test_llm_agent.py -q` -> 94 passed
- Previously also ran: `uv run pytest -q --ignore=tests/test_mcp_server.py` -> 342 passed

Full `uv run pytest -q` still stops during collection in `tests/test_mcp_server.py` due to the existing MCP dependency issue tracked as A2C-73.