### PR TITLE
Bind SessionInit JWT issuer

### DIFF
--- a/reference-implementation/python/a2cn/server.py
+++ b/reference-implementation/python/a2cn/server.py
@@ -355,6 +355,12 @@ async def create_session(request: Request, _jwt: dict = Depends(verify_jwt_auth)
     # Validate required fields
     _require(body, ["message_type", "message_id", "protocol_version", "session_params", "initiator", "initiator_mandate"])
 
+    initiator_did = (body.get("initiator") or {}).get("did", "")
+    if initiator_did and initiator_did != _jwt.get("iss", ""):
+        return error_response("SENDER_DID_MISMATCH",
+                               "JWT issuer does not match initiator.did in request body",
+                               401, detail="Section 14.1", message_id=message_id)
+
     if body.get("message_type") != "session_init":
         return error_response("WRONG_MESSAGE_TYPE", "Expected message_type 'session_init'", 400, message_id=message_id)
 

--- a/reference-implementation/python/tests/test_server.py
+++ b/reference-implementation/python/tests/test_server.py
@@ -91,6 +91,22 @@ async def test_session_init_accepts_ed25519_jwt(raw_test_client):
 
 
 @pytest.mark.asyncio
+async def test_session_init_rejects_initiator_did_mismatch(test_client):
+    body = make_session_init()
+    body["initiator"]["did"] = "did:web:impostor.example"
+
+    r = await test_client.post(
+        "/sessions",
+        json=body,
+        headers=init_headers(body["message_id"]),
+    )
+
+    assert r.status_code == 401
+    assert r.json()["error"]["code"] == "SENDER_DID_MISMATCH"
+    assert "initiator.did" in r.json()["error"]["message"]
+
+
+@pytest.mark.asyncio
 async def test_session_init_content_type(test_client):
     body = make_session_init()
     r = await test_client.post("/sessions", json=body, headers=init_headers(body["message_id"]))


### PR DESCRIPTION
## Summary

Fixes A2C-69 by binding `POST /sessions` authentication to the declared SessionInit initiator DID.

## What changed

- `create_session` now rejects SessionInit bodies whose `initiator.did` does not match the verified JWT `iss` claim.
- Uses the existing `SENDER_DID_MISMATCH` / 401 pattern from session message sending.
- Added a regression test proving a caller authenticated as one DID cannot create a session declaring another initiator DID.

## Validation

- `uv run pytest tests/test_server.py -q` -> 20 passed
- `uv run pytest -q --ignore=tests/test_mcp_server.py` -> 359 passed

Full `uv run pytest -q` remains blocked by the existing `tests/test_mcp_server.py` collection issue tracked separately as A2C-73.