### PR TITLE
Derive audit HITL metadata

### DIFF
--- a/reference-implementation/python/a2cn/record.py
+++ b/reference-implementation/python/a2cn/record.py
@@ -286,6 +286,8 @@ def generate_audit_log(session: Session) -> dict:
         }
         negotiation_log.append(entry)
 
+    human_oversight_present = bool(session.approval_receipts)
+
     return {
         "log_type": "a2cn_audit_log",
         "log_version": "0.1",
@@ -319,7 +321,7 @@ def generate_audit_log(session: Session) -> dict:
         "protocol_violations": [],
         "audit_metadata": {
             "ai_system_involved": True,
-            "human_oversight_present": False,
-            "autonomous_decision": True,
+            "human_oversight_present": human_oversight_present,
+            "autonomous_decision": not human_oversight_present,
         },
     }

--- a/reference-implementation/python/tests/test_session.py
+++ b/reference-implementation/python/tests/test_session.py
@@ -5,6 +5,7 @@ import pytest
 
 from a2cn.session import Session, SessionManager, SessionState, A2CNError
 from a2cn.crypto import generate_keypair, hash_object, public_key_to_jwk, sign_jws
+from a2cn.record import generate_audit_log
 from tests.conftest import make_did_document
 
 
@@ -693,6 +694,45 @@ def test_approval_receipt_releases_pause_and_restores_counterparty_turn():
     assert result["approval_receipt_id"] == "urn:concordia:receipt:test"
     assert result["approval_pending_offer_hash"] is None
     assert sess.approval_receipts[-1]["id"] == "urn:concordia:receipt:test"
+
+
+def test_audit_metadata_defaults_to_autonomous_without_approval_receipts():
+    mgr, sess = _new_session()
+    withdrawal = {
+        "message_type": "withdrawal",
+        "message_id": "withdrawal-autonomous",
+        "session_id": sess.session_id,
+        "sequence_number": 1,
+        "sender_did": INITIATOR_DID,
+        "sender_agent_id": "tc-agent",
+        "timestamp": "2026-03-24T10:02:00Z",
+        "reason_code": "STRATEGY_DECISION",
+    }
+    mgr.process_message(sess, withdrawal)
+
+    metadata = generate_audit_log(sess)["audit_metadata"]
+
+    assert metadata["ai_system_involved"] is True
+    assert metadata["human_oversight_present"] is False
+    assert metadata["autonomous_decision"] is True
+
+
+def test_audit_metadata_reflects_human_approval_receipt():
+    mgr, sess = _new_session()
+    sess.initiator_mandate = {
+        "mandate_type": "declared",
+        "principal_did": INITIATOR_DID,
+        "requires_human_approval_above": 9_000_000,
+    }
+    offer = _make_offer(sess.session_id, 1, 1, INITIATOR_DID)
+    mgr.process_message(sess, offer)
+    mgr.apply_approval_receipt(sess, _approval_receipt(sess))
+
+    metadata = generate_audit_log(sess)["audit_metadata"]
+
+    assert metadata["ai_system_involved"] is True
+    assert metadata["human_oversight_present"] is True
+    assert metadata["autonomous_decision"] is False
 
 
 def test_approval_receipt_wrong_offer_hash_rejected():


### PR DESCRIPTION
## Summary

Fixes A2C-65 by deriving audit HITL metadata from the session's approval receipts instead of hardcoding autonomous defaults.

## What changed

- `generate_audit_log` now sets `human_oversight_present` from `bool(session.approval_receipts)`.
- `autonomous_decision` is now the inverse of `human_oversight_present`.
- Preserves `ai_system_involved: True`.
- Added tests for an autonomous session and a human-approved session.

## Validation

- `uv run pytest tests/test_session.py -q` -> 37 passed
- `uv run pytest -q --ignore=tests/test_mcp_server.py` -> 361 passed

Full `uv run pytest -q` remains blocked by the existing `tests/test_mcp_server.py` collection issue tracked separately as A2C-73.