### PR TITLE
Enforce mandate commitment caps

### DIFF
--- a/reference-implementation/python/a2cn/session.py
+++ b/reference-implementation/python/a2cn/session.py
@@ -492,6 +492,7 @@ class SessionManager:
             payload_hash=expected_hash,
             signature_field="protocol_act_signature",
         )
+        self._enforce_max_commitment(session, sender_role, terms, message)
 
         # Message type check: round 1 must be "offer", round 2+ must be "counteroffer"
         if round_number == 1:
@@ -733,6 +734,61 @@ class SessionManager:
         except (TypeError, ValueError):
             return False
 
+    def _enforce_max_commitment(
+        self,
+        session: Session,
+        role: str,
+        terms: dict,
+        message: dict,
+    ) -> None:
+        """Enforce a declared mandate's hard commitment cap before state mutation."""
+        mandate = self._mandate_for_role(session, role)
+        max_value = mandate.get("max_commitment_value")
+        if max_value is None:
+            return
+
+        total_value = terms.get("total_value") if isinstance(terms, dict) else None
+        if total_value is None:
+            return
+
+        expected_currency = mandate.get("max_commitment_currency")
+        actual_currency = terms.get("currency") if isinstance(terms, dict) else None
+        if expected_currency and actual_currency != expected_currency:
+            raise A2CNError(
+                "MANDATE_INVALID",
+                (
+                    f"Commitment currency {actual_currency!r} does not match {role} "
+                    f"mandate currency {expected_currency!r}"
+                ),
+                403,
+                session_id=session.session_id,
+                message_id=message.get("message_id"),
+            )
+
+        try:
+            total = int(total_value)
+            cap = int(max_value)
+        except (TypeError, ValueError):
+            raise A2CNError(
+                "MANDATE_INVALID",
+                "Commitment total_value or mandate max_commitment_value is not an integer",
+                403,
+                session_id=session.session_id,
+                message_id=message.get("message_id"),
+            )
+
+        if total > cap:
+            raise A2CNError(
+                "MANDATE_INVALID",
+                (
+                    f"Commitment total_value {total} exceeds {role} mandate "
+                    f"max_commitment_value {cap}"
+                ),
+                403,
+                session_id=session.session_id,
+                message_id=message.get("message_id"),
+            )
+
     def _handle_acceptance(self, session: Session, message: dict) -> dict:
         message_id = message.get("message_id", "")
         sender_did = message.get("sender_did", "")
@@ -815,8 +871,12 @@ class SessionManager:
 
         now = _now()
         final_offer_total_value = None
+        final_offer_terms = {}
         if final_offer:
-            final_offer_total_value = (final_offer.get("terms") or {}).get("total_value")
+            final_offer_terms = final_offer.get("terms") or {}
+            final_offer_total_value = final_offer_terms.get("total_value")
+
+        self._enforce_max_commitment(session, sender_role, final_offer_terms, message)
 
         if self._requires_human_approval(session, sender_role, final_offer_total_value):
             session.sequence_number = sequence_number

--- a/reference-implementation/python/tests/test_session.py
+++ b/reference-implementation/python/tests/test_session.py
@@ -62,10 +62,18 @@ INITIATOR_PRIVATE_KEY, INITIATOR_PUBLIC_KEY = generate_keypair()
 RESPONDER_PRIVATE_KEY, RESPONDER_PUBLIC_KEY = generate_keypair()
 
 
-def _make_offer(session_id, seq, rnd, sender_did, msg_type="offer", in_reply_to=None):
+def _make_offer(
+    session_id,
+    seq,
+    rnd,
+    sender_did,
+    msg_type="offer",
+    in_reply_to=None,
+    terms=None,
+):
     timestamp = "2026-03-24T10:01:00Z"
     expires_at = "2030-01-01T00:00:00Z"
-    terms = {"total_value": 9_500_000, "currency": "USD"}
+    terms = terms or {"total_value": 9_500_000, "currency": "USD"}
     protocol_act = {
         "protocol_version": "0.2",
         "session_id": session_id,
@@ -442,6 +450,118 @@ def test_acceptance_signature_mismatch_rejected():
         mgr.process_message(sess, acceptance)
     assert exc_info.value.code == "INVALID_SIGNATURE"
     assert exc_info.value.http_status == 400
+
+
+def test_offer_at_max_commitment_value_accepted():
+    mgr, sess = _new_session()
+    sess.initiator_mandate = {
+        "mandate_type": "declared",
+        "principal_did": INITIATOR_DID,
+        "max_commitment_value": 9_500_000,
+        "max_commitment_currency": "USD",
+    }
+
+    offer = _make_offer(sess.session_id, 1, 1, INITIATOR_DID)
+    result = mgr.process_message(sess, offer)
+
+    assert result["state"] == SessionState.NEGOTIATING
+    assert sess.latest_offer_hash == offer["protocol_act_hash"]
+
+
+def test_offer_over_max_commitment_value_rejected():
+    mgr, sess = _new_session()
+    sess.initiator_mandate = {
+        "mandate_type": "declared",
+        "principal_did": INITIATOR_DID,
+        "max_commitment_value": 9_499_999,
+        "max_commitment_currency": "USD",
+    }
+
+    offer = _make_offer(sess.session_id, 1, 1, INITIATOR_DID)
+    with pytest.raises(A2CNError) as exc_info:
+        mgr.process_message(sess, offer)
+
+    assert exc_info.value.code == "MANDATE_INVALID"
+    assert exc_info.value.http_status == 403
+    assert sess.sequence_number == 0
+    assert sess.state == SessionState.ACTIVE
+
+
+def test_offer_currency_mismatch_rejected():
+    mgr, sess = _new_session()
+    sess.initiator_mandate = {
+        "mandate_type": "declared",
+        "principal_did": INITIATOR_DID,
+        "max_commitment_value": 20_000_000,
+        "max_commitment_currency": "EUR",
+    }
+
+    offer = _make_offer(sess.session_id, 1, 1, INITIATOR_DID)
+    with pytest.raises(A2CNError) as exc_info:
+        mgr.process_message(sess, offer)
+
+    assert exc_info.value.code == "MANDATE_INVALID"
+    assert exc_info.value.http_status == 403
+    assert sess.sequence_number == 0
+
+
+def test_acceptance_at_max_commitment_value_completes():
+    mgr, sess = _new_session()
+    sess.responder_mandate = {
+        "mandate_type": "declared",
+        "principal_did": RESPONDER_DID,
+        "max_commitment_value": 9_500_000,
+        "max_commitment_currency": "USD",
+    }
+    offer = _make_offer(sess.session_id, 1, 1, INITIATOR_DID)
+    mgr.process_message(sess, offer)
+
+    acceptance = _make_acceptance(sess, offer)
+    mgr.process_message(sess, acceptance)
+
+    assert sess.state == SessionState.COMPLETED
+
+
+def test_acceptance_over_max_commitment_value_rejected():
+    mgr, sess = _new_session()
+    sess.responder_mandate = {
+        "mandate_type": "declared",
+        "principal_did": RESPONDER_DID,
+        "max_commitment_value": 9_499_999,
+        "max_commitment_currency": "USD",
+    }
+    offer = _make_offer(sess.session_id, 1, 1, INITIATOR_DID)
+    mgr.process_message(sess, offer)
+
+    acceptance = _make_acceptance(sess, offer)
+    with pytest.raises(A2CNError) as exc_info:
+        mgr.process_message(sess, acceptance)
+
+    assert exc_info.value.code == "MANDATE_INVALID"
+    assert exc_info.value.http_status == 403
+    assert sess.state == SessionState.NEGOTIATING
+    assert sess.sequence_number == 1
+    assert sess._final_acceptance is None
+
+
+def test_acceptance_currency_mismatch_rejected():
+    mgr, sess = _new_session()
+    sess.responder_mandate = {
+        "mandate_type": "declared",
+        "principal_did": RESPONDER_DID,
+        "max_commitment_value": 20_000_000,
+        "max_commitment_currency": "EUR",
+    }
+    offer = _make_offer(sess.session_id, 1, 1, INITIATOR_DID)
+    mgr.process_message(sess, offer)
+
+    acceptance = _make_acceptance(sess, offer)
+    with pytest.raises(A2CNError) as exc_info:
+        mgr.process_message(sess, acceptance)
+
+    assert exc_info.value.code == "MANDATE_INVALID"
+    assert exc_info.value.http_status == 403
+    assert sess.state == SessionState.NEGOTIATING
 
 
 def test_acceptance_in_active_state_raises():


### PR DESCRIPTION
## Summary

Fixes A2C-64 by enforcing declared mandate `max_commitment_value` / `max_commitment_currency` during negotiation before state is mutated or an acceptance can complete.

## What changed

- Added hard-cap enforcement to `SessionManager` for the sender's mandate on incoming offers/counteroffers.
- Added hard-cap enforcement for the accepting party's mandate against the accepted offer terms before human-approval pause or completion.
- Reject over-limit commitments and currency mismatches with `MANDATE_INVALID` / 403.
- Preserved the existing soft `requires_human_approval_above` path; hard caps now run before that pause path.
- Added regression coverage for at-limit, over-limit, and currency-mismatch cases across offer and acceptance flows.

## Validation

- `uv run pytest tests/test_session.py -q` -> 35 passed
- `uv run pytest tests/test_session.py tests/test_server.py tests/conformance/test_conformance.py tests/test_post_commitment.py tests/test_llm_agent.py -q` -> 148 passed
- `uv run pytest -q --ignore=tests/test_mcp_server.py` -> 348 passed

Full `uv run pytest -q` is still blocked by the existing `tests/test_mcp_server.py` collection issue tracked separately as A2C-73.