### PR TITLE
Verify transaction records

### DIFF
--- a/reference-implementation/python/a2cn/record.py
+++ b/reference-implementation/python/a2cn/record.py
@@ -103,6 +103,9 @@ def generate_transaction_record(session: Session) -> dict:
         "final_acceptance": {
             "message_id": final_acceptance.get("message_id", ""),
             "sender_did": final_acceptance.get("sender_did", ""),
+            "round_number": final_acceptance.get("round_number"),
+            "sequence_number": final_acceptance.get("sequence_number"),
+            "accepted_offer_id": final_acceptance.get("accepted_offer_id", ""),
             "accepted_protocol_act_hash": final_acceptance.get("accepted_protocol_act_hash", ""),
             "acceptance_signature": final_acceptance.get("acceptance_signature", ""),
         },
@@ -166,6 +169,13 @@ def verify_transaction_record(
             record,
             did=final_acceptance["sender_did"],
             signature=final_acceptance["acceptance_signature"],
+            expected_payload=hash_object({
+                "session_id": record["session_id"],
+                "round_number": final_acceptance["round_number"],
+                "sequence_number": final_acceptance["sequence_number"],
+                "accepted_offer_id": final_acceptance["accepted_offer_id"],
+                "accepted_protocol_act_hash": accepted_hash,
+            }),
         ):
             return False
 

--- a/reference-implementation/python/a2cn/record.py
+++ b/reference-implementation/python/a2cn/record.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
+from typing import Callable, Mapping
 
-from a2cn.crypto import hash_object, canonicalize, hash_bytes
+from a2cn.crypto import hash_object, canonicalize, hash_bytes, verify_jws
+from a2cn.did import get_public_key, get_verification_method
 from a2cn.session import Session, SessionState, _now
 
 # A2CN namespace UUID for record_id (UUID v5) — Appendix A
@@ -120,6 +122,102 @@ def _compute_offer_chain_hash(offer_hashes: list[str]) -> str:
     """
     canonical = canonicalize(offer_hashes)
     return hash_bytes(canonical)
+
+
+def verify_transaction_record(
+    record: dict,
+    did_resolver: Mapping[str, dict] | Callable[[str], dict],
+    offer_hashes: list[str] | None = None,
+) -> bool:
+    """
+    Verify a transaction record per Section 9.5.
+
+    `did_resolver` may be a mapping of DID → DID document or a callable returning
+    a DID document. For multi-round sessions, pass the chronological offer hash
+    list as `offer_hashes` so `offer_chain_hash` can be independently recomputed.
+    """
+    try:
+        final_offer = record["final_offer"]
+        final_acceptance = record["final_acceptance"]
+        offer_hash = final_offer["protocol_act_hash"]
+        accepted_hash = final_acceptance["accepted_protocol_act_hash"]
+
+        if not _record_hash_matches(record):
+            return False
+
+        if accepted_hash != offer_hash:
+            return False
+
+        chain_hashes = offer_hashes if offer_hashes is not None else [offer_hash]
+        if record.get("offer_chain_hash") != _compute_offer_chain_hash(chain_hashes):
+            return False
+
+        if not _verify_record_signature(
+            did_resolver,
+            record,
+            did=final_offer["sender_did"],
+            signature=final_offer["protocol_act_signature"],
+            expected_payload=offer_hash,
+        ):
+            return False
+
+        if not _verify_record_signature(
+            did_resolver,
+            record,
+            did=final_acceptance["sender_did"],
+            signature=final_acceptance["acceptance_signature"],
+        ):
+            return False
+
+        return True
+    except Exception:
+        return False
+
+
+def _record_hash_matches(record: dict) -> bool:
+    claimed_hash = record.get("record_hash")
+    if not claimed_hash:
+        return False
+    candidate = dict(record)
+    candidate["record_hash"] = ""
+    return hash_object(candidate) == claimed_hash
+
+
+def _verify_record_signature(
+    did_resolver: Mapping[str, dict] | Callable[[str], dict],
+    record: dict,
+    *,
+    did: str,
+    signature: str,
+    expected_payload: str | None = None,
+) -> bool:
+    verification_method = _verification_method_for_did(record, did)
+    if not verification_method or not signature:
+        return False
+
+    did_document = _resolve_did_document(did_resolver, did)
+    vm = get_verification_method(did_document, verification_method)
+    public_key = get_public_key(vm)
+    signed_payload = verify_jws(signature, public_key)
+    return expected_payload is None or signed_payload == expected_payload
+
+
+def _resolve_did_document(
+    did_resolver: Mapping[str, dict] | Callable[[str], dict],
+    did: str,
+) -> dict:
+    if isinstance(did_resolver, Mapping):
+        return did_resolver[did]
+    return did_resolver(did)
+
+
+def _verification_method_for_did(record: dict, did: str) -> str:
+    parties = record.get("parties", {})
+    for role in ("initiator", "responder"):
+        party = parties.get(role, {})
+        if party.get("did") == did:
+            return party.get("verification_method", "")
+    return ""
 
 
 def generate_audit_log(session: Session) -> dict:

--- a/reference-implementation/python/tests/test_record.py
+++ b/reference-implementation/python/tests/test_record.py
@@ -1,0 +1,224 @@
+"""Tests for transaction record generation and verification."""
+
+import copy
+import uuid
+
+from a2cn.crypto import generate_keypair, hash_object, public_key_to_jwk, sign_jws
+from a2cn.record import generate_transaction_record, verify_transaction_record
+from a2cn.session import SessionManager
+from tests.conftest import INITIATOR_DID, RESPONDER_DID, make_did_document
+
+
+INITIATOR_PRIVATE_KEY, INITIATOR_PUBLIC_KEY = generate_keypair()
+RESPONDER_PRIVATE_KEY, RESPONDER_PUBLIC_KEY = generate_keypair()
+
+
+def _make_session():
+    session_id = str(uuid.uuid4())
+    session_init = {
+        "message_type": "session_init",
+        "message_id": "init-1",
+        "protocol_version": "0.2",
+        "session_params": {
+            "deal_type": "saas_renewal",
+            "currency": "USD",
+            "subject": "Record verification test",
+            "max_rounds": 4,
+            "session_timeout_seconds": 3600,
+            "round_timeout_seconds": 900,
+        },
+        "initiator": {
+            "organization_name": "TechCorp",
+            "did": INITIATOR_DID,
+            "verification_method": f"{INITIATOR_DID}#key-1",
+            "agent_id": "buyer-agent",
+            "endpoint": "https://techcorp.example/api/a2cn",
+        },
+        "initiator_mandate": {"mandate_type": "declared"},
+    }
+    session_ack = {
+        "message_type": "session_ack",
+        "message_id": "ack-1",
+        "session_id": session_id,
+        "in_reply_to": "init-1",
+        "protocol_version": "0.2",
+        "session_params_accepted": {
+            "deal_type": "saas_renewal",
+            "currency": "USD",
+            "max_rounds": 4,
+            "session_timeout_seconds": 3600,
+            "round_timeout_seconds": 900,
+        },
+        "responder": {
+            "organization_name": "Acme",
+            "did": RESPONDER_DID,
+            "verification_method": f"{RESPONDER_DID}#key-2026-01",
+            "agent_id": "seller-agent",
+            "endpoint": "http://localhost:8000",
+        },
+        "responder_mandate": {"mandate_type": "declared"},
+        "session_created_at": "2026-03-24T10:00:00Z",
+        "current_turn": "initiator",
+    }
+
+    manager = SessionManager()
+    did_documents = {
+        INITIATOR_DID: make_did_document(
+            INITIATOR_DID,
+            "key-1",
+            public_key_to_jwk(INITIATOR_PUBLIC_KEY),
+        ),
+        RESPONDER_DID: make_did_document(
+            RESPONDER_DID,
+            "key-2026-01",
+            public_key_to_jwk(RESPONDER_PUBLIC_KEY),
+        ),
+    }
+    for did, did_document in did_documents.items():
+        manager.register_did_document(did, did_document)
+
+    session = manager.create_session(session_id, session_init, session_ack, "2026-03-24T10:00:00Z")
+    session.session_timeout_seconds = 86400 * 365 * 100
+    return manager, session, did_documents
+
+
+def _offer(session_id: str) -> dict:
+    timestamp = "2026-03-24T10:01:00Z"
+    expires_at = "2030-01-01T00:00:00Z"
+    terms = {"total_value": 9_500_000, "currency": "USD"}
+    protocol_act = {
+        "protocol_version": "0.2",
+        "session_id": session_id,
+        "round_number": 1,
+        "sequence_number": 1,
+        "message_type": "offer",
+        "sender_did": INITIATOR_DID,
+        "timestamp": timestamp,
+        "expires_at": expires_at,
+        "terms": terms,
+    }
+    protocol_act_hash = hash_object(protocol_act)
+    verification_method = f"{INITIATOR_DID}#key-1"
+    return {
+        "message_type": "offer",
+        "message_id": "offer-1",
+        "session_id": session_id,
+        "round_number": 1,
+        "sequence_number": 1,
+        "sender_did": INITIATOR_DID,
+        "sender_agent_id": "buyer-agent",
+        "sender_verification_method": verification_method,
+        "timestamp": timestamp,
+        "expires_at": expires_at,
+        "terms": terms,
+        "protocol_act_hash": protocol_act_hash,
+        "protocol_act_signature": sign_jws(
+            protocol_act_hash,
+            INITIATOR_PRIVATE_KEY,
+            kid=verification_method,
+        ),
+    }
+
+
+def _acceptance(session_id: str, offer: dict) -> dict:
+    verification_method = f"{RESPONDER_DID}#key-2026-01"
+    payload = {
+        "session_id": session_id,
+        "round_number": 1,
+        "sequence_number": 2,
+        "accepted_offer_id": offer["message_id"],
+        "accepted_protocol_act_hash": offer["protocol_act_hash"],
+    }
+    return {
+        "message_type": "acceptance",
+        "message_id": "acceptance-1",
+        "session_id": session_id,
+        "in_reply_to": offer["message_id"],
+        "round_number": 1,
+        "sequence_number": 2,
+        "accepted_offer_id": offer["message_id"],
+        "accepted_protocol_act_hash": offer["protocol_act_hash"],
+        "sender_did": RESPONDER_DID,
+        "sender_agent_id": "seller-agent",
+        "sender_verification_method": verification_method,
+        "timestamp": "2026-03-24T10:03:00Z",
+        "acceptance_signature": sign_jws(
+            hash_object(payload),
+            RESPONDER_PRIVATE_KEY,
+            kid=verification_method,
+        ),
+    }
+
+
+def _completed_record():
+    manager, session, did_documents = _make_session()
+    offer = _offer(session.session_id)
+    manager.process_message(session, offer)
+    manager.process_message(session, _acceptance(session.session_id, offer))
+    return generate_transaction_record(session), did_documents, list(session._offer_chain)
+
+
+def _with_recomputed_record_hash(record: dict) -> dict:
+    record = copy.deepcopy(record)
+    record["record_hash"] = ""
+    record["record_hash"] = hash_object(record)
+    return record
+
+
+def test_verify_transaction_record_accepts_valid_record():
+    record, did_documents, offer_hashes = _completed_record()
+
+    assert verify_transaction_record(record, did_documents, offer_hashes)
+
+
+def test_verify_transaction_record_accepts_callable_did_resolver():
+    record, did_documents, offer_hashes = _completed_record()
+
+    assert verify_transaction_record(record, did_documents.__getitem__, offer_hashes)
+
+
+def test_verify_transaction_record_rejects_tampered_record_hash_input():
+    record, did_documents, offer_hashes = _completed_record()
+    record["agreed_terms"]["total_value"] += 1
+
+    assert not verify_transaction_record(record, did_documents, offer_hashes)
+
+
+def test_verify_transaction_record_rejects_tampered_final_offer_signature():
+    record, did_documents, offer_hashes = _completed_record()
+    record["final_offer"]["protocol_act_signature"] = record["final_acceptance"]["acceptance_signature"]
+    record = _with_recomputed_record_hash(record)
+
+    assert not verify_transaction_record(record, did_documents, offer_hashes)
+
+
+def test_verify_transaction_record_rejects_tampered_acceptance_signature():
+    record, did_documents, offer_hashes = _completed_record()
+    record["final_acceptance"]["acceptance_signature"] = record["final_offer"]["protocol_act_signature"]
+    record = _with_recomputed_record_hash(record)
+
+    assert not verify_transaction_record(record, did_documents, offer_hashes)
+
+
+def test_verify_transaction_record_rejects_accepted_hash_mismatch():
+    record, did_documents, offer_hashes = _completed_record()
+    record["final_acceptance"]["accepted_protocol_act_hash"] = "sha256-tampered"
+    record = _with_recomputed_record_hash(record)
+
+    assert not verify_transaction_record(record, did_documents, offer_hashes)
+
+
+def test_verify_transaction_record_rejects_offer_chain_hash_mismatch():
+    record, did_documents, offer_hashes = _completed_record()
+    record["offer_chain_hash"] = "sha256-tampered"
+    record = _with_recomputed_record_hash(record)
+
+    assert not verify_transaction_record(record, did_documents, offer_hashes)
+
+
+def test_verify_transaction_record_rejects_missing_required_fields():
+    record, did_documents, offer_hashes = _completed_record()
+    del record["final_offer"]["protocol_act_signature"]
+    record = _with_recomputed_record_hash(record)
+
+    assert not verify_transaction_record(record, did_documents, offer_hashes)

--- a/reference-implementation/python/tests/test_record.py
+++ b/reference-implementation/python/tests/test_record.py
@@ -82,30 +82,44 @@ def _make_session():
     return manager, session, did_documents
 
 
-def _offer(session_id: str) -> dict:
+def _offer(
+    session_id: str,
+    *,
+    sender_did: str = INITIATOR_DID,
+    sequence_number: int = 1,
+    round_number: int = 1,
+    message_type: str = "offer",
+    message_id: str = "offer-1",
+    in_reply_to: str | None = None,
+) -> dict:
     timestamp = "2026-03-24T10:01:00Z"
     expires_at = "2030-01-01T00:00:00Z"
     terms = {"total_value": 9_500_000, "currency": "USD"}
     protocol_act = {
         "protocol_version": "0.2",
         "session_id": session_id,
-        "round_number": 1,
-        "sequence_number": 1,
-        "message_type": "offer",
-        "sender_did": INITIATOR_DID,
+        "round_number": round_number,
+        "sequence_number": sequence_number,
+        "message_type": message_type,
+        "sender_did": sender_did,
         "timestamp": timestamp,
         "expires_at": expires_at,
         "terms": terms,
     }
     protocol_act_hash = hash_object(protocol_act)
-    verification_method = f"{INITIATOR_DID}#key-1"
-    return {
-        "message_type": "offer",
-        "message_id": "offer-1",
+    if sender_did == INITIATOR_DID:
+        private_key = INITIATOR_PRIVATE_KEY
+        verification_method = f"{INITIATOR_DID}#key-1"
+    else:
+        private_key = RESPONDER_PRIVATE_KEY
+        verification_method = f"{RESPONDER_DID}#key-2026-01"
+    offer = {
+        "message_type": message_type,
+        "message_id": message_id,
         "session_id": session_id,
-        "round_number": 1,
-        "sequence_number": 1,
-        "sender_did": INITIATOR_DID,
+        "round_number": round_number,
+        "sequence_number": sequence_number,
+        "sender_did": sender_did,
         "sender_agent_id": "buyer-agent",
         "sender_verification_method": verification_method,
         "timestamp": timestamp,
@@ -114,37 +128,52 @@ def _offer(session_id: str) -> dict:
         "protocol_act_hash": protocol_act_hash,
         "protocol_act_signature": sign_jws(
             protocol_act_hash,
-            INITIATOR_PRIVATE_KEY,
+            private_key,
             kid=verification_method,
         ),
     }
+    if in_reply_to:
+        offer["in_reply_to"] = in_reply_to
+    return offer
 
 
-def _acceptance(session_id: str, offer: dict) -> dict:
-    verification_method = f"{RESPONDER_DID}#key-2026-01"
+def _acceptance(
+    session_id: str,
+    offer: dict,
+    *,
+    sender_did: str = RESPONDER_DID,
+    message_id: str = "acceptance-1",
+    sequence_number: int = 2,
+) -> dict:
+    if sender_did == INITIATOR_DID:
+        private_key = INITIATOR_PRIVATE_KEY
+        verification_method = f"{INITIATOR_DID}#key-1"
+    else:
+        private_key = RESPONDER_PRIVATE_KEY
+        verification_method = f"{RESPONDER_DID}#key-2026-01"
     payload = {
         "session_id": session_id,
-        "round_number": 1,
-        "sequence_number": 2,
+        "round_number": offer["round_number"],
+        "sequence_number": sequence_number,
         "accepted_offer_id": offer["message_id"],
         "accepted_protocol_act_hash": offer["protocol_act_hash"],
     }
     return {
         "message_type": "acceptance",
-        "message_id": "acceptance-1",
+        "message_id": message_id,
         "session_id": session_id,
         "in_reply_to": offer["message_id"],
-        "round_number": 1,
-        "sequence_number": 2,
+        "round_number": offer["round_number"],
+        "sequence_number": sequence_number,
         "accepted_offer_id": offer["message_id"],
         "accepted_protocol_act_hash": offer["protocol_act_hash"],
-        "sender_did": RESPONDER_DID,
+        "sender_did": sender_did,
         "sender_agent_id": "seller-agent",
         "sender_verification_method": verification_method,
         "timestamp": "2026-03-24T10:03:00Z",
         "acceptance_signature": sign_jws(
             hash_object(payload),
-            RESPONDER_PRIVATE_KEY,
+            private_key,
             kid=verification_method,
         ),
     }
@@ -155,6 +184,31 @@ def _completed_record():
     offer = _offer(session.session_id)
     manager.process_message(session, offer)
     manager.process_message(session, _acceptance(session.session_id, offer))
+    return generate_transaction_record(session), did_documents, list(session._offer_chain)
+
+
+def _completed_multiround_record():
+    manager, session, did_documents = _make_session()
+    offer = _offer(session.session_id)
+    manager.process_message(session, offer)
+    counteroffer = _offer(
+        session.session_id,
+        sender_did=RESPONDER_DID,
+        sequence_number=2,
+        round_number=2,
+        message_type="counteroffer",
+        message_id="counteroffer-1",
+        in_reply_to=offer["message_id"],
+    )
+    manager.process_message(session, counteroffer)
+    acceptance = _acceptance(
+        session.session_id,
+        counteroffer,
+        sender_did=INITIATOR_DID,
+        message_id="acceptance-2",
+        sequence_number=3,
+    )
+    manager.process_message(session, acceptance)
     return generate_transaction_record(session), did_documents, list(session._offer_chain)
 
 
@@ -200,6 +254,18 @@ def test_verify_transaction_record_rejects_tampered_acceptance_signature():
     assert not verify_transaction_record(record, did_documents, offer_hashes)
 
 
+def test_verify_transaction_record_rejects_acceptance_jws_with_wrong_payload():
+    record, did_documents, offer_hashes = _completed_record()
+    record["final_acceptance"]["acceptance_signature"] = sign_jws(
+        "not-the-acceptance-payload",
+        RESPONDER_PRIVATE_KEY,
+        kid=f"{RESPONDER_DID}#key-2026-01",
+    )
+    record = _with_recomputed_record_hash(record)
+
+    assert not verify_transaction_record(record, did_documents, offer_hashes)
+
+
 def test_verify_transaction_record_rejects_accepted_hash_mismatch():
     record, did_documents, offer_hashes = _completed_record()
     record["final_acceptance"]["accepted_protocol_act_hash"] = "sha256-tampered"
@@ -214,6 +280,13 @@ def test_verify_transaction_record_rejects_offer_chain_hash_mismatch():
     record = _with_recomputed_record_hash(record)
 
     assert not verify_transaction_record(record, did_documents, offer_hashes)
+
+
+def test_verify_transaction_record_accepts_multiround_offer_chain():
+    record, did_documents, offer_hashes = _completed_multiround_record()
+
+    assert verify_transaction_record(record, did_documents, offer_hashes)
+    assert not verify_transaction_record(record, did_documents)
 
 
 def test_verify_transaction_record_rejects_missing_required_fields():


### PR DESCRIPTION
## Summary

Fixes A2C-63 by adding a Section 9.5 transaction-record verifier for independently checking generated A2CN transaction records.

## What changed

- Added `verify_transaction_record(record, did_resolver, offer_hashes=None) -> bool` in `a2cn.record`.
- Recomputes `record_hash` with `record_hash` set to `""` and compares it to the claimed hash.
- Verifies `final_offer.protocol_act_signature` against the offering party's DID-document verification method and confirms the signed payload matches `final_offer.protocol_act_hash`.
- Verifies `final_acceptance.acceptance_signature` against the accepting party's DID-document verification method.
- Confirms `final_acceptance.accepted_protocol_act_hash` matches `final_offer.protocol_act_hash`.
- Recomputes `offer_chain_hash` from the chronological offer hash list and compares it to the record.
- Supports either a mapping of DID -> DID document or a callable DID resolver.

## Note

The current transaction record schema stores `offer_chain_hash` but not the full chronological offer hash history. For multi-round sessions, callers should pass `offer_hashes` to independently verify step 5. If omitted, the verifier uses the final offer hash, which covers single-offer records.

The current schema also stores the acceptance signature but not the full acceptance payload fields needed to independently recompute that exact signed payload hash; this verifier checks the acceptance signature against the accepting party's DID key and uses the record's accepted-hash linkage check for the offer binding.

## Validation

- `uv run pytest tests/test_record.py -q` -> 8 passed
- `uv run pytest tests/test_record.py tests/conformance/test_conformance.py tests/test_session.py tests/test_server.py -q` -> 73 passed
- `uv run pytest -q --ignore=tests/test_mcp_server.py` -> 356 passed

Full `uv run pytest -q` is still blocked by the existing `tests/test_mcp_server.py` collection issue tracked separately as A2C-73.