### PR TITLE
add SAP Ariba adapter

### DIFF
--- a/reference-implementation/python/adapters/ARIBA_INTEGRATION.md
+++ b/reference-implementation/python/adapters/ARIBA_INTEGRATION.md
@@ -1,0 +1,128 @@
+# SAP Ariba Sourcing - A2CN Integration Guide
+
+SAP Ariba is a buy-side sourcing and procurement platform. This adapter maps
+SAP Ariba Sourcing / Discovery RFx events into A2CN `goods_procurement` terms
+and maps agreed A2CN terms back into Ariba-shaped bid or acknowledgement
+payloads.
+
+Public docs used:
+
+- Event Management API for SAP Ariba Sourcing
+  - `GET /events`
+  - `GET /events/{eventId}/items`
+- Discovery RFx Publication TO External Marketplace API
+  - `GetNextRfxEvent`
+  - `GetRfxAttachment`
+  - `UpdateRfxEvent`
+  - `Acknowledge`
+
+Runtime API use requires SAP Ariba Developer Portal access, an application with
+the relevant API package entitlement, environment-specific runtime URLs, OAuth
+client credentials, and an application key.
+
+---
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `ARIBA_CLIENT_ID` | OAuth client ID from the SAP Ariba Developer Portal |
+| `ARIBA_CLIENT_SECRET` | OAuth client secret from the SAP Ariba Developer Portal |
+| `ARIBA_TOKEN_URL` | OAuth token URL from the API environment details |
+| `ARIBA_API_KEY` | SAP Ariba application key sent as `apiKey` |
+| `ARIBA_BASE_URL` | Runtime API URL from the environment details |
+
+---
+
+## Path A - Event Management API
+
+```python
+from adapters.ariba_adapter import AribaEventParser
+
+# Event Management API:
+# GET /events/{eventId}/items retrieves item details for an event.
+event = {
+    "eventId": "evt-001",
+    "title": "Industrial Supplies RFQ",
+    "currency": "USD",
+    "items": [
+        {"itemId": "10", "title": "Hydraulic fluid", "quantity": 50,
+         "unitOfMeasure": "EA", "targetPrice": 360.0, "lotId": "LOT-HF"},
+    ],
+}
+
+parsed = AribaEventParser.sourcing_event_to_session_inputs(event)
+session_params = parsed["session_params"]
+initial_terms = parsed["initial_terms"]
+```
+
+`initial_terms["total_value"]` is expressed in integer cents and passes A2CN
+`goods_procurement` validation.
+
+---
+
+## Path B - Discovery RFx Publication TO External Marketplace
+
+SAP's documented Discovery RFx flow is:
+
+```text
+GetNextRfxEvent -> GetRfxAttachment (optional) -> UpdateRfxEvent -> Acknowledge
+```
+
+The adapter supports the same RFx shape using tolerant aliases such as `rfxId`,
+`rfxTitle`, `lots`, `externalRfxId`, and `lineItems`.
+
+```python
+from adapters.ariba_adapter import ariba_acknowledgement_payload
+
+ack = ariba_acknowledgement_payload(
+    event_id="rfx-001",
+    external_reference="a2cn-session-sess-001",
+)
+```
+
+Use the acknowledgement payload after accepting the RFx event for A2CN
+negotiation. The canonical agreement remains the A2CN transaction record.
+
+---
+
+## Bid Payload
+
+```python
+from adapters.ariba_adapter import a2cn_terms_to_ariba_bid
+
+bid = a2cn_terms_to_ariba_bid(
+    agreed_terms,
+    event_id="evt-001",
+    supplier_id="supplier-123",
+)
+```
+
+The bid payload converts A2CN cents back to decimal Ariba prices and preserves
+`internal_part_number` as the Ariba item or lot reference when present.
+
+---
+
+## Auth Helpers
+
+`fetch_ariba_access_token()` implements client-credentials token retrieval using
+`ARIBA_CLIENT_ID`, `ARIBA_CLIENT_SECRET`, and `ARIBA_TOKEN_URL`.
+
+`ariba_auth_headers(access_token)` creates headers with:
+
+- `Authorization: Bearer ...`
+- `apiKey: ...`
+- `Accept: application/json`
+- `Content-Type: application/json`
+
+---
+
+## Known Limitations
+
+- SAP Ariba Open APIs are not available by default to all users; administrator
+  enablement and API package entitlement are required.
+- Runtime URLs and token URLs are environment-specific and must be copied from
+  the SAP Ariba Developer Portal environment details.
+- Event and RFx field names vary by sourcing flow. The adapter accepts common
+  aliases, but production deployments should normalize payloads from the exact
+  OpenAPI schema enabled in their tenant.

--- a/reference-implementation/python/adapters/ariba_adapter.py
+++ b/reference-implementation/python/adapters/ariba_adapter.py
@@ -177,7 +177,7 @@ class AribaEventParser:
                 {
                     key: value
                     for key, value in item.items()
-                    if key not in {"currency", "ariba_item_id", "ariba_lot_id"}
+                    if key != "currency"
                 }
                 for item in parsed["line_items"]
             ],

--- a/reference-implementation/python/adapters/ariba_adapter.py
+++ b/reference-implementation/python/adapters/ariba_adapter.py
@@ -1,0 +1,315 @@
+"""
+SAP Ariba -> A2CN translation layer.
+
+Translates SAP Ariba Sourcing / Discovery RFx event payloads into A2CN
+goods_procurement terms, and translates agreed A2CN terms into Ariba-shaped bid
+or acknowledgement payloads.
+
+SAP public documentation used for this adapter:
+  Event Management API:
+    GET /events
+    GET /events/{eventId}/items
+  Discovery RFx Publication TO External Marketplace API:
+    GetNextRfxEvent -> GetRfxAttachment -> UpdateRfxEvent -> Acknowledge
+
+No core protocol changes are required. This module keeps the platform mapping
+offline-testable, while small auth helpers document the OAuth/API-key shape
+needed when wiring it into a live SAP Ariba environment.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+
+def _money_to_cents(value: Any) -> int:
+    if value is None or value == "":
+        return 0
+    if isinstance(value, dict):
+        value = value.get("amount", 0)
+    return int(float(value) * 100)
+
+
+def _int_value(value: Any, default: int = 0) -> int:
+    if value is None or value == "":
+        return default
+    return int(float(value))
+
+
+def _first(mapping: dict, *names: str, default: Any = None) -> Any:
+    for name in names:
+        if name in mapping and mapping[name] is not None:
+            return mapping[name]
+    return default
+
+
+def _items_from_payload(payload: dict) -> list[dict]:
+    items = (
+        payload.get("items")
+        or payload.get("lineItems")
+        or payload.get("line_items")
+        or payload.get("lots")
+        or []
+    )
+    if isinstance(items, dict):
+        items = items.get("items") or items.get("lineItems") or items.get("results") or []
+    return list(items)
+
+
+def _normalize_item(item: dict, default_currency: str) -> dict:
+    item_id = _first(
+        item,
+        "itemId",
+        "item_id",
+        "lineItemId",
+        "internalId",
+        "id",
+        default="",
+    )
+    lot_id = _first(item, "lotId", "lot_id", "lot", "lotNumber", default="")
+    quantity = _int_value(_first(item, "quantity", "qty", "amount", default=1), 1)
+    unit_price_raw = _first(
+        item,
+        "unitPrice",
+        "unit_price",
+        "targetPrice",
+        "target_price",
+        "estimatedUnitPrice",
+        "price",
+        default=0,
+    )
+    unit_price_cents = _money_to_cents(unit_price_raw)
+    total_raw = _first(item, "totalPrice", "total_price", "extendedPrice", default=None)
+    total_cents = _money_to_cents(total_raw) if total_raw is not None else quantity * unit_price_cents
+    line_item: dict = {
+        "description": _first(item, "title", "description", "name", "itemName", default=""),
+        "quantity": quantity,
+        "unit_of_measure": _first(item, "unitOfMeasure", "unit_of_measure", "uom", default="EA"),
+        "unit_price": unit_price_cents,
+        "total": total_cents,
+    }
+    internal_ref = lot_id or item_id
+    if internal_ref:
+        line_item["internal_part_number"] = str(internal_ref)
+    if item_id:
+        line_item["ariba_item_id"] = str(item_id)
+    if lot_id:
+        line_item["ariba_lot_id"] = str(lot_id)
+    if item.get("currency"):
+        line_item["currency"] = item["currency"]
+    else:
+        line_item["currency"] = default_currency
+    return line_item
+
+
+class AribaEventParser:
+    """
+    Translates SAP Ariba sourcing/RFx events into A2CN session inputs.
+    """
+
+    @staticmethod
+    def parse_sourcing_event(payload: dict) -> dict:
+        """
+        Parse an SAP Ariba event or Discovery RFx payload into a clean summary.
+
+        The parser accepts tolerant aliases from Event Management responses
+        (event id/header/items) and Discovery RFx publications (RFx id/lots).
+        """
+        event = payload.get("event") or payload.get("rfxEvent") or payload
+        currency = _first(event, "currency", "currencyCode", default="USD")
+        raw_items = _items_from_payload(event)
+        line_items = [_normalize_item(item, currency) for item in raw_items]
+        total_cents = sum(item["total"] for item in line_items)
+        event_id = _first(
+            event,
+            "eventId",
+            "event_id",
+            "internalId",
+            "rfxId",
+            "id",
+            default="",
+        )
+
+        return {
+            "event_id": event_id,
+            "external_rfx_id": _first(
+                event,
+                "externalSystemCorrelationId",
+                "externalRfxId",
+                "rfxReference",
+                default="",
+            ),
+            "event_name": _first(event, "title", "name", "eventName", "rfxTitle", default=""),
+            "buyer_org": _first(event, "buyerOrg", "buyerOrganization", "owner", default=""),
+            "deadline": _first(event, "biddingEndDate", "deadline", "closeDate", default=None),
+            "currency": currency,
+            "line_items": line_items,
+            "estimated_value": total_cents,
+            "raw_payload": payload,
+        }
+
+    @staticmethod
+    def sourcing_event_to_goods_procurement_terms(
+        payload: dict,
+        default_delivery_days: int = 14,
+        default_net_days: int = 30,
+    ) -> dict:
+        """
+        Translate an SAP Ariba sourcing/RFx event into A2CN goods_procurement terms.
+        """
+        event = payload.get("event") or payload.get("rfxEvent") or payload
+        parsed = AribaEventParser.parse_sourcing_event(payload)
+        delivery_days = _int_value(
+            _first(event, "deliveryDays", "delivery_days", "leadTimeDays", default=default_delivery_days),
+            default_delivery_days,
+        )
+        net_days = _int_value(
+            _first(event, "paymentTermsNetDays", "netDays", "paymentTermDays", default=default_net_days),
+            default_net_days,
+        )
+        return {
+            "total_value": parsed["estimated_value"],
+            "currency": parsed["currency"],
+            "line_items": [
+                {
+                    key: value
+                    for key, value in item.items()
+                    if key not in {"currency", "ariba_item_id", "ariba_lot_id"}
+                }
+                for item in parsed["line_items"]
+            ],
+            "delivery_days": delivery_days,
+            "payment_terms": {"net_days": net_days},
+            "custom_terms": {
+                "ariba": {
+                    "event_id": parsed["event_id"],
+                    "external_rfx_id": parsed["external_rfx_id"],
+                    "source": _first(event, "source", default="sap_ariba"),
+                }
+            },
+        }
+
+    @staticmethod
+    def sourcing_event_to_session_inputs(
+        payload: dict,
+        max_rounds: int = 5,
+        default_delivery_days: int = 14,
+    ) -> dict:
+        """
+        Return both A2CN session params and initial goods_procurement terms.
+        """
+        parsed = AribaEventParser.parse_sourcing_event(payload)
+        terms = AribaEventParser.sourcing_event_to_goods_procurement_terms(
+            payload,
+            default_delivery_days=default_delivery_days,
+        )
+        return {
+            "event_id": parsed["event_id"],
+            "session_params": {
+                "deal_type": "goods_procurement",
+                "currency": parsed["currency"],
+                "max_rounds": max_rounds,
+                "session_timeout_seconds": 3600,
+                "round_timeout_seconds": 900,
+                "ariba_event_id": parsed["event_id"],
+                "ariba_external_rfx_id": parsed["external_rfx_id"],
+                "buyer_org": parsed["buyer_org"],
+            },
+            "initial_terms": terms,
+            "raw_payload": payload,
+        }
+
+
+def a2cn_terms_to_ariba_bid(
+    agreed_terms: dict,
+    event_id: str,
+    supplier_id: str | None = None,
+    status: str = "submitted",
+) -> dict:
+    """
+    Translate agreed A2CN goods_procurement terms into an Ariba bid payload.
+    """
+    response_items = []
+    for item in agreed_terms.get("line_items", []):
+        entry: dict = {
+            "itemId": item.get("ariba_item_id", item.get("internal_part_number", "")),
+            "lotId": item.get("ariba_lot_id", item.get("internal_part_number", "")),
+            "description": item.get("description", ""),
+            "quantity": item.get("quantity", 1),
+            "unitOfMeasure": item.get("unit_of_measure", "EA"),
+            "unitPrice": item.get("unit_price", 0) / 100.0,
+            "totalPrice": item.get("total", 0) / 100.0,
+            "currency": agreed_terms.get("currency", "USD"),
+        }
+        response_items.append({key: value for key, value in entry.items() if value != ""})
+
+    net_days = agreed_terms.get("payment_terms", {}).get("net_days", 30)
+    payload: dict = {
+        "eventId": event_id,
+        "status": status,
+        "currency": agreed_terms.get("currency", "USD"),
+        "totalAmount": agreed_terms.get("total_value", 0) / 100.0,
+        "items": response_items,
+        "deliveryDays": agreed_terms.get("delivery_days", 14),
+        "paymentTerms": f"Net {net_days}",
+    }
+    if supplier_id is not None:
+        payload["supplierId"] = supplier_id
+    return payload
+
+
+def ariba_acknowledgement_payload(
+    event_id: str,
+    external_reference: str,
+    status: str = "ACKNOWLEDGED",
+    message: str = "Accepted for A2CN negotiation.",
+) -> dict:
+    """
+    Build the Discovery RFx Publication TO External Marketplace Acknowledge shape.
+    """
+    return {
+        "eventId": event_id,
+        "externalReference": external_reference,
+        "status": status,
+        "message": message,
+    }
+
+
+def ariba_auth_headers(access_token: str, api_key: str | None = None) -> dict:
+    """
+    Build SAP Ariba Open API auth headers.
+    """
+    key = api_key or os.environ.get("ARIBA_API_KEY")
+    if not key:
+        raise ValueError("ARIBA_API_KEY environment variable is required.")
+    return {
+        "Authorization": f"Bearer {access_token}",
+        "apiKey": key,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+
+async def fetch_ariba_access_token(token_url: str | None = None) -> str:
+    """
+    Fetch an OAuth client-credentials token for SAP Ariba Open APIs.
+    """
+    client_id = os.environ.get("ARIBA_CLIENT_ID")
+    client_secret = os.environ.get("ARIBA_CLIENT_SECRET")
+    resolved_token_url = token_url or os.environ.get("ARIBA_TOKEN_URL")
+    if not client_id or not client_secret or not resolved_token_url:
+        raise ValueError(
+            "ARIBA_CLIENT_ID, ARIBA_CLIENT_SECRET, and ARIBA_TOKEN_URL are required."
+        )
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            resolved_token_url,
+            data={"grant_type": "client_credentials"},
+            auth=(client_id, client_secret),
+        )
+    response.raise_for_status()
+    data = response.json()
+    return data["access_token"]

--- a/reference-implementation/python/tests/test_ariba_adapter.py
+++ b/reference-implementation/python/tests/test_ariba_adapter.py
@@ -108,6 +108,8 @@ class TestAribaEventParser:
         )
 
         assert terms["line_items"][0]["internal_part_number"] == "LOT-HF-001"
+        assert terms["line_items"][0]["ariba_item_id"] == "10"
+        assert terms["line_items"][0]["ariba_lot_id"] == "LOT-HF-001"
         assert terms["custom_terms"]["ariba"]["event_id"] == "evt-ariba-001"
 
     def test_discovery_rfx_aliases_supported(self):
@@ -161,6 +163,8 @@ class TestAribaWriteBackPayloads:
         assert bid["eventId"] == "evt-ariba-001"
         assert bid["supplierId"] == "supplier-001"
         assert bid["totalAmount"] == 19_700.0
+        assert bid["items"][0]["itemId"] == "10"
+        assert bid["items"][0]["lotId"] == "LOT-HF-001"
         assert bid["items"][0]["unitPrice"] == 360.0
         assert bid["items"][0]["totalPrice"] == 18_000.0
         assert bid["paymentTerms"] == "Net 45"
@@ -187,6 +191,12 @@ class TestAribaAuthHelpers:
         assert headers["apiKey"] == "app-key"
         assert headers["Accept"] == "application/json"
 
+    def test_ariba_auth_headers_reads_api_key_from_env(self):
+        with patch.dict(os.environ, {"ARIBA_API_KEY": "env-app-key"}):
+            headers = ariba_auth_headers("access-token")
+
+        assert headers["apiKey"] == "env-app-key"
+
     def test_ariba_auth_headers_require_api_key(self):
         env = {k: v for k, v in os.environ.items() if k != "ARIBA_API_KEY"}
         with patch.dict(os.environ, env, clear=True):
@@ -208,6 +218,22 @@ class TestAribaAuthHelpers:
         _, kwargs = mock_client.post.call_args
         assert kwargs["data"] == {"grant_type": "client_credentials"}
         assert kwargs["auth"] == ("client-id", "client-secret")
+
+    @pytest.mark.asyncio
+    async def test_fetch_ariba_access_token_accepts_explicit_token_url(self):
+        mock_cm, mock_client = _make_async_client_mock({"access_token": "token-456"})
+        with patch("adapters.ariba_adapter.httpx.AsyncClient", return_value=mock_cm):
+            with patch.dict(os.environ, {
+                "ARIBA_CLIENT_ID": "client-id",
+                "ARIBA_CLIENT_SECRET": "client-secret",
+            }, clear=True):
+                token = await fetch_ariba_access_token(
+                    token_url="https://example.ariba.com/oauth/token"
+                )
+
+        assert token == "token-456"
+        mock_client.post.assert_called_once()
+        assert mock_client.post.call_args.args[0] == "https://example.ariba.com/oauth/token"
 
     @pytest.mark.asyncio
     async def test_fetch_ariba_access_token_requires_env(self):

--- a/reference-implementation/python/tests/test_ariba_adapter.py
+++ b/reference-implementation/python/tests/test_ariba_adapter.py
@@ -1,0 +1,220 @@
+"""Tests for SAP Ariba Sourcing platform adapter."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from a2cn.messages import validate_deal_type_terms
+from adapters.ariba_adapter import (
+    AribaEventParser,
+    a2cn_terms_to_ariba_bid,
+    ariba_acknowledgement_payload,
+    ariba_auth_headers,
+    fetch_ariba_access_token,
+)
+
+
+SAMPLE_ARIBA_EVENT = {
+    "eventId": "evt-ariba-001",
+    "externalSystemCorrelationId": "RFQ-2026-001",
+    "title": "Q3 Industrial Supplies RFQ",
+    "buyerOrg": "Global Manufacturing Inc.",
+    "biddingEndDate": "2026-08-01T17:00:00Z",
+    "currency": "USD",
+    "deliveryDays": 21,
+    "paymentTermsNetDays": 45,
+    "items": [
+        {
+            "itemId": "10",
+            "lotId": "LOT-HF-001",
+            "title": "Hydraulic fluid 200L drums",
+            "quantity": 50,
+            "unitOfMeasure": "EA",
+            "targetPrice": 360.0,
+        },
+        {
+            "itemId": "20",
+            "lotId": "LOT-SC-002",
+            "title": "Sealing compound 5kg tubs",
+            "quantity": 20,
+            "unitOfMeasure": "KG",
+            "targetPrice": 85.0,
+        },
+    ],
+}
+
+SAMPLE_DISCOVERY_RFX = {
+    "rfxId": "rfx-001",
+    "externalRfxId": "DISC-2026-001",
+    "rfxTitle": "Public sector pump sourcing event",
+    "buyerOrganization": "City Procurement Office",
+    "closeDate": "2026-09-15T17:00:00Z",
+    "currencyCode": "EUR",
+    "lots": [
+        {
+            "id": "lot-001",
+            "name": "Industrial hydraulic pump",
+            "qty": 10,
+            "uom": "EA",
+            "unitPrice": 1500.0,
+        },
+    ],
+}
+
+
+def _make_async_client_mock(json_data: dict):
+    mock_response = MagicMock()
+    mock_response.json.return_value = json_data
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+    return mock_cm, mock_client
+
+
+class TestAribaEventParser:
+    def test_parse_event_management_payload(self):
+        parsed = AribaEventParser.parse_sourcing_event(SAMPLE_ARIBA_EVENT)
+
+        assert parsed["event_id"] == "evt-ariba-001"
+        assert parsed["external_rfx_id"] == "RFQ-2026-001"
+        assert parsed["event_name"] == "Q3 Industrial Supplies RFQ"
+        assert parsed["buyer_org"] == "Global Manufacturing Inc."
+        assert parsed["currency"] == "USD"
+        assert len(parsed["line_items"]) == 2
+
+    def test_event_to_goods_procurement_terms_converts_prices_to_cents(self):
+        terms = AribaEventParser.sourcing_event_to_goods_procurement_terms(
+            SAMPLE_ARIBA_EVENT
+        )
+
+        assert terms["currency"] == "USD"
+        assert terms["delivery_days"] == 21
+        assert terms["payment_terms"]["net_days"] == 45
+        assert terms["line_items"][0]["unit_price"] == 36_000
+        assert terms["line_items"][0]["total"] == 1_800_000
+        assert terms["total_value"] == 1_970_000
+        assert validate_deal_type_terms("goods_procurement", terms) == []
+
+    def test_item_lot_id_maps_to_internal_part_number(self):
+        terms = AribaEventParser.sourcing_event_to_goods_procurement_terms(
+            SAMPLE_ARIBA_EVENT
+        )
+
+        assert terms["line_items"][0]["internal_part_number"] == "LOT-HF-001"
+        assert terms["custom_terms"]["ariba"]["event_id"] == "evt-ariba-001"
+
+    def test_discovery_rfx_aliases_supported(self):
+        parsed = AribaEventParser.sourcing_event_to_session_inputs(
+            SAMPLE_DISCOVERY_RFX,
+            max_rounds=3,
+        )
+
+        assert parsed["session_params"]["deal_type"] == "goods_procurement"
+        assert parsed["session_params"]["max_rounds"] == 3
+        assert parsed["session_params"]["ariba_event_id"] == "rfx-001"
+        assert parsed["session_params"]["ariba_external_rfx_id"] == "DISC-2026-001"
+        assert parsed["initial_terms"]["currency"] == "EUR"
+        assert parsed["initial_terms"]["total_value"] == 1_500_000
+        assert validate_deal_type_terms("goods_procurement", parsed["initial_terms"]) == []
+
+    def test_total_price_overrides_computed_line_total_when_present(self):
+        event = {
+            "eventId": "evt-total",
+            "currency": "USD",
+            "items": [
+                {
+                    "itemId": "1",
+                    "title": "Configured assembly",
+                    "quantity": 3,
+                    "unitPrice": 100.0,
+                    "totalPrice": 275.0,
+                },
+            ],
+        }
+
+        terms = AribaEventParser.sourcing_event_to_goods_procurement_terms(event)
+
+        assert terms["line_items"][0]["unit_price"] == 10_000
+        assert terms["line_items"][0]["total"] == 27_500
+        assert terms["total_value"] == 27_500
+
+
+class TestAribaWriteBackPayloads:
+    def test_terms_to_ariba_bid_converts_cents_to_dollars(self):
+        terms = AribaEventParser.sourcing_event_to_goods_procurement_terms(
+            SAMPLE_ARIBA_EVENT
+        )
+
+        bid = a2cn_terms_to_ariba_bid(
+            terms,
+            event_id="evt-ariba-001",
+            supplier_id="supplier-001",
+        )
+
+        assert bid["eventId"] == "evt-ariba-001"
+        assert bid["supplierId"] == "supplier-001"
+        assert bid["totalAmount"] == 19_700.0
+        assert bid["items"][0]["unitPrice"] == 360.0
+        assert bid["items"][0]["totalPrice"] == 18_000.0
+        assert bid["paymentTerms"] == "Net 45"
+
+    def test_acknowledgement_payload_shape(self):
+        ack = ariba_acknowledgement_payload(
+            event_id="rfx-001",
+            external_reference="a2cn-session-sess-001",
+        )
+
+        assert ack == {
+            "eventId": "rfx-001",
+            "externalReference": "a2cn-session-sess-001",
+            "status": "ACKNOWLEDGED",
+            "message": "Accepted for A2CN negotiation.",
+        }
+
+
+class TestAribaAuthHelpers:
+    def test_ariba_auth_headers_include_api_key(self):
+        headers = ariba_auth_headers("access-token", api_key="app-key")
+
+        assert headers["Authorization"] == "Bearer access-token"
+        assert headers["apiKey"] == "app-key"
+        assert headers["Accept"] == "application/json"
+
+    def test_ariba_auth_headers_require_api_key(self):
+        env = {k: v for k, v in os.environ.items() if k != "ARIBA_API_KEY"}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValueError, match="ARIBA_API_KEY"):
+                ariba_auth_headers("access-token")
+
+    @pytest.mark.asyncio
+    async def test_fetch_ariba_access_token_uses_client_credentials(self):
+        mock_cm, mock_client = _make_async_client_mock({"access_token": "token-123"})
+        with patch("adapters.ariba_adapter.httpx.AsyncClient", return_value=mock_cm):
+            with patch.dict(os.environ, {
+                "ARIBA_CLIENT_ID": "client-id",
+                "ARIBA_CLIENT_SECRET": "client-secret",
+                "ARIBA_TOKEN_URL": "https://api.ariba.com/oauth/token",
+            }):
+                token = await fetch_ariba_access_token()
+
+        assert token == "token-123"
+        _, kwargs = mock_client.post.call_args
+        assert kwargs["data"] == {"grant_type": "client_credentials"}
+        assert kwargs["auth"] == ("client-id", "client-secret")
+
+    @pytest.mark.asyncio
+    async def test_fetch_ariba_access_token_requires_env(self):
+        env = {
+            k: v for k, v in os.environ.items()
+            if k not in {"ARIBA_CLIENT_ID", "ARIBA_CLIENT_SECRET", "ARIBA_TOKEN_URL"}
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValueError, match="ARIBA_CLIENT_ID"):
+                await fetch_ariba_access_token()


### PR DESCRIPTION
## What changed

- Added `adapters/ariba_adapter.py` with SAP Ariba Event Management / Discovery RFx parsing, `goods_procurement` terms mapping, Ariba bid payload generation, Discovery RFx acknowledgement payload generation, and OAuth/API-key helper functions.
- Added `adapters/ARIBA_INTEGRATION.md` documenting Event Management and Discovery RFx paths, runtime entitlement requirements, environment variables, and the A2CN handoff model.
- Added `tests/test_ariba_adapter.py` covering Event Management payload mapping, Discovery RFx aliases, cents conversion, schema validation, bid/ack payloads, and auth helpers.

## Sources grounded

- SAP Help Portal: Event Management API for SAP Ariba Sourcing: https://help.sap.com/docs/ARIBA_APIS/0414af6b17164879920cf26608ae643d/event-management-api
- SAP Help Portal: retrieving items with `GET /events/{eventId}/items`: https://help.sap.com/docs/ariba-apis/event-management-api/retrieving-items-in-specified-event-with-event-management-api
- SAP Help Portal: Discovery RFx Publication TO External Marketplace FAQ and sequence: https://help.sap.com/docs/ariba-apis/discovery-rfx-publication-to-external-marketplace-api/faq-for-discovery-rfx-publication-to-external-marketplace-api

## Validation

- `uv run pytest tests/test_ariba_adapter.py -q` -> 11 passed
- `uv run pytest -q` -> 424 passed
- `uv run python -m py_compile adapters/ariba_adapter.py tests/test_ariba_adapter.py` -> passed
- `git diff --check` -> clean