### PR TITLE
add Vendr adapter

### DIFF
--- a/reference-implementation/python/adapters/VENDR_INTEGRATION.md
+++ b/reference-implementation/python/adapters/VENDR_INTEGRATION.md
@@ -1,0 +1,125 @@
+# Vendr MCP and Webhooks - A2CN Integration Guide
+
+Vendr is a buy-side SaaS procurement platform with two useful integration
+surfaces for A2CN:
+
+- Vendr MCP server: exposes pricing and benchmark intelligence to agents.
+- Vendr webhooks: notify your endpoint about renewal and workflow events.
+
+The cleanest A2CN integration is MCP-to-MCP. An agent asks Vendr's MCP server
+for SaaS benchmark context, translates the result into A2CN `saas_renewal`
+terms with `vendr_adapter.py`, then calls A2CN's MCP tools to run the bilateral
+negotiation and produce the dual-signed transaction record.
+
+No Vendr platform changes are required.
+
+---
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `VENDR_API_KEY` | Access key for Vendr MCP/API surfaces, issued by Vendr |
+| `VENDR_WEBHOOK_SECRET` | Optional shared secret for HMAC-SHA256 webhook verification |
+
+---
+
+## Path A - Vendr Webhook Starts an A2CN Renewal
+
+```python
+from adapters.vendr_adapter import VendrWebhookParser
+
+# Verify against the exact raw request body when Vendr provides a webhook secret.
+VendrWebhookParser.verify_webhook_signature(
+    body_bytes,
+    headers["X-Vendr-Signature"],
+    webhook_secret,
+)
+
+parsed = VendrWebhookParser.parse_renewal_webhook(payload)
+session_params = parsed["session_params"]
+initial_terms = parsed["initial_terms"]
+
+# session_params["deal_type"] == "saas_renewal"
+# initial_terms["total_value"] is integer cents
+```
+
+Vendr webhooks are one-way notifications. The adapter keeps the Vendr event ID
+and workflow ID in `session_params` for audit correlation, then A2CN owns the
+negotiation state and transaction record.
+
+---
+
+## Path B - MCP-to-MCP Pricing Intelligence
+
+```text
+1. Agent calls Vendr MCP server
+      -> benchmark/pricing context for vendor, product, seat count, discount band
+
+2. Agent calls vendr_pricing_to_a2cn_terms(pricing)
+      -> A2CN saas_renewal terms
+
+3. Agent calls A2CN MCP tools
+      -> start_session(...)
+      -> send_offer(...)
+      -> accept_offer(...)
+
+4. A2CN emits dual-signed transaction record
+      -> a2cn_terms_to_vendr_summary(...) creates a local audit summary
+```
+
+The bridge is intentionally thin: Vendr remains the pricing-intelligence source,
+while A2CN remains the neutral bilateral negotiation and record layer.
+
+---
+
+## Pricing Field Map
+
+The adapter accepts a tolerant benchmark shape so agents can normalize Vendr MCP
+responses without deep platform coupling:
+
+```python
+pricing = {
+    "vendor": "Example SaaS",
+    "product": "Enterprise Analytics",
+    "list_price": 1200.0,  # dollars per seat per year
+    "seat_count": 100,
+    "currency": "USD",
+    "term_months": 12,
+    "observed_discount_band": {"min": 0.15, "max": 0.25},
+    "benchmark_range": {"low": 85000.0, "median": 95000.0, "high": 110000.0},
+    "source": "vendr_mcp",
+}
+```
+
+`vendr_pricing_to_a2cn_terms()` applies the observed discount midpoint to the
+per-seat list price and converts dollar values to integer cents.
+
+---
+
+## Round-Trip Summary
+
+Vendr's webhook surface does not ingest completed negotiation data, so
+`a2cn_terms_to_vendr_summary()` returns a local, Vendr-shaped audit artifact:
+
+```python
+summary = a2cn_terms_to_vendr_summary(
+    agreed_terms,
+    session_id="sess-001",
+    record_hash="...",
+    workflow_id="wf-001",
+)
+```
+
+Attach the summary to your internal renewal system, Zip-linked workflow, or
+agent memory. The canonical commitment remains the A2CN transaction record.
+
+---
+
+## Known Limitations
+
+- Vendr MCP/API access currently requires an access key from Vendr.
+- Webhooks are one-way; they should initiate or correlate A2CN work, not act as
+  the write-back channel.
+- Field names from MCP responses may vary as Vendr evolves its agent surface.
+  Normalize into the documented `pricing` shape before calling the adapter.

--- a/reference-implementation/python/adapters/vendr_adapter.py
+++ b/reference-implementation/python/adapters/vendr_adapter.py
@@ -1,0 +1,284 @@
+"""
+Vendr -> A2CN translation layer.
+
+Translates Vendr renewal/workflow webhook payloads and pricing benchmark data
+into A2CN SaaS renewal terms. The primary integration pattern is MCP-to-MCP:
+an agent calls Vendr's MCP server for pricing intelligence, then calls A2CN's
+MCP tools to run the bilateral negotiation and produce the signed record.
+
+No I/O in this module -- pure data translation, fully testable offline.
+
+Vendr integration surfaces:
+  MCP server: pricing and benchmark intelligence for agent use
+  Webhooks:   one-way procurement/workflow notifications from Vendr
+
+Field mapping -- Vendr pricing -> A2CN saas_renewal:
+
+  Vendr field                         A2CN saas_renewal field
+  ----------------------------------------------------------------------
+  vendor                              custom_terms.vendr.vendor
+  product                             subscription_tier / line description
+  list_price                          line_items[].unit_price (cents)
+  seat_count                          seat_count / line quantity
+  term_months                         term_months
+  currency                            currency
+  observed_discount_band.midpoint     total_value discount basis
+  benchmark_range                     custom_terms.vendr.benchmark_range
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from typing import Any
+
+
+def _money_to_cents(value: Any) -> int:
+    """Convert a decimal money value into integer cents."""
+    if value is None:
+        return 0
+    return int(float(value) * 100)
+
+
+def _int_value(value: Any, default: int = 0) -> int:
+    if value is None or value == "":
+        return default
+    return int(float(value))
+
+
+def _discount_to_fraction(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    discount = float(value)
+    if discount > 1:
+        discount = discount / 100.0
+    return discount
+
+
+def _discount_band_midpoint(discount_band: dict | None) -> float | None:
+    if not isinstance(discount_band, dict):
+        return None
+    if "midpoint" in discount_band:
+        return _discount_to_fraction(discount_band["midpoint"])
+    minimum = _discount_to_fraction(discount_band.get("min"))
+    maximum = _discount_to_fraction(discount_band.get("max"))
+    if minimum is None and maximum is None:
+        return None
+    if minimum is None:
+        return maximum
+    if maximum is None:
+        return minimum
+    return (minimum + maximum) / 2.0
+
+
+def vendr_pricing_to_a2cn_terms(
+    pricing: dict,
+    default_net_days: int = 30,
+) -> dict:
+    """
+    Map Vendr benchmark/pricing data into A2CN saas_renewal terms.
+
+    Expected pricing fields:
+      vendor: str
+      product: str
+      list_price: number        # per-seat annual price in dollars
+      seat_count: int
+      currency: str             # ISO 4217, default USD
+      term_months: int          # default 12
+      observed_discount_band: {min, max} or {midpoint}
+      benchmark_range: {low, median, high}  # optional, dollars
+
+    The observed discount band midpoint is applied to list_price to create the
+    proposed A2CN total_value. Values are stored in integer cents.
+    """
+    vendor = str(pricing.get("vendor", ""))
+    product = str(pricing.get("product", ""))
+    seat_count = max(_int_value(pricing.get("seat_count"), 1), 1)
+    term_months = max(_int_value(pricing.get("term_months"), 12), 1)
+    list_price_cents = _money_to_cents(
+        pricing.get("list_price", pricing.get("annual_unit_price", 0))
+    )
+
+    discount = _discount_band_midpoint(pricing.get("observed_discount_band"))
+    if discount is None:
+        discount = _discount_to_fraction(pricing.get("observed_discount"))
+    effective_unit_price_cents = list_price_cents
+    if discount is not None:
+        effective_unit_price_cents = int(list_price_cents * (1.0 - discount))
+
+    total_cents = effective_unit_price_cents * seat_count
+    benchmark_range = pricing.get("benchmark_range") or {}
+    benchmark_range_cents = {
+        key: _money_to_cents(value)
+        for key, value in benchmark_range.items()
+        if key in {"low", "median", "high"}
+    }
+
+    return {
+        "deal_type": "saas_renewal",
+        "total_value": total_cents,
+        "currency": pricing.get("currency", "USD"),
+        "line_items": [
+            {
+                "description": product or vendor or "Vendr benchmarked subscription",
+                "quantity": seat_count,
+                "unit_price": effective_unit_price_cents,
+                "total": total_cents,
+            }
+        ],
+        "payment_terms": {"net_days": default_net_days},
+        "seat_count": seat_count,
+        "subscription_tier": pricing.get("subscription_tier", product or "standard"),
+        "term_months": term_months,
+        "custom_terms": {
+            "vendr": {
+                "vendor": vendor,
+                "product": product,
+                "list_price": list_price_cents,
+                "observed_discount": discount,
+                "benchmark_range": benchmark_range_cents,
+                "source": pricing.get("source", "vendr_mcp"),
+            }
+        },
+    }
+
+
+class VendrWebhookParser:
+    """
+    Translates Vendr workflow/renewal webhooks into A2CN session inputs.
+
+    Vendr webhooks are one-way notifications, so this parser returns local
+    session parameters and opening terms; it does not try to write back to Vendr.
+    """
+
+    @staticmethod
+    def parse_renewal_webhook(
+        payload: dict,
+        max_rounds: int = 5,
+    ) -> dict:
+        """
+        Parse a Vendr renewal/workflow event into A2CN session params and terms.
+
+        Expected payload fields are intentionally tolerant because Vendr webhook
+        payloads may vary by workflow:
+          event_id, event_type, workflow_id, buyer_org, vendor, product,
+          renewal_date, currency, seat_count, term_months, pricing
+
+        Returns:
+          Dict with session_params, initial_terms, event_id, workflow_id, and
+          raw_payload for audit correlation.
+        """
+        pricing = dict(payload.get("pricing") or {})
+        for key in (
+            "vendor",
+            "product",
+            "list_price",
+            "annual_unit_price",
+            "seat_count",
+            "currency",
+            "term_months",
+            "observed_discount",
+            "observed_discount_band",
+            "benchmark_range",
+            "subscription_tier",
+        ):
+            if key not in pricing and key in payload:
+                pricing[key] = payload[key]
+
+        terms = vendr_pricing_to_a2cn_terms(pricing)
+        event_id = payload.get("event_id", payload.get("id", ""))
+        workflow_id = payload.get("workflow_id", payload.get("workflowId", ""))
+
+        session_params = {
+            "deal_type": "saas_renewal",
+            "currency": terms.get("currency", "USD"),
+            "max_rounds": max_rounds,
+            "session_timeout_seconds": 3600,
+            "round_timeout_seconds": 900,
+            "vendr_event_id": event_id,
+            "vendr_workflow_id": workflow_id,
+            "buyer_org": payload.get("buyer_org", payload.get("buyerOrg", "")),
+            "vendor": pricing.get("vendor", ""),
+            "product": pricing.get("product", ""),
+            "renewal_date": payload.get("renewal_date", payload.get("renewalDate", "")),
+        }
+
+        return {
+            "event_id": event_id,
+            "event_type": payload.get("event_type", payload.get("eventType", "")),
+            "workflow_id": workflow_id,
+            "session_params": session_params,
+            "initial_terms": terms,
+            "raw_payload": payload,
+        }
+
+    @staticmethod
+    def verify_webhook_signature(
+        payload_bytes: bytes,
+        signature_header: str,
+        webhook_secret: str,
+    ) -> bool:
+        """
+        Verify an HMAC-SHA256 Vendr webhook signature when a secret is provided.
+
+        Accepts either a bare hex digest or common prefixed forms such as
+        ``sha256=<digest>`` and ``v1=<digest>``.
+        """
+        if not webhook_secret or not signature_header:
+            return False
+        expected = hmac.new(
+            webhook_secret.encode("utf-8"),
+            payload_bytes,
+            hashlib.sha256,
+        ).hexdigest()
+        received = signature_header.strip()
+        for prefix in ("sha256=", "v1="):
+            if received.startswith(prefix):
+                received = received[len(prefix):]
+                break
+        return hmac.compare_digest(expected, received)
+
+
+def a2cn_terms_to_vendr_summary(
+    agreed_terms: dict,
+    session_id: str,
+    record_hash: str,
+    workflow_id: str | None = None,
+) -> dict:
+    """
+    Translate agreed A2CN terms into a Vendr-shaped summary for audit linkage.
+
+    Vendr webhooks do not provide a write-back API, so this is a local summary
+    that can be attached to downstream systems or used by an agent when calling
+    non-webhook Vendr surfaces.
+    """
+    vendr_meta = agreed_terms.get("custom_terms", {}).get("vendr", {})
+    total_value = agreed_terms.get("total_value", 0)
+    seat_count = max(_int_value(agreed_terms.get("seat_count"), 1), 1)
+    summary = {
+        "source": "a2cn",
+        "a2cn_session_id": session_id,
+        "a2cn_record_hash": record_hash,
+        "workflow_id": workflow_id,
+        "vendor": vendr_meta.get("vendor", ""),
+        "product": vendr_meta.get("product", agreed_terms.get("subscription_tier", "")),
+        "status": "negotiated",
+        "total_value": total_value / 100.0,
+        "currency": agreed_terms.get("currency", "USD"),
+        "seat_count": seat_count,
+        "unit_price": total_value / seat_count / 100.0,
+        "term_months": agreed_terms.get("term_months", 12),
+        "payment_terms": f"Net {agreed_terms.get('payment_terms', {}).get('net_days', 30)}",
+    }
+    return {k: v for k, v in summary.items() if v is not None}
+
+
+def webhook_body_for_signature(payload: dict) -> bytes:
+    """
+    Deterministically encode a sample payload for tests and webhook fixtures.
+
+    Production servers should verify the exact raw request body bytes they
+    received, not a re-serialized dict.
+    """
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")

--- a/reference-implementation/python/tests/test_vendr_adapter.py
+++ b/reference-implementation/python/tests/test_vendr_adapter.py
@@ -1,0 +1,165 @@
+"""Tests for Vendr MCP/webhook platform adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+from a2cn.messages import validate_deal_type_terms
+from adapters.vendr_adapter import (
+    VendrWebhookParser,
+    a2cn_terms_to_vendr_summary,
+    vendr_pricing_to_a2cn_terms,
+    webhook_body_for_signature,
+)
+
+
+SAMPLE_VENDR_PRICING = {
+    "vendor": "Acme Analytics",
+    "product": "Enterprise Analytics Suite",
+    "list_price": 1200.0,
+    "seat_count": 100,
+    "currency": "USD",
+    "term_months": 12,
+    "observed_discount_band": {"min": 0.15, "max": 0.25},
+    "benchmark_range": {"low": 85000.0, "median": 95000.0, "high": 110000.0},
+    "source": "vendr_mcp",
+}
+
+SAMPLE_VENDR_WEBHOOK = {
+    "event_id": "vendr-evt-001",
+    "event_type": "renewal.workflow.updated",
+    "workflow_id": "vendr-wf-001",
+    "buyer_org": "TechCorp",
+    "renewal_date": "2026-07-01",
+    "vendor": "Acme Analytics",
+    "product": "Enterprise Analytics Suite",
+    "list_price": 1200.0,
+    "seat_count": 100,
+    "currency": "USD",
+    "term_months": 12,
+    "observed_discount_band": {"min": 0.15, "max": 0.25},
+}
+
+
+class TestVendrPricingToA2CNTerms:
+    def test_pricing_maps_to_saas_renewal_terms(self):
+        terms = vendr_pricing_to_a2cn_terms(SAMPLE_VENDR_PRICING)
+
+        assert terms["deal_type"] == "saas_renewal"
+        assert terms["currency"] == "USD"
+        assert terms["seat_count"] == 100
+        assert terms["subscription_tier"] == "Enterprise Analytics Suite"
+        assert validate_deal_type_terms("saas_renewal", terms) == []
+
+    def test_discount_midpoint_applied_and_converted_to_cents(self):
+        terms = vendr_pricing_to_a2cn_terms(SAMPLE_VENDR_PRICING)
+
+        # $1200 list * 20% midpoint discount = $960 per seat.
+        assert terms["line_items"][0]["unit_price"] == 96_000
+        assert terms["total_value"] == 9_600_000
+
+    def test_benchmark_range_converted_to_cents(self):
+        terms = vendr_pricing_to_a2cn_terms(SAMPLE_VENDR_PRICING)
+
+        benchmark = terms["custom_terms"]["vendr"]["benchmark_range"]
+        assert benchmark["low"] == 8_500_000
+        assert benchmark["median"] == 9_500_000
+        assert benchmark["high"] == 11_000_000
+
+    def test_percentage_discount_values_are_supported(self):
+        pricing = {
+            "product": "Security Platform",
+            "list_price": 1000.0,
+            "seat_count": 10,
+            "observed_discount_band": {"min": 10, "max": 20},
+        }
+
+        terms = vendr_pricing_to_a2cn_terms(pricing)
+
+        assert terms["line_items"][0]["unit_price"] == 85_000
+        assert terms["total_value"] == 850_000
+
+    def test_missing_seat_count_defaults_to_one_valid_seat(self):
+        terms = vendr_pricing_to_a2cn_terms({"list_price": 500.0})
+
+        assert terms["seat_count"] == 1
+        assert validate_deal_type_terms("saas_renewal", terms) == []
+
+
+class TestVendrWebhookParser:
+    def test_webhook_parse_returns_session_params_and_terms(self):
+        parsed = VendrWebhookParser.parse_renewal_webhook(SAMPLE_VENDR_WEBHOOK)
+
+        assert parsed["event_id"] == "vendr-evt-001"
+        assert parsed["workflow_id"] == "vendr-wf-001"
+        assert parsed["session_params"]["deal_type"] == "saas_renewal"
+        assert parsed["session_params"]["vendr_event_id"] == "vendr-evt-001"
+        assert parsed["session_params"]["vendr_workflow_id"] == "vendr-wf-001"
+        assert parsed["initial_terms"]["total_value"] == 9_600_000
+
+    def test_webhook_nested_pricing_shape_supported(self):
+        payload = {
+            "event_id": "vendr-evt-002",
+            "workflowId": "vendr-wf-002",
+            "buyerOrg": "MegaBuyer",
+            "renewalDate": "2026-09-01",
+            "pricing": SAMPLE_VENDR_PRICING,
+        }
+
+        parsed = VendrWebhookParser.parse_renewal_webhook(payload, max_rounds=3)
+
+        assert parsed["session_params"]["max_rounds"] == 3
+        assert parsed["session_params"]["buyer_org"] == "MegaBuyer"
+        assert parsed["session_params"]["renewal_date"] == "2026-09-01"
+        assert parsed["initial_terms"]["seat_count"] == 100
+
+    def test_webhook_signature_accepts_prefixed_sha256_digest(self):
+        body = webhook_body_for_signature(SAMPLE_VENDR_WEBHOOK)
+        secret = "vendr-secret"
+        digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+
+        assert VendrWebhookParser.verify_webhook_signature(
+            body,
+            f"sha256={digest}",
+            secret,
+        )
+
+    def test_webhook_signature_rejects_wrong_digest(self):
+        body = webhook_body_for_signature(SAMPLE_VENDR_WEBHOOK)
+
+        assert not VendrWebhookParser.verify_webhook_signature(
+            body,
+            "sha256=not-the-real-digest",
+            "vendr-secret",
+        )
+
+
+class TestVendrRoundTripSummary:
+    def test_terms_to_vendr_summary_converts_cents_to_dollars(self):
+        terms = vendr_pricing_to_a2cn_terms(SAMPLE_VENDR_PRICING)
+        summary = a2cn_terms_to_vendr_summary(
+            terms,
+            session_id="sess-vendr-001",
+            record_hash="deadbeef" * 8,
+            workflow_id="vendr-wf-001",
+        )
+
+        assert summary["source"] == "a2cn"
+        assert summary["a2cn_session_id"] == "sess-vendr-001"
+        assert summary["workflow_id"] == "vendr-wf-001"
+        assert summary["total_value"] == 96_000.0
+        assert summary["unit_price"] == 960.0
+        assert summary["payment_terms"] == "Net 30"
+
+    def test_summary_preserves_vendr_vendor_and_product(self):
+        terms = vendr_pricing_to_a2cn_terms(SAMPLE_VENDR_PRICING)
+        summary = a2cn_terms_to_vendr_summary(
+            terms,
+            session_id="sess-vendr-002",
+            record_hash="cafebabe" * 8,
+        )
+
+        assert summary["vendor"] == "Acme Analytics"
+        assert summary["product"] == "Enterprise Analytics Suite"
+        assert summary["status"] == "negotiated"

--- a/reference-implementation/python/tests/test_vendr_adapter.py
+++ b/reference-implementation/python/tests/test_vendr_adapter.py
@@ -66,6 +66,7 @@ class TestVendrPricingToA2CNTerms:
         assert benchmark["low"] == 8_500_000
         assert benchmark["median"] == 9_500_000
         assert benchmark["high"] == 11_000_000
+        assert terms["custom_terms"]["vendr"]["source"] == "vendr_mcp"
 
     def test_percentage_discount_values_are_supported(self):
         pricing = {
@@ -79,6 +80,18 @@ class TestVendrPricingToA2CNTerms:
 
         assert terms["line_items"][0]["unit_price"] == 85_000
         assert terms["total_value"] == 850_000
+
+    def test_flat_observed_discount_field_is_supported(self):
+        terms = vendr_pricing_to_a2cn_terms({
+            "product": "AI Contract Review",
+            "list_price": 2000.0,
+            "seat_count": 5,
+            "observed_discount": 0.25,
+        })
+
+        assert terms["line_items"][0]["unit_price"] == 150_000
+        assert terms["total_value"] == 750_000
+        assert terms["custom_terms"]["vendr"]["observed_discount"] == 0.25
 
     def test_missing_seat_count_defaults_to_one_valid_seat(self):
         terms = vendr_pricing_to_a2cn_terms({"list_price": 500.0})
@@ -122,6 +135,17 @@ class TestVendrWebhookParser:
         assert VendrWebhookParser.verify_webhook_signature(
             body,
             f"sha256={digest}",
+            secret,
+        )
+
+    def test_webhook_signature_accepts_v1_prefixed_digest(self):
+        body = webhook_body_for_signature(SAMPLE_VENDR_WEBHOOK)
+        secret = "vendr-secret"
+        digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+
+        assert VendrWebhookParser.verify_webhook_signature(
+            body,
+            f"v1={digest}",
             secret,
         )
 


### PR DESCRIPTION
## What changed

- Added `adapters/vendr_adapter.py` with Vendr webhook parsing, Vendr pricing/benchmark to A2CN `saas_renewal` terms mapping, optional HMAC webhook verification, and a local Vendr-shaped round-trip summary helper.
- Added `adapters/VENDR_INTEGRATION.md` documenting the MCP-to-MCP bridge: Vendr MCP for pricing intelligence, A2CN MCP for negotiation and the signed transaction record.
- Added `tests/test_vendr_adapter.py` covering webhook parsing, cents conversion, discount-band handling, schema validation, signature verification, and summary generation.

## Why

A2C-84 targets Vendr as the high-priority SaaS renewal wedge. The implementation keeps the adapter thin and offline-testable, with no core protocol changes.

## Validation

- `uv run pytest tests/test_vendr_adapter.py -q` -> 11 passed
- `uv run pytest -q` -> 401 passed
- `git diff --check` -> clean