### PR TITLE
Include MCP tests in full suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A2CN defines neutral infrastructure for agent-to-agent commercial negotiation.
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Spec Version](https://img.shields.io/badge/Spec-v0.2.0-green.svg)](spec/a2cn-spec-v0.2.0.md)
-[![Tests](https://img.shields.io/badge/Tests-300%2B%20passing-brightgreen.svg)](reference-implementation/python/tests)
+[![Tests](https://img.shields.io/badge/Tests-390%20passing-brightgreen.svg)](reference-implementation/python/tests)
 [![Status](https://img.shields.io/badge/Status-Partner%20Ready-orange.svg)]()
 
 ---
@@ -178,7 +178,7 @@ python examples/invitation_flow.py
 ```bash
 pip install -r requirements.txt
 pytest tests/ -v
-# 300+ passed
+# 390 passed
 ```
 
 ---
@@ -254,7 +254,7 @@ rather than platform-local implementation details.
 
 Full protocol specification: [`spec/a2cn-spec-v0.2.0.md`](spec/a2cn-spec-v0.2.0.md) — 3,300+ lines covering eight protocol components with normative JSON schemas, platform integration patterns for Fairmarkit, Salesforce Revenue Cloud, Dynamics 365, Luminance, and A2A, and a complete four-round SaaS renewal walkthrough with concrete message envelopes.
 
-**Spec status:** v0.2.0. Passed four independent critique cycles. Verified against reference implementation (300+ tests).
+**Spec status:** v0.2.0. Passed four independent critique cycles. Verified against reference implementation (390 tests).
 
 ---
 
@@ -303,7 +303,7 @@ A2CN/
 | Milestone | Status |
 |-----------|--------|
 | Protocol spec v0.2.0 | ✓ Complete — 3,300+ lines, 8 components |
-| Reference implementation (Python) | ✓ Complete — 300+ tests passing |
+| Reference implementation (Python) | ✓ Complete — 390 tests passing |
 | Session Invitation (Component 8) | ✓ Complete — signed invitations, lifecycle, hosted endpoint pattern |
 | Platform adapters | ✓ Complete — Fairmarkit, Salesforce Revenue Cloud, Keelvar |
 | LLM agent skills file | ✓ Complete — `reference-implementation/skills/a2cn-negotiation.md` |

--- a/RELEASE_NOTES_v0.2.0.md
+++ b/RELEASE_NOTES_v0.2.0.md
@@ -2,7 +2,7 @@
 
 **Released:** April 2026  
 **Spec:** v0.2.0 (3,300+ lines)  
-**Tests:** 202 passing  
+**Tests:** 390 passing
 **License:** Apache 2.0
 
 ## What's new in v0.2.0
@@ -55,7 +55,7 @@ python examples/keelvar_demo.py
 ```bash
 pip install -r requirements.txt
 pytest tests/ -v
-# 202 passed
+# 390 passed
 ```
 
 ## What's next (v0.3)

--- a/index.html
+++ b/index.html
@@ -1212,7 +1212,7 @@
             <div class="tl-dot"></div>
             <div class="tl-content">
               <div class="tl-title">A2CN v0.2.0 — you are here</div>
-              <div class="tl-desc">Open, neutral protocol for commercial negotiation between agents from different organizations. 8 components, 300+ tests, Fairmarkit + Keelvar + Salesforce adapters, MCP server, A2A extension proposal submitted.</div>
+              <div class="tl-desc">Open, neutral protocol for commercial negotiation between agents from different organizations. 8 components, 390 tests, Fairmarkit + Keelvar + Salesforce adapters, MCP server, A2A extension proposal submitted.</div>
             </div>
           </div>
 
@@ -1458,7 +1458,7 @@
     <h2 class="section-heading">Built. Being proposed. Still to come.</h2>
     <p class="section-lede">
       A2CN is an open protocol with a complete Python reference implementation,
-      300+ passing tests, platform adapters, and an A2A extension proposal in review.
+      390 passing tests, platform adapters, and an A2A extension proposal in review.
     </p>
 
     <div class="status-split">
@@ -1469,7 +1469,7 @@
         </div>
         <ul>
           <li>Protocol spec v0.2.0 <span class="detail">3,700+ lines, 8 components, Apache 2.0</span></li>
-          <li>Reference implementation <span class="detail">Python, 300+ tests passing</span></li>
+          <li>Reference implementation <span class="detail">Python, 390 tests passing</span></li>
           <li>Session invitation <span class="detail">cold-start adoption solved</span></li>
           <li>Platform adapters <span class="detail">Fairmarkit, Keelvar, Salesforce Revenue Cloud</span></li>
           <li>MCP server <span class="detail">Claude Desktop, LangChain, LangGraph, Agentforce, Cursor</span></li>
@@ -1562,7 +1562,7 @@
       <div class="involve-card">
         <div class="involve-title">Build on it</div>
         <div class="involve-body">
-          Python reference implementation with 300+ passing tests. LangChain, CrewAI,
+          Python reference implementation with 390 passing tests. LangChain, CrewAI,
           and Agentforce compatible. Apache 2.0 license.
         </div>
         <a class="involve-link" href="https://github.com/A2CN-protocol/A2CN" target="_blank" rel="noopener">github.com/A2CN-protocol/A2CN →</a>
@@ -1594,7 +1594,7 @@
 <footer>
   <div class="footer-inner">
     <span class="footer-brand">A2CN</span>
-    <span class="footer-meta">Apache 2.0 · spec v0.2.0 · 300+ tests passing</span>
+    <span class="footer-meta">Apache 2.0 · spec v0.2.0 · 390 tests passing</span>
   </div>
 </footer>
 

--- a/reference-implementation/README.md
+++ b/reference-implementation/README.md
@@ -361,6 +361,7 @@ httpx==0.27.0          # Async HTTP client
 PyJWT==2.9.0           # JWT/JWS signing (ES256)
 cryptography==43.0.0   # P-256 key generation and operations
 jcs==0.2.1             # RFC 8785 JSON Canonicalization Scheme
+mcp==1.12.4            # MCP server and tool registration
 pytest==8.3.0          # Test runner
 pytest-asyncio==0.24.0 # Async test support
 ```

--- a/reference-implementation/python/README.md
+++ b/reference-implementation/python/README.md
@@ -3,7 +3,7 @@
 **The canonical Python implementation of the A2CN protocol.**
 
 [![Python](https://img.shields.io/badge/Python-3.11%2B-blue.svg)](https://python.org)
-[![Tests](https://img.shields.io/badge/Tests-300%2B%20passing-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/Tests-390%20passing-brightgreen.svg)](tests/)
 [![Spec](https://img.shields.io/badge/Spec-v0.2.0-green.svg)](../../spec/a2cn-spec-v0.2.0.md)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.115-009688.svg)](https://fastapi.tiangolo.com)
 
@@ -303,7 +303,7 @@ Fork it, modify it, or build your own from scratch.
 ## Running the tests
 
 ```bash
-pytest tests/ -v   # 300+ passed
+pytest tests/ -v   # 390 passed
 ```
 
 | Test file | What it covers |
@@ -311,6 +311,7 @@ pytest tests/ -v   # 300+ passed
 | `test_crypto.py` | JCS, ES256, Ed25519, invitation signing |
 | `test_session.py` | State machine, turn-taking, impasse |
 | `test_server.py` | All HTTP endpoints, error codes |
+| `test_mcp_server.py` | MCP tool server and session orchestration |
 | `test_invitations.py` | Invitation lifecycle, signature, expiry |
 | `test_deal_type_terms.py` | `goods_procurement` and `saas_renewal` validation |
 | `test_adapters.py` | Fairmarkit and Revenue Cloud translation |

--- a/reference-implementation/python/mcp_server.py
+++ b/reference-implementation/python/mcp_server.py
@@ -36,8 +36,6 @@ Tools exposed:
     a2cn_get_session_status    Poll for counterparty response
 """
 
-from __future__ import annotations
-
 import argparse
 import os
 import uuid

--- a/reference-implementation/python/pyproject.toml
+++ b/reference-implementation/python/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "PyJWT==2.9.0",
     "cryptography==43.0.0",
     "jcs==0.2.1",
-    "mcp",
+    "mcp==1.12.4",
 ]
 
 [project.optional-dependencies]

--- a/reference-implementation/python/requirements.txt
+++ b/reference-implementation/python/requirements.txt
@@ -4,6 +4,7 @@ httpx==0.27.0
 PyJWT==2.9.0
 cryptography==43.0.0
 jcs==0.2.1
+mcp==1.12.4
 pytest==8.3.0
 pytest-asyncio==0.24.0
 python-multipart==0.0.12

--- a/reference-implementation/python/uv.lock
+++ b/reference-implementation/python/uv.lock
@@ -11,7 +11,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "jcs" },
-    { name = "mcp" },
+    { name = "mcp", specifier = "==1.12.4" },
     { name = "pyjwt" },
     { name = "uvicorn" },
 ]
@@ -30,7 +30,7 @@ requires-dist = [
     { name = "fastapi", specifier = "==0.115.0" },
     { name = "httpx", specifier = "==0.27.0" },
     { name = "jcs", specifier = "==0.2.1" },
-    { name = "mcp" },
+    { name = "mcp", specifier = "==1.12.4" },
     { name = "pyjwt", specifier = "==2.9.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==8.3.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==0.24.0" },

--- a/spec/a2cn-spec-v0.2.0.md
+++ b/spec/a2cn-spec-v0.2.0.md
@@ -3714,7 +3714,7 @@ LLMs as their reasoning layer.
 - Round-trip `lot_id` ↔ `internal_part_number` field mapping (USD ↔ cents)
 - `terms_to_keelvar_bid_response` translates agreed A2CN terms to Keelvar bid
   response payload for submission to the Keelvar sourcing event API
-- 17 tests added (`TestKeelvarAdapter`); total test count: 202
+- 17 tests added (`TestKeelvarAdapter`); total test count at that patch point: 202
 
 **New: A2CN MCP Server (Section 16.12)**
 


### PR DESCRIPTION
## Summary
- Fix `tests/test_mcp_server.py` collection by removing postponed annotations from `mcp_server.py`, matching FastMCP's runtime annotation parser
- Pin `mcp==1.12.4` in package metadata, requirements, and lock metadata so fresh installs include the MCP server dependency with the known-good `httpx`/`starlette` set
- Update stale 202/300+ test-count claims to the verified full-suite count of 390 passing tests
- Add the MCP server test file to the Python reference implementation test table

## Validation
- `uv run pytest -q` -> 390 passed

Notes: the full suite now runs without excluding `tests/test_mcp_server.py`.