### PR TITLE
Restrict DID signing key purposes

### DIFF
--- a/reference-implementation/python/a2cn/did.py
+++ b/reference-implementation/python/a2cn/did.py
@@ -51,35 +51,37 @@ def _did_web_to_url(did: str) -> str:
         return f"https://{domain}/.well-known/did.json"
 
 
-def get_verification_method(did_document: dict, method_id: str) -> dict:
+def get_verification_method(
+    did_document: dict,
+    method_id: str,
+    *,
+    allowed_relationships: tuple[str, ...] = ("assertionMethod", "authentication"),
+) -> dict:
     """
-    Extract a specific verification method from a DID document by its DID URL.
+    Extract a signing verification method from a DID document by its DID URL.
 
-    Searches verificationMethod, authentication, assertionMethod arrays.
+    The method MUST be authorized for one of the allowed verification
+    relationships. By default this permits assertion signatures and JWT
+    authentication signatures, while excluding keyAgreement-only keys.
 
     Raises:
         KeyError: if the method is not found
     """
-    search_keys = [
-        "verificationMethod",
-        "authentication",
-        "assertionMethod",
-        "keyAgreement",
-        "capabilityInvocation",
-        "capabilityDelegation",
-    ]
+    verification_methods = {
+        method.get("id"): method
+        for method in did_document.get("verificationMethod", [])
+        if isinstance(method, dict) and method.get("id")
+    }
 
-    for key in search_keys:
+    for key in allowed_relationships:
         for method in did_document.get(key, []):
-            # Methods can be embedded objects or string references
-            if isinstance(method, dict):
-                if method.get("id") == method_id:
-                    return method
-            elif isinstance(method, str) and method == method_id:
-                # It's a reference — look up in verificationMethod
-                for vm in did_document.get("verificationMethod", []):
-                    if isinstance(vm, dict) and vm.get("id") == method_id:
-                        return vm
+            # Methods can be embedded objects or string references.
+            if isinstance(method, dict) and method.get("id") == method_id:
+                return method
+            if isinstance(method, str) and method == method_id:
+                if method_id in verification_methods:
+                    return verification_methods[method_id]
+                break
 
     raise KeyError(f"Verification method {method_id!r} not found in DID document")
 

--- a/reference-implementation/python/tests/test_did.py
+++ b/reference-implementation/python/tests/test_did.py
@@ -86,6 +86,30 @@ def test_get_verification_method_found():
     assert vm["id"] == vm_id
 
 
+def test_get_verification_method_rejects_key_agreement_only_key():
+    priv, pub = generate_keypair()
+    vm_id = f"{INITIATOR_DID}#agreement-key"
+    did_doc = {
+        "@context": [
+            "https://www.w3.org/ns/did/v1",
+            "https://w3id.org/security/suites/jws-2020/v1",
+        ],
+        "id": INITIATOR_DID,
+        "verificationMethod": [
+            {
+                "id": vm_id,
+                "type": "JsonWebKey2020",
+                "controller": INITIATOR_DID,
+                "publicKeyJwk": public_key_to_jwk(pub),
+            }
+        ],
+        "keyAgreement": [vm_id],
+    }
+
+    with pytest.raises(KeyError, match="not found"):
+        get_verification_method(did_doc, vm_id)
+
+
 def test_get_verification_method_not_found_raises():
     priv, pub = generate_keypair()
     did_doc = make_did_document(INITIATOR_DID, "key-1", public_key_to_jwk(pub))


### PR DESCRIPTION
## Summary
- Make `get_verification_method` require a signing-capable verification relationship by default
- Resolve string references only through `assertionMethod` or `authentication`, excluding `keyAgreement`, `capabilityInvocation`, and `capabilityDelegation`
- Add a regression test proving a keyAgreement-only key is rejected even when its key material is present in `verificationMethod`

## Validation
- `uv run pytest tests/test_did.py tests/test_session.py tests/test_server.py tests/test_record.py -q` -> 82 passed
- `uv run pytest -q --ignore=tests/test_mcp_server.py` -> 364 passed

Notes: full `uv run pytest -q` remains blocked by the known A2C-73 MCP/httpx collection issue.