### PR TITLE
Allow signature-authenticated inbound invitations

### DIFF
--- a/reference-implementation/python/a2cn/server.py
+++ b/reference-implementation/python/a2cn/server.py
@@ -120,8 +120,12 @@ async def transport_auth_middleware(request: Request, call_next) -> Response:
     Enforce Bearer JWT on all state-mutating requests (POST, PUT, PATCH).
     Only validates token shape here; full DID-based signature verification
     is performed by verify_jwt_auth dependency on each protected endpoint.
+    Inbound invitation delivery is the cold-start exception: POST /invitations
+    authenticates with invitation_signature instead of transport JWT.
     """
     if request.method in ("POST", "PUT", "PATCH"):
+        if request.method == "POST" and request.url.path == "/invitations":
+            return await call_next(request)
         auth = request.headers.get("Authorization", "")
         if not auth.startswith("Bearer "):
             return JSONResponse(
@@ -891,7 +895,6 @@ async def receive_invitation(request: Request) -> Response:
     if not body.get("invitation_signature"):
         return error_response("MISSING_INVITATION_SIGNATURE", "invitation_signature is required", 400)
 
-    # TODO v0.3: Verify invitation signature against inviter DID document
     # Resolve DID document (_did_doc_override first, then HTTP)
     if inviter_did in _did_doc_override:
         did_doc = _did_doc_override[inviter_did]

--- a/reference-implementation/python/tests/test_server.py
+++ b/reference-implementation/python/tests/test_server.py
@@ -13,6 +13,7 @@ from a2cn.crypto import (
     hash_bytes,
     hash_object,
     public_key_to_jwk,
+    sign_invitation,
     sign_jws,
     verify_jws,
 )
@@ -129,6 +130,62 @@ async def test_session_init_wrong_deal_type(test_client):
     r = await test_client.post("/sessions", json=body, headers=init_headers(body["message_id"]))
     assert r.status_code == 403
     assert r.json()["error"]["code"] == "DEAL_TYPE_NOT_SUPPORTED"
+
+
+# ---------------------------------------------------------------------------
+# POST /invitations — signature-authenticated cold-start delivery
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_receive_invitation_does_not_require_bearer_token(raw_test_client):
+    import a2cn.server as server_module
+
+    inviter_priv, inviter_pub = generate_keypair()
+    inviter_did = "did:web:buyer.example"
+    vm_id = f"{inviter_did}#key-1"
+    server_module.register_did_document(
+        inviter_did,
+        make_did_document(inviter_did, "key-1", public_key_to_jwk(inviter_pub)),
+    )
+    invitation = {
+        "message_type": "session_invitation",
+        "invitation_id": str(uuid.uuid4()),
+        "a2cn_version": "0.2",
+        "inviter_did": inviter_did,
+        "inviter_endpoint": "https://buyer.example/a2cn",
+        "inviter_discovery_url": "https://buyer.example/.well-known/a2cn-agent",
+        "proposed_deal_type": "saas_renewal",
+        "proposed_session_params": {
+            "currency": "USD",
+            "max_rounds": 4,
+            "session_timeout_seconds": 3600,
+            "round_timeout_seconds": 900,
+        },
+        "proposed_terms_summary": {"total_value": 9_500_000, "currency": "USD"},
+        "inviter_mandate_summary": {"mandate_type": "declared"},
+        "invitation_expires_at": "2030-01-01T00:00:00Z",
+        "accept_endpoint": "https://buyer.example/a2cn/invitations/test/accept",
+        "decline_endpoint": "https://buyer.example/a2cn/invitations/test/decline",
+        "inviter_verification_method": vm_id,
+        "invitation_signature": "",
+    }
+    invitation["invitation_signature"] = sign_invitation(invitation, inviter_priv)
+
+    r = await raw_test_client.post("/invitations", json=invitation)
+
+    assert r.status_code == 201
+    assert r.json() == {
+        "invitation_id": invitation["invitation_id"],
+        "status": "pending",
+    }
+
+
+@pytest.mark.asyncio
+async def test_invitation_create_still_requires_bearer_token(raw_test_client):
+    r = await raw_test_client.post("/invitations/create", json={})
+
+    assert r.status_code == 401
+    assert r.json()["error"]["code"] == "INVALID_JWT"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Exempt only exact `POST /invitations` from the global Bearer-token shape middleware
- Keep `/invitations/create`, accept, and decline paths protected by transport JWT
- Remove the stale invitation-signature TODO now that the endpoint already resolves the inviter DID and verifies `invitation_signature`
- Add regression coverage for cold-start inbound delivery without Authorization and for `/invitations/create` still requiring Bearer auth

## Validation
- `uv run pytest tests/test_server.py -q` -> 22 passed
- `uv run pytest -q --ignore=tests/test_mcp_server.py` -> 366 passed

Notes: full `uv run pytest -q` remains blocked by the known A2C-73 MCP/httpx collection issue.