### PR TITLE
Emit compact JWS payloads directly

### DIFF
--- a/reference-implementation/python/a2cn/crypto.py
+++ b/reference-implementation/python/a2cn/crypto.py
@@ -11,13 +11,17 @@ Implements:
 
 import base64
 import hashlib
+import json
 import uuid
 from datetime import datetime, timezone
 from typing import Any
 
 import jcs
 import jwt as pyjwt
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import utils
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     Ed25519PrivateKey,
@@ -162,18 +166,19 @@ def sign_jws(payload_str: str, private_key: SigningPrivateKey, kid: str | None =
     if kid:
         headers["kid"] = kid
 
-    pem = private_key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
+    protected = _b64url_encode(
+        json.dumps(headers, separators=(",", ":"), sort_keys=True).encode("utf-8")
     )
-    token = pyjwt.encode(
-        {"payload": payload_str},  # wrap in a claim so PyJWT is happy
-        pem,
-        algorithm=algorithm,
-        headers=headers,
-    )
-    return token
+    payload = _b64url_encode(payload_str.encode("utf-8"))
+    signing_input = f"{protected}.{payload}".encode("ascii")
+
+    if isinstance(private_key, Ed25519PrivateKey):
+        signature = private_key.sign(signing_input)
+    else:
+        der_signature = private_key.sign(signing_input, ec.ECDSA(hashes.SHA256()))
+        signature = _ecdsa_der_to_raw(der_signature)
+
+    return f"{protected}.{payload}.{_b64url_encode(signature)}"
 
 
 def verify_jws(token: str, public_key: SigningPublicKey) -> str:
@@ -181,16 +186,28 @@ def verify_jws(token: str, public_key: SigningPublicKey) -> str:
     Verify a JWS compact token and return the payload string.
     Raises jwt.InvalidSignatureError on failure.
     """
-    pem = public_key.public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-    decoded = pyjwt.decode(
-        token,
-        pem,
-        algorithms=[_jwt_algorithm_for_public_key(public_key)],
-    )
-    return decoded["payload"]
+    try:
+        protected, payload, signature = token.split(".")
+        header = json.loads(_b64url_decode(protected))
+        expected_alg = _jwt_algorithm_for_public_key(public_key)
+        if header.get("alg") != expected_alg:
+            raise pyjwt.exceptions.InvalidSignatureError("JWS alg does not match key type")
+
+        signing_input = f"{protected}.{payload}".encode("ascii")
+        signature_bytes = _b64url_decode(signature)
+        if isinstance(public_key, Ed25519PublicKey):
+            public_key.verify(signature_bytes, signing_input)
+        else:
+            public_key.verify(
+                _ecdsa_raw_to_der(signature_bytes),
+                signing_input,
+                ec.ECDSA(hashes.SHA256()),
+            )
+        return _b64url_decode(payload).decode("utf-8")
+    except pyjwt.exceptions.InvalidSignatureError:
+        raise
+    except (InvalidSignature, ValueError, TypeError, json.JSONDecodeError) as exc:
+        raise pyjwt.exceptions.InvalidSignatureError("Invalid JWS signature") from exc
 
 
 # ---------------------------------------------------------------------------
@@ -338,6 +355,19 @@ def _b64url_decode(s: str) -> bytes:
     # Re-add padding
     padded = s + "=" * (-len(s) % 4)
     return base64.urlsafe_b64decode(padded)
+
+
+def _ecdsa_der_to_raw(der_signature: bytes) -> bytes:
+    r, s = utils.decode_dss_signature(der_signature)
+    return r.to_bytes(32, "big") + s.to_bytes(32, "big")
+
+
+def _ecdsa_raw_to_der(raw_signature: bytes) -> bytes:
+    if len(raw_signature) != 64:
+        raise ValueError("ES256 signatures must be 64 raw bytes")
+    r = int.from_bytes(raw_signature[:32], "big")
+    s = int.from_bytes(raw_signature[32:], "big")
+    return utils.encode_dss_signature(r, s)
 
 
 def _jwt_algorithm_for_private_key(private_key: SigningPrivateKey) -> str:

--- a/reference-implementation/python/tests/test_crypto.py
+++ b/reference-implementation/python/tests/test_crypto.py
@@ -1,5 +1,8 @@
 """Tests for a2cn.crypto"""
 
+import base64
+import json
+
 import pytest
 import jcs
 
@@ -150,6 +153,21 @@ def test_jws_roundtrip():
     assert recovered == payload
 
 
+def test_jws_compact_payload_is_the_raw_payload_string():
+    priv, _ = generate_keypair()
+    payload = "sha256-somehashvalue"
+    token = sign_jws(payload, priv, kid="did:web:example.com#key-1")
+    header_b64, payload_b64, signature_b64 = token.split(".")
+
+    header = json.loads(_b64url_decode(header_b64))
+    assert header["alg"] == "ES256"
+    assert header["kid"] == "did:web:example.com#key-1"
+    assert _b64url_decode(payload_b64).decode("utf-8") == payload
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(_b64url_decode(payload_b64))
+    assert signature_b64
+
+
 def test_jws_wrong_key_raises():
     import jwt as pyjwt
     priv1, _ = generate_keypair()
@@ -177,6 +195,10 @@ def test_jws_ed25519_roundtrip():
 
     recovered = verify_jws(token, pub)
     assert recovered == "ed25519-payload"
+
+
+def _b64url_decode(s: str) -> bytes:
+    return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
 
 
 # ---------------------------------------------------------------------------

--- a/spec/a2cn-spec-v0.2.0.md
+++ b/spec/a2cn-spec-v0.2.0.md
@@ -1171,6 +1171,10 @@ The **protocol act object** used for signing is:
    where signing_alg is ES256 or EdDSA/Ed25519 per Section 13.4
 ```
 
+`protocol_act_signature` MUST use attached JWS Compact Serialization. The JWS
+payload segment MUST be `base64url(ASCII(protocol_act_hash))`; implementations
+MUST NOT wrap the hash in JWT claims such as `{"payload": protocol_act_hash}`.
+
 `protocol_act_hash` and `protocol_act_signature` are included in the offer message.
 
 Receivers MUST verify the signature before processing the offer:
@@ -1216,7 +1220,8 @@ Schema: `spec/schemas/acceptance.schema.json`
 **`accepted_protocol_act_hash`** — MUST match the `protocol_act_hash` of the
 accepted offer. This binds the acceptance to the specific protocol act.
 
-**`acceptance_signature`** — JWS over the JCS-canonicalized form of:
+**`acceptance_signature`** — JWS over the base64url SHA-256 hash of the
+JCS-canonicalized form of:
 ```json
 {
   "session_id": "...",
@@ -1232,6 +1237,11 @@ acceptance could be replayed within the same session against a different offer
 at the same round position. Both signatures (the offer's `protocol_act_signature`
 and the acceptance's `acceptance_signature`) together form the dual-signature
 basis of the transaction record.
+
+Like `protocol_act_signature`, `acceptance_signature` uses attached JWS Compact
+Serialization and signs the hash string for this canonical acceptance object as
+the JWS payload bytes. The payload segment MUST be
+`base64url(ASCII(acceptance_payload_hash))`, not a JWT claim set.
 
 Receivers MUST reject acceptances of expired offers (`expires_at` in the past).
 


### PR DESCRIPTION
## Summary
- Replace the PyJWT `{ "payload": ... }` claim wrapper in `sign_jws` with direct attached compact JWS construction
- Verify ES256 and EdDSA compact JWS signatures directly against `base64url(header).base64url(payload)`
- Add ES256 raw signature conversion helpers for JOSE-compatible `r || s` signatures
- Pin the wire format with a test proving the compact JWS payload segment is the raw payload string, not JSON claims
- Clarify the spec rule for `protocol_act_signature` and `acceptance_signature`: payload segment is `base64url(ASCII(hash_string))`, not a JWT claim set

## Validation
- `uv run pytest tests/test_crypto.py tests/test_session.py tests/test_server.py tests/test_record.py -q` -> 94 passed
- `uv run pytest tests/test_crypto.py -q` -> 23 passed
- `uv run pytest -q --ignore=tests/test_mcp_server.py` -> 367 passed

Notes: full `uv run pytest -q` remains blocked by the known A2C-73 MCP/httpx collection issue.