### PR TITLE
Align impasse detection with full rounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Two registered deal types now have normative JSON schemas:
 
 ### Impasse detection
 
-`impasse_threshold` field in `session_params`. When N consecutive rounds show less than 0.5% movement in `total_value`, the session transitions to `IMPASSE`. Default N = 3, configurable 1–10.
+`impasse_threshold` field in `session_params`. When N consecutive full rounds show no change in `total_value` from either party, the session transitions to `IMPASSE`. Default N = 3, configurable 1–10.
 
 ### Webhooks required at Level 2
 

--- a/RELEASE_NOTES_v0.2.0.md
+++ b/RELEASE_NOTES_v0.2.0.md
@@ -20,7 +20,7 @@ Solves the cold-start problem. A buyer agent can now invite a supplier who has n
 - `saas_renewal` — seat_count, subscription_tier, support_tier, auto_renew_terms, uptime_sla_percent
 
 ### Impasse detection
-Configurable `impasse_threshold` in session_params. When N consecutive rounds show less than 0.5% movement in total_value, session transitions to IMPASSE. Default N=3, configurable 1-10.
+Configurable `impasse_threshold` in session_params. When N consecutive full rounds show no change in total_value from either party, session transitions to IMPASSE. Default N=3, configurable 1-10.
 
 ### LLM negotiation skills file
 Reference skills file for LLM agents participating in A2CN sessions. Covers warmth-dominance calibration, chain-of-thought reasoning patterns, and Inject+Voss prompt injection defense. Based on Vaccaro et al. (2026) arXiv:2503.06416v3 — 182,812 AI-to-AI negotiations.

--- a/reference-implementation/python/README.md
+++ b/reference-implementation/python/README.md
@@ -152,7 +152,7 @@ errors = validate_deal_type_terms("goods_procurement", terms_dict)
 
 States: `PENDING → ACTIVE → NEGOTIATING → COMPLETED / REJECTED_FINAL / WITHDRAWN / IMPASSE / TIMED_OUT / ERROR`
 
-**Impasse detection (v0.2):** `consecutive_non_moving_rounds >= impasse_threshold` → `IMPASSE`. A round is non-moving if `|delta_total_value| < 0.5% of prev_total_value`.
+**Impasse detection (v0.2):** `consecutive_non_moving_rounds >= impasse_threshold` → `IMPASSE`. A full round is non-moving when both parties repeat their own previous `total_value` exactly.
 
 Enforces: turn-taking, sequence ordering, offer expiry, hash integrity, terminal state enforcement, idempotency.
 

--- a/reference-implementation/python/a2cn/session.py
+++ b/reference-implementation/python/a2cn/session.py
@@ -62,7 +62,7 @@ class Session:
     # Offer tracking
     latest_offer_id: str | None = None
     latest_offer_hash: str | None = None
-    latest_offer_total_value: int | None = None  # for impasse detection
+    latest_offer_total_value: int | None = None  # for impasse detection / reporting
 
     # Human approval pause state
     approval_pending_offer_id: str | None = None
@@ -75,6 +75,8 @@ class Session:
     # v0.2.0: Impasse detection (OQ-005)
     impasse_threshold: int = 3                   # from session_params
     consecutive_non_moving_rounds: int = 0
+    _impasse_last_total_by_role: dict[str, Any] = field(default_factory=dict)
+    _impasse_unchanged_roles_this_round: set[str] = field(default_factory=set)
 
     # Timing
     session_created_at: str = ""
@@ -550,23 +552,21 @@ class SessionManager:
         session.state = SessionState.NEGOTIATING
         session.state_updated_at = now
 
-        # v0.2.0: Impasse detection — only on counteroffers (round > 1)
-        if round_number > 1 and new_total_value is not None:
-            if _is_moving_round(session.latest_offer_total_value, new_total_value):
-                session.consecutive_non_moving_rounds = 0
-            else:
-                session.consecutive_non_moving_rounds += 1
-                if session.consecutive_non_moving_rounds >= session.impasse_threshold:
-                    session.state = SessionState.IMPASSE
-                    session.current_turn = "none"
-                    session.terminal_reason = "impasse"
-                    session.terminal_message_id = message_id
-                    session.state_updated_at = now
-                    if message.get("protocol_act_hash"):
-                        session._offer_chain.append(message["protocol_act_hash"])
-                    session._message_log.append(message)
-                    session.latest_offer_total_value = new_total_value
-                    return session.to_state_dict()
+        if new_total_value is not None and _record_impasse_progress(
+            session,
+            sender_role,
+            new_total_value,
+        ):
+            session.state = SessionState.IMPASSE
+            session.current_turn = "none"
+            session.terminal_reason = "impasse"
+            session.terminal_message_id = message_id
+            session.state_updated_at = now
+            if message.get("protocol_act_hash"):
+                session._offer_chain.append(message["protocol_act_hash"])
+            session._message_log.append(message)
+            session.latest_offer_total_value = new_total_value
+            return session.to_state_dict()
 
         session.latest_offer_total_value = new_total_value
 
@@ -1031,16 +1031,32 @@ def _now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _is_moving_round(prev_total_value: int | None, new_total_value: int) -> bool:
+def _record_impasse_progress(session: Session, sender_role: str, new_total_value: Any) -> bool:
     """
-    A round is moving if the delta in total_value is >= 0.5% of prev_total_value.
-    Returns True (moving) when prev is None or zero.
+    Track spec §8.7 soft-impasse progress.
+
+    A non-moving full round is complete only after both parties repeat their own
+    previous total_value exactly. Any party changing total_value resets the
+    consecutive count.
     """
-    if prev_total_value is None or prev_total_value == 0:
-        return True
-    delta = abs(new_total_value - prev_total_value)
-    threshold = prev_total_value * 0.005
-    return delta >= threshold
+    last_total = session._impasse_last_total_by_role.get(sender_role)
+    session._impasse_last_total_by_role[sender_role] = new_total_value
+
+    if last_total is None:
+        session._impasse_unchanged_roles_this_round.discard(sender_role)
+        return False
+
+    if new_total_value != last_total:
+        session.consecutive_non_moving_rounds = 0
+        session._impasse_unchanged_roles_this_round.clear()
+        return False
+
+    session._impasse_unchanged_roles_this_round.add(sender_role)
+    if {"initiator", "responder"}.issubset(session._impasse_unchanged_roles_this_round):
+        session.consecutive_non_moving_rounds += 1
+        session._impasse_unchanged_roles_this_round.clear()
+
+    return session.consecutive_non_moving_rounds >= session.impasse_threshold
 
 
 def _receipt_references_session(receipt: dict, session_id: str) -> bool:

--- a/reference-implementation/python/tests/test_llm_agent.py
+++ b/reference-implementation/python/tests/test_llm_agent.py
@@ -478,14 +478,14 @@ class TestMockLLMNegotiation:
     @pytest.mark.asyncio
     async def test_impasse_detection(self):
         """
-        When both parties offer values that change by < 0.5% per round, the
-        session transitions to IMPASSE after impasse_threshold non-moving rounds.
+        When both parties repeat their own total_value exactly, the session
+        transitions to IMPASSE after impasse_threshold non-moving full rounds.
 
         Setup:
           Buyer always counters at $100,020 (10_002_000 cents).
           Seller always counters at $100,000 (10_000_000 cents).
-          Delta = $20 / $100,000 = 0.02% < 0.5% threshold → non-moving.
-          impasse_threshold = 2 → IMPASSE triggers at round 3.
+          impasse_threshold = 2 → IMPASSE triggers after both parties repeat
+          their own prior value twice.
 
         The FixedValueLLM always counteroffers (never accepts) so neither side
         exits the loop voluntarily — the session state machine must end it.

--- a/reference-implementation/python/tests/test_session.py
+++ b/reference-implementation/python/tests/test_session.py
@@ -229,6 +229,76 @@ def test_turn_flips_after_counteroffer():
     assert sess.round_number == 2
 
 
+def test_impasse_counts_only_full_rounds_with_no_change():
+    mgr, sess = _new_session()
+    sess.max_rounds = 6
+    sess.impasse_threshold = 2
+
+    totals = [
+        (INITIATOR_DID, 10_000_000),
+        (RESPONDER_DID, 9_900_000),
+        (INITIATOR_DID, 10_000_000),
+        (RESPONDER_DID, 9_900_000),
+        (INITIATOR_DID, 10_000_000),
+        (RESPONDER_DID, 9_900_000),
+    ]
+
+    previous = None
+    for index, (sender_did, total_value) in enumerate(totals, start=1):
+        message = _make_offer(
+            sess.session_id,
+            index,
+            index,
+            sender_did,
+            msg_type="offer" if index == 1 else "counteroffer",
+            in_reply_to=previous,
+            terms={"total_value": total_value, "currency": "USD"},
+        )
+        mgr.process_message(sess, message)
+        previous = message["message_id"]
+
+        if index == 3:
+            assert sess.consecutive_non_moving_rounds == 0
+            assert sess.state == SessionState.NEGOTIATING
+        if index == 4:
+            assert sess.consecutive_non_moving_rounds == 1
+            assert sess.state == SessionState.NEGOTIATING
+
+    assert sess.state == SessionState.IMPASSE
+    assert sess.current_turn == "none"
+    assert sess.consecutive_non_moving_rounds == 2
+
+
+def test_impasse_treats_any_total_value_change_as_movement():
+    mgr, sess = _new_session()
+    sess.max_rounds = 6
+    sess.impasse_threshold = 1
+
+    totals = [
+        (INITIATOR_DID, 10_000_000),
+        (RESPONDER_DID, 9_999_980),
+        (INITIATOR_DID, 10_000_020),
+        (RESPONDER_DID, 9_999_980),
+    ]
+
+    previous = None
+    for index, (sender_did, total_value) in enumerate(totals, start=1):
+        message = _make_offer(
+            sess.session_id,
+            index,
+            index,
+            sender_did,
+            msg_type="offer" if index == 1 else "counteroffer",
+            in_reply_to=previous,
+            terms={"total_value": total_value, "currency": "USD"},
+        )
+        mgr.process_message(sess, message)
+        previous = message["message_id"]
+
+    assert sess.state == SessionState.NEGOTIATING
+    assert sess.consecutive_non_moving_rounds == 0
+
+
 # ---------------------------------------------------------------------------
 # Sequence number enforcement (Section 7.1)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace the 0.5% per-offer impasse heuristic with exact no-change full-round tracking
- Count a non-moving round only after both parties repeat their own previous `total_value`
- Reset impasse progress on any `total_value` change and refresh stale docs/comments that described the old heuristic
- Add regression tests for full-round counting and sub-threshold value changes

## Validation
- `uv run pytest tests/test_session.py -q` -> 39 passed
- `uv run pytest tests/test_llm_agent.py::TestMockLLMNegotiation::test_impasse_detection -q` -> 1 passed
- `uv run pytest -q --ignore=tests/test_mcp_server.py` -> 363 passed

Notes: full `uv run pytest -q` remains blocked by the known A2C-73 MCP/httpx collection issue.