### PR TITLE
Add JAGGAER ASO adapter

### DIFF
--- a/reference-implementation/python/adapters/JAGGAER_INTEGRATION.md
+++ b/reference-implementation/python/adapters/JAGGAER_INTEGRATION.md
@@ -1,0 +1,154 @@
+# JAGGAER ASO - A2CN Integration Guide
+
+JAGGAER ONE is a buy-side source-to-pay platform. This adapter maps JAGGAER
+Advanced Sourcing Optimizer (ASO) customer-host / sourcing events into A2CN
+`goods_procurement` terms and maps agreed A2CN terms back into
+JAGGAER-shaped bid response payloads.
+
+Public docs used:
+
+- ASO API documentation
+  - Customer Host Entity Service: query ASO events belonging to a customer host
+  - Event Entity Service: interact with a specific ASO event
+  - Async upload endpoints: entity imports for `rate` and `bid`
+- ASO Getting Started
+  - `POST /oauth2/token`
+  - `GET /chost/{customer-host-id}/user/{user-id}/apiEvents`
+  - `Authorization: Bearer ...`
+  - `X-API-Key: ...`
+- Integration via JAGGAER Public APIs
+  - REST services using JSON messaging
+  - request/response or event-driven push integration patterns
+
+Runtime API use requires tenant enablement, customer-host configuration,
+environment-specific service URLs, OAuth client credentials, an API key, and
+JAGGAER Professional Services coordination for the exact tenant schema.
+
+---
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `JAGGAER_CLIENT_ID` | OAuth client ID supplied for ASO API access |
+| `JAGGAER_CLIENT_SECRET` | OAuth client secret supplied for ASO API access |
+| `JAGGAER_TOKEN_URL` | Authorization Utility Service token URL |
+| `JAGGAER_API_KEY` | ASO API key sent as `X-API-Key` |
+| `JAGGAER_SCOPE` | Optional OAuth scope, often tenant/customer-host scoped |
+| `JAGGAER_CHES_BASE_URL` | Customer Host Entity Service base URL |
+| `JAGGAER_EES_BASE_URL` | Event Entity Service base URL |
+
+---
+
+## Path A - Event-Driven Push
+
+JAGGAER public APIs support event-driven push integrations where noted. In this
+path, JAGGAER posts a sourcing event notification or event-shaped JSON payload
+to middleware. The middleware validates tenant-specific authentication, then
+normalizes the payload through the adapter.
+
+```python
+from adapters.jaggaer_adapter import JaggaerEventParser
+
+push_event = {
+    "event": {
+        "eventId": "aso-10003",
+        "customerHostId": "275",
+        "name": "Industrial Supplies RFQ",
+        "currency": "USD",
+        "items": [
+            {"itemId": "10", "lotId": "LOT-HF", "description": "Hydraulic fluid",
+             "quantity": 50, "unitOfMeasure": "EA", "targetPrice": 360.0},
+        ],
+    }
+}
+
+parsed = JaggaerEventParser.sourcing_event_to_session_inputs(push_event)
+session_params = parsed["session_params"]
+initial_terms = parsed["initial_terms"]
+```
+
+`initial_terms["total_value"]` is expressed in integer cents and passes A2CN
+`goods_procurement` validation.
+
+---
+
+## Path B - ASO Poll Mode
+
+ASO Customer Host Entity Service documents polling events for a customer host:
+
+```text
+GET /chost/{customer-host-id}/user/{user-id}/apiEvents
+```
+
+Use `jaggaer_poll_request()` to build the documented request path, then call it
+with `jaggaer_auth_headers(access_token)`.
+
+```python
+from adapters.jaggaer_adapter import jaggaer_auth_headers, jaggaer_poll_request
+
+request = jaggaer_poll_request(
+    customer_host_id="275",
+    user_id="user-123",
+    base_url="https://ches.example.jaggaer.com",
+)
+headers = jaggaer_auth_headers("access-token", api_key="api-key")
+```
+
+The adapter can parse each returned ASO event with `mode="poll"` so the A2CN
+transaction record retains whether the session began from push or polling.
+
+---
+
+## Bid Response Payload
+
+```python
+from adapters.jaggaer_adapter import a2cn_terms_to_jaggaer_response
+
+response = a2cn_terms_to_jaggaer_response(
+    agreed_terms,
+    event_id="aso-10003",
+    supplier_id="supplier-123",
+)
+```
+
+The response payload converts A2CN cents back to decimal JAGGAER prices and
+preserves `jaggaer_item_id` and `jaggaer_lot_id` separately. That distinction
+matters for ASO bid imports where item IDs and lot IDs are different platform
+references.
+
+For live write-back, tenant middleware can submit the response through the
+configured JAGGAER bid import or async upload flow. The canonical agreement
+remains the A2CN transaction record.
+
+---
+
+## Auth Helpers
+
+`fetch_jaggaer_access_token()` implements client-credentials token retrieval
+using:
+
+- `Authorization: Basic` via HTTP client auth
+- `grant_type=client_credentials`
+- optional `scope`
+- `X-API-Key`
+
+`jaggaer_auth_headers(access_token)` creates API call headers with:
+
+- `Authorization: Bearer ...`
+- `X-API-Key: ...`
+- `Accept: application/json`
+- `Content-Type: application/json`
+
+---
+
+## Known Limitations
+
+- JAGGAER public API integrations are tenant-enabled and coordinated through
+  JAGGAER Professional Services; exact payload fields may vary.
+- The adapter intentionally performs no network I/O except the token helper.
+  Tenant middleware should own webhook verification, polling, retries, and
+  async bid-upload orchestration.
+- ASO supports multiple event categories and bid models. Production deployments
+  should normalize their enabled ASO schema into the aliases accepted here before
+  starting an A2CN session.

--- a/reference-implementation/python/adapters/jaggaer_adapter.py
+++ b/reference-implementation/python/adapters/jaggaer_adapter.py
@@ -1,0 +1,357 @@
+"""
+JAGGAER ASO -> A2CN translation layer.
+
+Translates JAGGAER Advanced Sourcing Optimizer (ASO) customer-host / sourcing
+event payloads into A2CN goods_procurement terms, and translates agreed A2CN
+terms into JAGGAER-shaped bid response payloads.
+
+Public documentation used for this adapter:
+  ASO API documentation:
+    Customer Host Entity Service - query ASO events for a customer host
+    Event Entity Service - interact with a specific ASO event
+    Async upload endpoints - entity imports for rate and bid
+  Integration via JAGGAER Public APIs:
+    REST/JSON integrations, request/response or event-driven push
+
+No core protocol changes are required. This module keeps platform mapping
+offline-testable, while small auth/request helpers document the OAuth/API-key
+shape needed when wiring it into a live JAGGAER environment.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+
+def _money_to_cents(value: Any) -> int:
+    if value is None or value == "":
+        return 0
+    if isinstance(value, dict):
+        value = value.get("amount", value.get("value", 0))
+    return int(float(value) * 100)
+
+
+def _int_value(value: Any, default: int = 0) -> int:
+    if value is None or value == "":
+        return default
+    return int(float(value))
+
+
+def _first(mapping: dict, *names: str, default: Any = None) -> Any:
+    for name in names:
+        if name in mapping and mapping[name] is not None:
+            return mapping[name]
+    return default
+
+
+def _event_from_payload(payload: dict) -> dict:
+    return (
+        payload.get("event")
+        or payload.get("asoEvent")
+        or payload.get("sourcingEvent")
+        or payload.get("apiEvent")
+        or payload.get("data")
+        or payload
+    )
+
+
+def _items_from_payload(payload: dict) -> list[dict]:
+    items = (
+        payload.get("items")
+        or payload.get("lineItems")
+        or payload.get("line_items")
+        or payload.get("eventItems")
+        or payload.get("lots")
+        or []
+    )
+    if isinstance(items, dict):
+        items = (
+            items.get("items")
+            or items.get("lineItems")
+            or items.get("eventItems")
+            or items.get("results")
+            or []
+        )
+    return list(items)
+
+
+def _normalize_item(item: dict, default_currency: str) -> dict:
+    item_id = _first(
+        item,
+        "itemId",
+        "item_id",
+        "lineItemId",
+        "line_item_id",
+        "bidItemId",
+        "id",
+        default="",
+    )
+    lot_id = _first(item, "lotId", "lot_id", "lotNumber", "lot", default="")
+    quantity = _int_value(_first(item, "quantity", "qty", "amount", default=1), 1)
+    unit_price_raw = _first(
+        item,
+        "unitPrice",
+        "unit_price",
+        "targetPrice",
+        "target_price",
+        "reservePrice",
+        "price",
+        default=0,
+    )
+    unit_price_cents = _money_to_cents(unit_price_raw)
+    total_raw = _first(item, "totalPrice", "total_price", "extendedPrice", default=None)
+    total_cents = (
+        _money_to_cents(total_raw)
+        if total_raw is not None
+        else quantity * unit_price_cents
+    )
+
+    line_item: dict = {
+        "description": _first(item, "description", "name", "title", "itemName", default=""),
+        "quantity": quantity,
+        "unit_of_measure": _first(item, "unitOfMeasure", "unit_of_measure", "uom", default="EA"),
+        "unit_price": unit_price_cents,
+        "total": total_cents,
+    }
+    internal_ref = lot_id or item_id
+    if internal_ref:
+        line_item["internal_part_number"] = str(internal_ref)
+    if item_id:
+        line_item["jaggaer_item_id"] = str(item_id)
+    if lot_id:
+        line_item["jaggaer_lot_id"] = str(lot_id)
+    line_item["currency"] = item.get("currency") or item.get("currencyCode") or default_currency
+    return line_item
+
+
+class JaggaerEventParser:
+    """
+    Translates JAGGAER ASO sourcing events into A2CN session inputs.
+    """
+
+    @staticmethod
+    def parse_sourcing_event(payload: dict, mode: str = "push") -> dict:
+        """
+        Parse a JAGGAER push event or polled ASO event into a clean summary.
+
+        The parser accepts tolerant aliases from push-webhook payloads and ASO
+        CHES/EES event responses. Tenant-specific integrations should normalize
+        their exact JAGGAER schema before calling this helper.
+        """
+        event = _event_from_payload(payload)
+        currency = _first(event, "currency", "currencyCode", default="USD")
+        line_items = [_normalize_item(item, currency) for item in _items_from_payload(event)]
+        total_cents = sum(item["total"] for item in line_items)
+        event_id = _first(
+            event,
+            "eventId",
+            "event_id",
+            "apiEventId",
+            "sourcingEventId",
+            "rfqId",
+            "id",
+            default="",
+        )
+
+        return {
+            "event_id": str(event_id) if event_id != "" else "",
+            "customer_host_id": _first(
+                event,
+                "customerHostId",
+                "customer_host_id",
+                "chostId",
+                default="",
+            ),
+            "event_name": _first(event, "name", "eventName", "title", "rfxTitle", default=""),
+            "buyer_org": _first(event, "buyerOrg", "buyerOrganization", "owner", "eventOwner", default=""),
+            "deadline": _first(event, "biddingClose", "deadline", "closeDate", "dueDate", default=None),
+            "currency": currency,
+            "line_items": line_items,
+            "estimated_value": total_cents,
+            "mode": mode,
+            "raw_payload": payload,
+        }
+
+    @staticmethod
+    def sourcing_event_to_goods_procurement_terms(
+        payload: dict,
+        default_delivery_days: int = 14,
+        default_net_days: int = 30,
+        mode: str = "push",
+    ) -> dict:
+        """
+        Translate a JAGGAER ASO event into A2CN goods_procurement terms.
+        """
+        event = _event_from_payload(payload)
+        parsed = JaggaerEventParser.parse_sourcing_event(payload, mode=mode)
+        delivery_days = _int_value(
+            _first(event, "deliveryDays", "delivery_days", "leadTimeDays", default=default_delivery_days),
+            default_delivery_days,
+        )
+        net_days = _int_value(
+            _first(event, "paymentTermsNetDays", "netDays", "paymentTermDays", default=default_net_days),
+            default_net_days,
+        )
+        return {
+            "total_value": parsed["estimated_value"],
+            "currency": parsed["currency"],
+            "line_items": [
+                {
+                    key: value
+                    for key, value in item.items()
+                    if key != "currency"
+                }
+                for item in parsed["line_items"]
+            ],
+            "delivery_days": delivery_days,
+            "payment_terms": {"net_days": net_days},
+            "custom_terms": {
+                "jaggaer": {
+                    "event_id": parsed["event_id"],
+                    "customer_host_id": parsed["customer_host_id"],
+                    "source": _first(event, "source", default="jaggaer_aso"),
+                    "mode": mode,
+                }
+            },
+        }
+
+    @staticmethod
+    def sourcing_event_to_session_inputs(
+        payload: dict,
+        max_rounds: int = 5,
+        default_delivery_days: int = 14,
+        mode: str = "push",
+    ) -> dict:
+        """
+        Return both A2CN session params and initial goods_procurement terms.
+        """
+        parsed = JaggaerEventParser.parse_sourcing_event(payload, mode=mode)
+        terms = JaggaerEventParser.sourcing_event_to_goods_procurement_terms(
+            payload,
+            default_delivery_days=default_delivery_days,
+            mode=mode,
+        )
+        return {
+            "event_id": parsed["event_id"],
+            "session_params": {
+                "deal_type": "goods_procurement",
+                "currency": parsed["currency"],
+                "max_rounds": max_rounds,
+                "session_timeout_seconds": 3600,
+                "round_timeout_seconds": 900,
+                "jaggaer_event_id": parsed["event_id"],
+                "jaggaer_customer_host_id": parsed["customer_host_id"],
+                "buyer_org": parsed["buyer_org"],
+            },
+            "initial_terms": terms,
+            "raw_payload": payload,
+        }
+
+
+def a2cn_terms_to_jaggaer_response(
+    agreed_terms: dict,
+    event_id: str,
+    supplier_id: str | None = None,
+    status: str = "submitted",
+) -> dict:
+    """
+    Translate agreed A2CN goods_procurement terms into a JAGGAER bid response.
+    """
+    response_items = []
+    for item in agreed_terms.get("line_items", []):
+        entry: dict = {
+            "itemId": item.get("jaggaer_item_id", item.get("internal_part_number", "")),
+            "lotId": item.get("jaggaer_lot_id", item.get("internal_part_number", "")),
+            "description": item.get("description", ""),
+            "quantity": item.get("quantity", 1),
+            "unitOfMeasure": item.get("unit_of_measure", "EA"),
+            "unitPrice": item.get("unit_price", 0) / 100.0,
+            "totalPrice": item.get("total", 0) / 100.0,
+            "currency": agreed_terms.get("currency", "USD"),
+        }
+        response_items.append({key: value for key, value in entry.items() if value != ""})
+
+    net_days = agreed_terms.get("payment_terms", {}).get("net_days", 30)
+    payload: dict = {
+        "eventId": event_id,
+        "status": status,
+        "currency": agreed_terms.get("currency", "USD"),
+        "totalAmount": agreed_terms.get("total_value", 0) / 100.0,
+        "items": response_items,
+        "deliveryDays": agreed_terms.get("delivery_days", 14),
+        "paymentTerms": f"Net {net_days}",
+    }
+    if supplier_id is not None:
+        payload["supplierId"] = supplier_id
+    return payload
+
+
+def jaggaer_poll_request(
+    customer_host_id: str,
+    user_id: str,
+    base_url: str | None = None,
+) -> dict:
+    """
+    Build the documented ASO CHES request shape for polling customer-host events.
+    """
+    resolved_base_url = (base_url or os.environ.get("JAGGAER_CHES_BASE_URL") or "").rstrip("/")
+    if not resolved_base_url:
+        raise ValueError("JAGGAER_CHES_BASE_URL or base_url is required.")
+    return {
+        "method": "GET",
+        "url": f"{resolved_base_url}/chost/{customer_host_id}/user/{user_id}/apiEvents",
+        "headers": {
+            "Accept": "application/vnd.sciquest.com.ches+json",
+        },
+    }
+
+
+def jaggaer_auth_headers(access_token: str, api_key: str | None = None) -> dict:
+    """
+    Build JAGGAER ASO API auth headers.
+    """
+    key = api_key or os.environ.get("JAGGAER_API_KEY")
+    if not key:
+        raise ValueError("JAGGAER_API_KEY environment variable is required.")
+    return {
+        "Authorization": f"Bearer {access_token}",
+        "X-API-Key": key,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+
+async def fetch_jaggaer_access_token(token_url: str | None = None) -> str:
+    """
+    Fetch an OAuth client-credentials bearer access token for JAGGAER ASO APIs.
+    """
+    client_id = os.environ.get("JAGGAER_CLIENT_ID")
+    client_secret = os.environ.get("JAGGAER_CLIENT_SECRET")
+    api_key = os.environ.get("JAGGAER_API_KEY")
+    resolved_token_url = token_url or os.environ.get("JAGGAER_TOKEN_URL")
+    scope = os.environ.get("JAGGAER_SCOPE")
+    if not client_id or not client_secret or not api_key or not resolved_token_url:
+        raise ValueError(
+            "JAGGAER_CLIENT_ID, JAGGAER_CLIENT_SECRET, JAGGAER_API_KEY, "
+            "and JAGGAER_TOKEN_URL are required."
+        )
+
+    data = {"grant_type": "client_credentials"}
+    if scope:
+        data["scope"] = scope
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            resolved_token_url,
+            data=data,
+            auth=(client_id, client_secret),
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/x-www-form-urlencoded",
+                "X-API-Key": api_key,
+            },
+        )
+    response.raise_for_status()
+    return response.json()["access_token"]

--- a/reference-implementation/python/tests/test_jaggaer_adapter.py
+++ b/reference-implementation/python/tests/test_jaggaer_adapter.py
@@ -1,0 +1,254 @@
+"""Tests for JAGGAER ASO platform adapter."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from a2cn.messages import validate_deal_type_terms
+from adapters.jaggaer_adapter import (
+    JaggaerEventParser,
+    a2cn_terms_to_jaggaer_response,
+    fetch_jaggaer_access_token,
+    jaggaer_auth_headers,
+    jaggaer_poll_request,
+)
+
+
+SAMPLE_JAGGAER_PUSH_EVENT = {
+    "event": {
+        "eventId": "aso-10003",
+        "customerHostId": "275",
+        "name": "Industrial Supplies RFQ",
+        "eventOwner": "Global Manufacturing Inc.",
+        "biddingClose": "2026-08-01T17:00:00Z",
+        "currency": "USD",
+        "deliveryDays": 21,
+        "paymentTermsNetDays": 45,
+        "items": [
+            {
+                "itemId": "10",
+                "lotId": "LOT-HF-001",
+                "description": "Hydraulic fluid 200L drums",
+                "quantity": 50,
+                "unitOfMeasure": "EA",
+                "targetPrice": 360.0,
+            },
+            {
+                "itemId": "20",
+                "lotId": "LOT-SC-002",
+                "description": "Sealing compound 5kg tubs",
+                "quantity": 20,
+                "unitOfMeasure": "KG",
+                "targetPrice": 85.0,
+            },
+        ],
+    }
+}
+
+SAMPLE_JAGGAER_POLLED_EVENT = {
+    "eventId": 10004,
+    "customerHostId": 275,
+    "title": "Public sector pump sourcing event",
+    "buyerOrganization": "City Procurement Office",
+    "closeDate": "2026-09-15T17:00:00Z",
+    "currencyCode": "EUR",
+    "lineItems": {
+        "results": [
+            {
+                "id": "item-001",
+                "lotNumber": "lot-001",
+                "name": "Industrial hydraulic pump",
+                "qty": 10,
+                "uom": "EA",
+                "unitPrice": {"amount": 1500.0, "currency": "EUR"},
+            },
+        ],
+    },
+}
+
+
+def _make_async_client_mock(json_data: dict):
+    mock_response = MagicMock()
+    mock_response.json.return_value = json_data
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+    return mock_cm, mock_client
+
+
+class TestJaggaerEventParser:
+    def test_parse_push_event_payload(self):
+        parsed = JaggaerEventParser.parse_sourcing_event(SAMPLE_JAGGAER_PUSH_EVENT)
+
+        assert parsed["event_id"] == "aso-10003"
+        assert parsed["customer_host_id"] == "275"
+        assert parsed["event_name"] == "Industrial Supplies RFQ"
+        assert parsed["buyer_org"] == "Global Manufacturing Inc."
+        assert parsed["currency"] == "USD"
+        assert parsed["mode"] == "push"
+        assert len(parsed["line_items"]) == 2
+
+    def test_event_to_goods_procurement_terms_converts_prices_to_cents(self):
+        terms = JaggaerEventParser.sourcing_event_to_goods_procurement_terms(
+            SAMPLE_JAGGAER_PUSH_EVENT
+        )
+
+        assert terms["currency"] == "USD"
+        assert terms["delivery_days"] == 21
+        assert terms["payment_terms"]["net_days"] == 45
+        assert terms["line_items"][0]["unit_price"] == 36_000
+        assert terms["line_items"][0]["total"] == 1_800_000
+        assert terms["total_value"] == 1_970_000
+        assert validate_deal_type_terms("goods_procurement", terms) == []
+
+    def test_item_and_lot_ids_are_preserved_for_bid_reconstruction(self):
+        terms = JaggaerEventParser.sourcing_event_to_goods_procurement_terms(
+            SAMPLE_JAGGAER_PUSH_EVENT
+        )
+
+        assert terms["line_items"][0]["internal_part_number"] == "LOT-HF-001"
+        assert terms["line_items"][0]["jaggaer_item_id"] == "10"
+        assert terms["line_items"][0]["jaggaer_lot_id"] == "LOT-HF-001"
+        assert terms["custom_terms"]["jaggaer"]["event_id"] == "aso-10003"
+        assert terms["custom_terms"]["jaggaer"]["source"] == "jaggaer_aso"
+
+    def test_polled_event_aliases_supported(self):
+        parsed = JaggaerEventParser.sourcing_event_to_session_inputs(
+            SAMPLE_JAGGAER_POLLED_EVENT,
+            max_rounds=3,
+            mode="poll",
+        )
+
+        assert parsed["session_params"]["deal_type"] == "goods_procurement"
+        assert parsed["session_params"]["max_rounds"] == 3
+        assert parsed["session_params"]["jaggaer_event_id"] == "10004"
+        assert parsed["session_params"]["jaggaer_customer_host_id"] == 275
+        assert parsed["initial_terms"]["currency"] == "EUR"
+        assert parsed["initial_terms"]["total_value"] == 1_500_000
+        assert parsed["initial_terms"]["custom_terms"]["jaggaer"]["mode"] == "poll"
+        assert validate_deal_type_terms("goods_procurement", parsed["initial_terms"]) == []
+
+    def test_total_price_overrides_computed_line_total_when_present(self):
+        event = {
+            "eventId": "evt-total",
+            "currency": "USD",
+            "items": [
+                {
+                    "itemId": "1",
+                    "description": "Configured assembly",
+                    "quantity": 3,
+                    "unitPrice": 100.0,
+                    "totalPrice": 275.0,
+                },
+            ],
+        }
+
+        terms = JaggaerEventParser.sourcing_event_to_goods_procurement_terms(event)
+
+        assert terms["line_items"][0]["unit_price"] == 10_000
+        assert terms["line_items"][0]["total"] == 27_500
+        assert terms["total_value"] == 27_500
+
+
+class TestJaggaerWriteBackPayloads:
+    def test_terms_to_jaggaer_response_converts_cents_to_dollars(self):
+        terms = JaggaerEventParser.sourcing_event_to_goods_procurement_terms(
+            SAMPLE_JAGGAER_PUSH_EVENT
+        )
+
+        response = a2cn_terms_to_jaggaer_response(
+            terms,
+            event_id="aso-10003",
+            supplier_id="supplier-001",
+        )
+
+        assert response["eventId"] == "aso-10003"
+        assert response["supplierId"] == "supplier-001"
+        assert response["totalAmount"] == 19_700.0
+        assert response["items"][0]["itemId"] == "10"
+        assert response["items"][0]["lotId"] == "LOT-HF-001"
+        assert response["items"][0]["unitPrice"] == 360.0
+        assert response["items"][0]["totalPrice"] == 18_000.0
+        assert response["paymentTerms"] == "Net 45"
+
+    def test_poll_request_builds_customer_host_api_events_path(self):
+        request = jaggaer_poll_request(
+            customer_host_id="275",
+            user_id="user-123",
+            base_url="https://ches.demo-api.example.com/",
+        )
+
+        assert request == {
+            "method": "GET",
+            "url": "https://ches.demo-api.example.com/chost/275/user/user-123/apiEvents",
+            "headers": {
+                "Accept": "application/vnd.sciquest.com.ches+json",
+            },
+        }
+
+
+class TestJaggaerAuthHelpers:
+    def test_jaggaer_auth_headers_include_api_key(self):
+        headers = jaggaer_auth_headers("access-token", api_key="api-key")
+
+        assert headers["Authorization"] == "Bearer access-token"
+        assert headers["X-API-Key"] == "api-key"
+        assert headers["Accept"] == "application/json"
+
+    def test_jaggaer_auth_headers_reads_api_key_from_env(self):
+        with patch.dict(os.environ, {"JAGGAER_API_KEY": "env-api-key"}):
+            headers = jaggaer_auth_headers("access-token")
+
+        assert headers["X-API-Key"] == "env-api-key"
+
+    def test_jaggaer_auth_headers_require_api_key(self):
+        env = {k: v for k, v in os.environ.items() if k != "JAGGAER_API_KEY"}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValueError, match="JAGGAER_API_KEY"):
+                jaggaer_auth_headers("access-token")
+
+    @pytest.mark.asyncio
+    async def test_fetch_jaggaer_access_token_uses_client_credentials(self):
+        mock_cm, mock_client = _make_async_client_mock({"access_token": "token-123"})
+        with patch("adapters.jaggaer_adapter.httpx.AsyncClient", return_value=mock_cm):
+            with patch.dict(os.environ, {
+                "JAGGAER_CLIENT_ID": "client-id",
+                "JAGGAER_CLIENT_SECRET": "client-secret",
+                "JAGGAER_API_KEY": "api-key",
+                "JAGGAER_TOKEN_URL": "https://auth.demo-api.example.com/oauth2/token",
+            }):
+                token = await fetch_jaggaer_access_token()
+
+        assert token == "token-123"
+        _, kwargs = mock_client.post.call_args
+        assert kwargs["data"] == {"grant_type": "client_credentials"}
+        assert kwargs["auth"] == ("client-id", "client-secret")
+        assert kwargs["headers"]["X-API-Key"] == "api-key"
+
+    @pytest.mark.asyncio
+    async def test_fetch_jaggaer_access_token_includes_scope_when_present(self):
+        mock_cm, mock_client = _make_async_client_mock({"access_token": "token-123"})
+        with patch("adapters.jaggaer_adapter.httpx.AsyncClient", return_value=mock_cm):
+            with patch.dict(os.environ, {
+                "JAGGAER_CLIENT_ID": "client-id",
+                "JAGGAER_CLIENT_SECRET": "client-secret",
+                "JAGGAER_API_KEY": "api-key",
+                "JAGGAER_SCOPE": "tenant-aso 275",
+            }):
+                token = await fetch_jaggaer_access_token(
+                    token_url="https://auth.demo-api.example.com/oauth2/token"
+                )
+
+        assert token == "token-123"
+        _, kwargs = mock_client.post.call_args
+        assert kwargs["data"] == {
+            "grant_type": "client_credentials",
+            "scope": "tenant-aso 275",
+        }


### PR DESCRIPTION
## Summary

Implements A2C-87 by adding a JAGGAER ASO adapter for the buy-side goods procurement flow:

- Adds `JaggaerEventParser` for push-webhook and ASO poll event shapes, mapping sourcing events into A2CN `goods_procurement` terms.
- Adds `a2cn_terms_to_jaggaer_response()` for converting agreed A2CN terms back into a JAGGAER bid-response payload while preserving distinct item and lot IDs.
- Adds OAuth/client-credentials helpers and a CHES `apiEvents` poll request builder.
- Adds `JAGGAER_INTEGRATION.md` covering push vs request/response paths, env vars, auth headers, and live integration limits.
- Adds offline unit tests for parsing, cents conversion, schema validation, response mapping, poll request shape, and token/header helpers.

## Validation

- `uv run pytest tests/test_jaggaer_adapter.py -q` -> 12 passed
- `uv run pytest -q` -> 438 passed
- `uv run python -m py_compile adapters/jaggaer_adapter.py tests/test_jaggaer_adapter.py`
- `git diff --check`