### PR TITLE
Add Conga CPQ CLM adapter

### DIFF
--- a/reference-implementation/python/adapters/CONGA_INTEGRATION.md
+++ b/reference-implementation/python/adapters/CONGA_INTEGRATION.md
@@ -1,0 +1,157 @@
+# Conga CPQ/CLM - A2CN Integration Guide
+
+Conga is a sell-side CPQ and CLM platform. This adapter maps Conga CPQ
+quote/cart payloads into A2CN `saas_renewal` or `goods_procurement` terms and
+maps agreed A2CN terms back into Conga-shaped quote update payloads. It also
+provides a small CLM agreement metadata payload for linking the final contract
+workflow to an A2CN transaction record.
+
+Public docs used:
+
+- Conga Documentation Portal
+  - CPQ REST API Version 5
+  - CPQ REST API areas including Quote, Cart Items, Order, and Assets
+  - Example cart paths such as `POST /api/cart/v1/carts/{cartId}/items`
+  - CLM for REST API Developers
+- Conga Developer Portal
+  - Advantage Platform REST API Introduction
+  - RESTful URLs, JSON messaging, and standard HTTP response codes
+- Conga Salesforce pages
+  - Conga CPQ and CLM are available as Salesforce-native products
+
+Conga deployments can be Salesforce-native or Advantage Platform-native. The
+adapter deliberately accepts tolerant field aliases so the same A2CN mapping can
+sit behind either tenant shape.
+
+---
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `CONGA_CLIENT_ID` | OAuth client ID for Conga or Salesforce-connected app access |
+| `CONGA_CLIENT_SECRET` | OAuth client secret |
+| `CONGA_TOKEN_URL` | OAuth token URL for the Conga/Salesforce environment |
+| `CONGA_SCOPE` | Optional OAuth scope for Advantage Platform tenants |
+| `CONGA_INSTANCE_URL` | Conga or Salesforce instance base URL |
+| `CONGA_CPQ_BASE_URL` | Optional CPQ REST base URL override |
+| `CONGA_CLM_BASE_URL` | Optional CLM REST base URL override |
+
+---
+
+## Path A - CPQ Quote to A2CN Session
+
+When a Conga quote reaches a negotiation-ready stage, tenant middleware can load
+the quote through the Conga CPQ REST APIs and convert it into A2CN terms:
+
+```python
+from adapters.conga_adapter import CongaAdapter
+
+quote = {
+    "id": "conga-q-001",
+    "accountId": "001xx000003DGbY",
+    "currency": "USD",
+    "lineItems": [
+        {"id": "qli-001", "productId": "prod-001",
+         "productName": "Enterprise Subscription License",
+         "quantity": 100, "unitPrice": 950.0, "totalPrice": 95000.0},
+    ],
+}
+
+parsed = CongaAdapter.quote_to_session_inputs(quote)
+session_params = parsed["session_params"]
+initial_terms = parsed["initial_terms"]
+```
+
+The adapter classifies subscription-like quotes as `saas_renewal` using product
+or charge-type keywords such as `subscription`, `license`, `seat`, and
+`renewal`. Otherwise, it emits `goods_procurement` with `delivery_days`.
+
+All monetary values are converted from decimal dollars into integer cents for
+A2CN.
+
+---
+
+## Path B - A2CN Agreement to Conga Quote Update
+
+After the A2CN session completes, convert the agreed terms back into a
+Conga-shaped update payload:
+
+```python
+from adapters.conga_adapter import a2cn_terms_to_conga_quote
+
+payload = a2cn_terms_to_conga_quote(
+    agreed_terms,
+    quote_id="conga-q-001",
+    agreement_id="clm-agreement-001",
+)
+```
+
+The payload preserves `conga_line_item_id` and `conga_product_id` from the
+original quote so middleware can update the correct Conga quote line records.
+Prices are converted back from A2CN cents into decimal values.
+
+---
+
+## CLM Agreement Linkage
+
+For formalization in Conga CLM, use `conga_agreement_update_payload()` to link
+the Conga agreement to the A2CN transaction record:
+
+```python
+from adapters.conga_adapter import conga_agreement_update_payload
+
+metadata = conga_agreement_update_payload(
+    agreement_id="clm-agreement-001",
+    a2cn_session_id="sess-001",
+    record_hash="record-hash",
+)
+```
+
+The canonical commercial agreement remains the A2CN transaction record, while
+Conga owns document generation, contracting workflow, approvals, and CLM
+execution.
+
+---
+
+## Revenue Cloud Synergy
+
+Conga’s Salesforce-native deployments share the same broad CRM data model shape
+as the existing `RevenueCloudAdapter`: account IDs, opportunity IDs, quote line
+items, product IDs, quantity, unit price, total price, and contract dates. That
+means existing A2CN Revenue Cloud orchestration can usually reuse:
+
+- Salesforce OAuth / connected-app credential handling
+- account and opportunity resolution
+- product and pricebook lookup
+- downstream quote/order formalization patterns
+
+For Advantage Platform tenants, use the same A2CN terms mapping but configure
+the Conga-specific base URLs and token endpoint.
+
+---
+
+## Auth Helpers
+
+`fetch_conga_access_token()` implements OAuth client-credentials token retrieval
+using `CONGA_CLIENT_ID`, `CONGA_CLIENT_SECRET`, and `CONGA_TOKEN_URL`, with
+optional `CONGA_SCOPE`.
+
+`conga_auth_headers(access_token)` creates headers with:
+
+- `Authorization: Bearer ...`
+- `Accept: application/json`
+- `Content-Type: application/json`
+
+---
+
+## Known Limitations
+
+- Conga CPQ/CLM field names vary across Salesforce-native and Advantage
+  Platform tenants. The adapter accepts common aliases, but production
+  deployments should provide a `field_map` for tenant-specific API names.
+- This module performs no quote, cart, agreement, or document network writes.
+  Tenant middleware should own retries, lifecycle actions, and final API calls.
+- The subscription-vs-goods classifier is intentionally conservative and based
+  on quote-line metadata. Production deployments can pass an explicit field map
+  or pre-classify the quote before starting A2CN.

--- a/reference-implementation/python/adapters/conga_adapter.py
+++ b/reference-implementation/python/adapters/conga_adapter.py
@@ -349,7 +349,7 @@ def conga_quote_to_a2cn_terms(
             default=None,
         )
         if term_months is not None:
-            terms["contract_term_months"] = _int_value(term_months)
+            terms["term_months"] = _int_value(term_months)
     else:
         terms["delivery_days"] = _int_value(_first(
             quote,
@@ -404,8 +404,8 @@ def a2cn_terms_to_conga_quote(
         payload["startDate"] = duration["start_date"]
     if duration.get("end_date"):
         payload["endDate"] = duration["end_date"]
-    if agreed_terms.get("contract_term_months"):
-        payload["termMonths"] = agreed_terms["contract_term_months"]
+    if agreed_terms.get("term_months"):
+        payload["termMonths"] = agreed_terms["term_months"]
     return payload
 
 

--- a/reference-implementation/python/adapters/conga_adapter.py
+++ b/reference-implementation/python/adapters/conga_adapter.py
@@ -1,0 +1,466 @@
+"""
+Conga CPQ/CLM -> A2CN translation layer.
+
+Translates Conga CPQ quote / cart payloads into A2CN terms, and translates
+agreed A2CN terms back into Conga quote update payloads.
+
+Public documentation used for this adapter:
+  Conga Documentation Portal:
+    CPQ REST API Version 5 - Quote, Cart Items, Order, Assets
+    CLM for REST API Developers - agreement records and lifecycle actions
+  Conga Developer Portal:
+    Advantage Platform REST APIs use predictable REST URLs and JSON payloads
+
+No core protocol changes are required. This module keeps platform mapping
+offline-testable, while auth helpers document the Salesforce/Advantage OAuth
+shape used by live Conga integrations.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+
+_SUBSCRIPTION_KEYWORDS = frozenset({
+    "license",
+    "subscription",
+    "seat",
+    "renewal",
+    "term",
+})
+
+
+def _money_to_cents(value: Any) -> int:
+    if value is None or value == "":
+        return 0
+    if isinstance(value, dict):
+        value = value.get("amount", value.get("value", 0))
+    return int(float(value) * 100)
+
+
+def _int_value(value: Any, default: int = 0) -> int:
+    if value is None or value == "":
+        return default
+    return int(float(value))
+
+
+def _first(mapping: dict, *names: str, default: Any = None) -> Any:
+    for name in names:
+        if name in mapping and mapping[name] is not None:
+            return mapping[name]
+    return default
+
+
+def _line_items_from_quote(quote: dict, field_map: dict) -> list[dict]:
+    items = _first(
+        quote,
+        field_map["line_items_field"],
+        "lineItems",
+        "LineItems",
+        "quoteLineItems",
+        "cartItems",
+        "items",
+        "records",
+        default=[],
+    )
+    if isinstance(items, dict):
+        items = (
+            items.get("lineItems")
+            or items.get("quoteLineItems")
+            or items.get("cartItems")
+            or items.get("records")
+            or items.get("items")
+            or []
+        )
+    return list(items)
+
+
+def _is_subscription_item(item: dict, field_map: dict) -> bool:
+    product_name = str(_first(
+        item,
+        field_map["product_name_field"],
+        "productName",
+        "ProductName",
+        "Name",
+        "Description",
+        "Apttus_Config2__Description__c",
+        default="",
+    )).lower()
+    charge_type = str(_first(
+        item,
+        "chargeType",
+        "ChargeType",
+        "pricingType",
+        "Apttus_Config2__ChargeType__c",
+        default="",
+    )).lower()
+    return any(keyword in product_name or keyword in charge_type for keyword in _SUBSCRIPTION_KEYWORDS)
+
+
+class CongaAdapter:
+    """
+    Translates Conga CPQ / CLM records into A2CN session terms and write-back
+    payloads.
+    """
+
+    DEFAULT_FIELD_MAP: dict[str, str] = {
+        "quote_id_field": "id",
+        "agreement_id_field": "agreementId",
+        "account_id_field": "accountId",
+        "opportunity_id_field": "opportunityId",
+        "total_value_field": "totalAmount",
+        "currency_field": "currency",
+        "line_items_field": "lineItems",
+        "line_item_id_field": "id",
+        "product_id_field": "productId",
+        "product_name_field": "productName",
+        "quantity_field": "quantity",
+        "unit_price_field": "unitPrice",
+        "total_price_field": "totalPrice",
+        "unit_of_measure_field": "unitOfMeasure",
+        "start_date_field": "startDate",
+        "end_date_field": "endDate",
+        "term_months_field": "termMonths",
+    }
+
+    @staticmethod
+    def quote_to_session_inputs(
+        quote: dict,
+        max_rounds: int = 5,
+        field_map: dict | None = None,
+        default_delivery_days: int = 14,
+    ) -> dict:
+        """
+        Return both A2CN session params and initial terms for a Conga quote.
+        """
+        fm = {**CongaAdapter.DEFAULT_FIELD_MAP, **(field_map or {})}
+        terms = conga_quote_to_a2cn_terms(
+            quote,
+            field_map=fm,
+            default_delivery_days=default_delivery_days,
+        )
+        quote_id = _first(
+            quote,
+            fm["quote_id_field"],
+            "quoteId",
+            "QuoteId",
+            "Id",
+            "Apttus_Proposal__Proposal__c",
+            default="",
+        )
+        return {
+            "quote_id": str(quote_id) if quote_id != "" else "",
+            "session_params": {
+                "deal_type": "saas_renewal" if "seat_count" in terms else "goods_procurement",
+                "currency": terms.get("currency", "USD"),
+                "max_rounds": max_rounds,
+                "session_timeout_seconds": 3600,
+                "round_timeout_seconds": 900,
+                "conga_quote_id": str(quote_id) if quote_id != "" else "",
+                "conga_account_id": _first(
+                    quote,
+                    fm["account_id_field"],
+                    "account",
+                    "AccountId",
+                    "Apttus_Proposal__Account__c",
+                    default="",
+                ),
+                "conga_opportunity_id": _first(
+                    quote,
+                    fm["opportunity_id_field"],
+                    "opportunity",
+                    "OpportunityId",
+                    "Apttus_Proposal__Opportunity__c",
+                    default="",
+                ),
+            },
+            "initial_terms": terms,
+            "raw_payload": quote,
+        }
+
+
+def conga_quote_to_a2cn_terms(
+    quote: dict,
+    field_map: dict | None = None,
+    default_delivery_days: int = 14,
+    default_net_days: int = 30,
+) -> dict:
+    """
+    Translate a Conga CPQ quote/cart response into A2CN terms.
+
+    The default field map accepts simple REST JSON names while the alias list
+    covers common Conga/Salesforce-style names for quote and line-item records.
+    """
+    fm = {**CongaAdapter.DEFAULT_FIELD_MAP, **(field_map or {})}
+    items_raw = _line_items_from_quote(quote, fm)
+    line_items: list[dict] = []
+    total_cents = 0
+
+    for item in items_raw:
+        quantity = _int_value(_first(
+            item,
+            fm["quantity_field"],
+            "Quantity",
+            "Apttus_Config2__Quantity__c",
+            default=1,
+        ), 1)
+        unit_price_cents = _money_to_cents(_first(
+            item,
+            fm["unit_price_field"],
+            "UnitPrice",
+            "netUnitPrice",
+            "NetUnitPrice",
+            "ListPrice",
+            "Apttus_Config2__NetUnitPrice__c",
+            "Apttus_Config2__NetPrice__c",
+            default=0,
+        ))
+        total_raw = _first(
+            item,
+            fm["total_price_field"],
+            "netAmount",
+            "NetAmount",
+            "TotalPrice",
+            "lineTotal",
+            "Apttus_Config2__NetAmount__c",
+            default=None,
+        )
+        line_total = _money_to_cents(total_raw) if total_raw is not None else quantity * unit_price_cents
+        total_cents += line_total
+        line_item: dict = {
+            "description": _first(
+                item,
+                fm["product_name_field"],
+                "ProductName",
+                "Name",
+                "Description",
+                "Apttus_Config2__Description__c",
+                default="",
+            ),
+            "quantity": quantity,
+            "unit_price": unit_price_cents,
+            "total": line_total,
+        }
+        uom = _first(item, fm["unit_of_measure_field"], "Uom", "uom", default=None)
+        if uom:
+            line_item["unit_of_measure"] = str(uom)
+        line_id = _first(
+            item,
+            fm["line_item_id_field"],
+            "lineItemId",
+            "LineItemId",
+            "Id",
+            "Apttus_Config2__LineItemId__c",
+            default="",
+        )
+        product_id = _first(
+            item,
+            fm["product_id_field"],
+            "ProductId",
+            "product",
+            "Apttus_Config2__ProductId__c",
+            default="",
+        )
+        if line_id:
+            line_item["conga_line_item_id"] = str(line_id)
+            line_item["internal_part_number"] = str(line_id)
+        if product_id:
+            line_item["conga_product_id"] = str(product_id)
+        line_items.append(line_item)
+
+    header_total_cents = _money_to_cents(_first(
+        quote,
+        fm["total_value_field"],
+        "grandTotal",
+        "netAmount",
+        "totalPrice",
+        "TotalPrice",
+        "NetAmount",
+        "GrandTotal",
+        "Apttus_Proposal__Net_Amount__c",
+        default=0,
+    ))
+    total_cents = total_cents or header_total_cents
+    currency = str(_first(
+        quote,
+        fm["currency_field"],
+        "currencyCode",
+        "CurrencyCode",
+        "currencyIsoCode",
+        "CurrencyIsoCode",
+        "Apttus_Proposal__CurrencyIsoCode__c",
+        default="USD",
+    ))
+
+    deal_type = "saas_renewal" if any(_is_subscription_item(item, fm) for item in items_raw) else "goods_procurement"
+    terms: dict = {
+        "total_value": total_cents,
+        "currency": currency,
+        "line_items": line_items,
+        "payment_terms": {"net_days": _int_value(_first(
+            quote,
+            "paymentTermsNetDays",
+            "netDays",
+            "paymentTermDays",
+            default=default_net_days,
+        ), default_net_days)},
+        "custom_terms": {
+            "conga": {
+                "quote_id": str(_first(quote, fm["quote_id_field"], "quoteId", "Id", default="")),
+                "agreement_id": str(_first(quote, fm["agreement_id_field"], "AgreementId", "contractId", default="")),
+                "source": str(_first(quote, "source", default="conga_cpq")),
+            }
+        },
+    }
+
+    start_date = _first(quote, fm["start_date_field"], "StartDate", "effectiveDate", default=None)
+    end_date = _first(quote, fm["end_date_field"], "EndDate", "expirationDate", default=None)
+    if start_date and end_date:
+        terms["contract_duration"] = {
+            "start_date": start_date,
+            "end_date": end_date,
+        }
+
+    if deal_type == "saas_renewal":
+        terms["seat_count"] = _int_value(_first(
+            items_raw[0] if items_raw else {},
+            fm["quantity_field"],
+            "Quantity",
+            "Apttus_Config2__Quantity__c",
+            default=1,
+        ), 1)
+        first_item = items_raw[0] if items_raw else {}
+        terms["subscription_tier"] = str(_first(
+            first_item,
+            fm["product_name_field"],
+            "ProductName",
+            "Name",
+            default="",
+        ))
+        term_months = _first(
+            quote,
+            fm["term_months_field"],
+            "sellingTerm",
+            "SellingTerm",
+            "Apttus_QPConfig__ProposalTerm__c",
+            default=None,
+        )
+        if term_months is not None:
+            terms["contract_term_months"] = _int_value(term_months)
+    else:
+        terms["delivery_days"] = _int_value(_first(
+            quote,
+            "deliveryDays",
+            "delivery_days",
+            "leadTimeDays",
+            default=default_delivery_days,
+        ), default_delivery_days)
+
+    return terms
+
+
+def a2cn_terms_to_conga_quote(
+    agreed_terms: dict,
+    quote_id: str,
+    agreement_id: str | None = None,
+    status: str = "Accepted",
+) -> dict:
+    """
+    Translate agreed A2CN terms into a Conga quote update payload.
+    """
+    line_items = []
+    for item in agreed_terms.get("line_items", []):
+        entry: dict = {
+            "id": item.get("conga_line_item_id", item.get("internal_part_number", "")),
+            "productId": item.get("conga_product_id", ""),
+            "description": item.get("description", ""),
+            "quantity": item.get("quantity", 1),
+            "unitPrice": item.get("unit_price", 0) / 100.0,
+            "totalPrice": item.get("total", 0) / 100.0,
+        }
+        if item.get("unit_of_measure"):
+            entry["unitOfMeasure"] = item["unit_of_measure"]
+        line_items.append({key: value for key, value in entry.items() if value != ""})
+
+    payload: dict = {
+        "quoteId": quote_id,
+        "status": status,
+        "currency": agreed_terms.get("currency", "USD"),
+        "totalAmount": agreed_terms.get("total_value", 0) / 100.0,
+        "lineItems": line_items,
+        "paymentTerms": f"Net {agreed_terms.get('payment_terms', {}).get('net_days', 30)}",
+    }
+    if agreement_id is not None:
+        payload["agreementId"] = agreement_id
+    if "seat_count" in agreed_terms:
+        payload["seatCount"] = agreed_terms["seat_count"]
+    if "delivery_days" in agreed_terms:
+        payload["deliveryDays"] = agreed_terms["delivery_days"]
+    duration = agreed_terms.get("contract_duration", {})
+    if duration.get("start_date"):
+        payload["startDate"] = duration["start_date"]
+    if duration.get("end_date"):
+        payload["endDate"] = duration["end_date"]
+    if agreed_terms.get("contract_term_months"):
+        payload["termMonths"] = agreed_terms["contract_term_months"]
+    return payload
+
+
+def conga_agreement_update_payload(
+    agreement_id: str,
+    a2cn_session_id: str,
+    record_hash: str,
+    status: str = "Ready for Contracting",
+) -> dict:
+    """
+    Build a CLM agreement metadata update payload linked to an A2CN record.
+    """
+    return {
+        "agreementId": agreement_id,
+        "status": status,
+        "externalReferences": {
+            "a2cn_session_id": a2cn_session_id,
+            "a2cn_record_hash": record_hash,
+        },
+    }
+
+
+def conga_auth_headers(access_token: str) -> dict:
+    """
+    Build Conga REST API auth headers for Salesforce or Advantage API calls.
+    """
+    return {
+        "Authorization": f"Bearer {access_token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+
+async def fetch_conga_access_token(token_url: str | None = None) -> str:
+    """
+    Fetch an OAuth client-credentials bearer token for Conga REST APIs.
+    """
+    client_id = os.environ.get("CONGA_CLIENT_ID")
+    client_secret = os.environ.get("CONGA_CLIENT_SECRET")
+    resolved_token_url = token_url or os.environ.get("CONGA_TOKEN_URL")
+    scope = os.environ.get("CONGA_SCOPE")
+    if not client_id or not client_secret or not resolved_token_url:
+        raise ValueError(
+            "CONGA_CLIENT_ID, CONGA_CLIENT_SECRET, and CONGA_TOKEN_URL are required."
+        )
+
+    data = {"grant_type": "client_credentials"}
+    if scope:
+        data["scope"] = scope
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            resolved_token_url,
+            data=data,
+            auth=(client_id, client_secret),
+            headers={"Accept": "application/json"},
+        )
+    response.raise_for_status()
+    return response.json()["access_token"]

--- a/reference-implementation/python/tests/test_conga_adapter.py
+++ b/reference-implementation/python/tests/test_conga_adapter.py
@@ -1,0 +1,290 @@
+"""Tests for Conga CPQ/CLM platform adapter."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from a2cn.messages import validate_deal_type_terms
+from adapters.conga_adapter import (
+    CongaAdapter,
+    a2cn_terms_to_conga_quote,
+    conga_agreement_update_payload,
+    conga_auth_headers,
+    conga_quote_to_a2cn_terms,
+    fetch_conga_access_token,
+)
+
+
+SAMPLE_CONGA_SAAS_QUOTE = {
+    "id": "conga-q-001",
+    "agreementId": "clm-agreement-001",
+    "accountId": "001xx000003DGbY",
+    "opportunityId": "006xx000004TqVQ",
+    "currency": "USD",
+    "startDate": "2026-07-01",
+    "endDate": "2027-06-30",
+    "termMonths": 12,
+    "paymentTermsNetDays": 45,
+    "lineItems": [
+        {
+            "id": "qli-001",
+            "productId": "prod-001",
+            "productName": "Enterprise Subscription License",
+            "quantity": 100,
+            "unitPrice": 950.0,
+            "totalPrice": 95_000.0,
+        },
+        {
+            "id": "qli-002",
+            "productId": "prod-002",
+            "productName": "Premium Support",
+            "quantity": 1,
+            "unitPrice": 5_000.0,
+            "totalPrice": 5_000.0,
+        },
+    ],
+}
+
+SAMPLE_CONGA_GOODS_QUOTE = {
+    "Id": "a1Qxx0000009abc",
+    "CurrencyIsoCode": "EUR",
+    "deliveryDays": 21,
+    "records": [
+        {
+            "Id": "a2Lxx0000001",
+            "ProductId": "01txx0000001",
+            "Name": "Hydraulic fluid 200L drums",
+            "Quantity": 50,
+            "NetUnitPrice": 360.0,
+            "NetAmount": 18_000.0,
+            "Uom": "EA",
+        },
+    ],
+}
+
+
+def _make_async_client_mock(json_data: dict):
+    mock_response = MagicMock()
+    mock_response.json.return_value = json_data
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+    return mock_cm, mock_client
+
+
+class TestCongaQuoteToTerms:
+    def test_saas_quote_maps_to_saas_renewal_terms(self):
+        terms = conga_quote_to_a2cn_terms(SAMPLE_CONGA_SAAS_QUOTE)
+
+        assert terms["currency"] == "USD"
+        assert terms["total_value"] == 10_000_000
+        assert terms["seat_count"] == 100
+        assert terms["subscription_tier"] == "Enterprise Subscription License"
+        assert terms["contract_term_months"] == 12
+        assert terms["payment_terms"]["net_days"] == 45
+        assert terms["contract_duration"] == {
+            "start_date": "2026-07-01",
+            "end_date": "2027-06-30",
+        }
+        assert validate_deal_type_terms("saas_renewal", terms) == []
+
+    def test_line_item_ids_and_product_ids_are_preserved(self):
+        terms = conga_quote_to_a2cn_terms(SAMPLE_CONGA_SAAS_QUOTE)
+
+        assert terms["line_items"][0]["conga_line_item_id"] == "qli-001"
+        assert terms["line_items"][0]["conga_product_id"] == "prod-001"
+        assert terms["line_items"][0]["internal_part_number"] == "qli-001"
+        assert terms["custom_terms"]["conga"]["quote_id"] == "conga-q-001"
+        assert terms["custom_terms"]["conga"]["agreement_id"] == "clm-agreement-001"
+
+    def test_goods_quote_maps_to_goods_procurement_terms(self):
+        terms = conga_quote_to_a2cn_terms(SAMPLE_CONGA_GOODS_QUOTE)
+
+        assert terms["currency"] == "EUR"
+        assert terms["delivery_days"] == 21
+        assert terms["line_items"][0]["description"] == "Hydraulic fluid 200L drums"
+        assert terms["line_items"][0]["unit_of_measure"] == "EA"
+        assert terms["line_items"][0]["unit_price"] == 36_000
+        assert terms["line_items"][0]["total"] == 1_800_000
+        assert validate_deal_type_terms("goods_procurement", terms) == []
+
+    def test_header_total_used_when_line_items_have_no_prices(self):
+        quote = {
+            "id": "conga-q-empty-price",
+            "totalAmount": 7_500.0,
+            "currency": "USD",
+            "lineItems": [
+                {"productName": "Widget", "quantity": 1, "unitPrice": 0.0, "totalPrice": 0.0},
+            ],
+        }
+
+        terms = conga_quote_to_a2cn_terms(quote)
+
+        assert terms["total_value"] == 750_000
+
+    def test_custom_field_map_overrides_tenant_names(self):
+        quote = {
+            "quote_total": 5_000.0,
+            "ccy": "GBP",
+            "rows": [
+                {"label": "Widget Pro", "qty": 10, "price": 500.0, "row_total": 5_000.0},
+            ],
+        }
+        field_map = {
+            "total_value_field": "quote_total",
+            "currency_field": "ccy",
+            "line_items_field": "rows",
+            "product_name_field": "label",
+            "quantity_field": "qty",
+            "unit_price_field": "price",
+            "total_price_field": "row_total",
+        }
+
+        terms = conga_quote_to_a2cn_terms(quote, field_map=field_map)
+
+        assert terms["currency"] == "GBP"
+        assert terms["line_items"][0]["description"] == "Widget Pro"
+        assert terms["line_items"][0]["quantity"] == 10
+        assert terms["line_items"][0]["unit_price"] == 50_000
+
+    def test_advantage_platform_casing_aliases_supported(self):
+        quote = {
+            "Id": "cart-001",
+            "CurrencyCode": "CAD",
+            "LineItems": [
+                {
+                    "Id": "line-001",
+                    "ProductName": "Managed Service Subscription",
+                    "Quantity": 2,
+                    "UnitPrice": 1_200.0,
+                    "TotalPrice": 2_400.0,
+                },
+            ],
+        }
+
+        terms = conga_quote_to_a2cn_terms(quote)
+
+        assert terms["currency"] == "CAD"
+        assert terms["total_value"] == 240_000
+        assert terms["seat_count"] == 2
+        assert terms["line_items"][0]["unit_price"] == 120_000
+
+
+class TestCongaSessionAndWriteBack:
+    def test_quote_to_session_inputs_sets_saas_deal_type(self):
+        parsed = CongaAdapter.quote_to_session_inputs(SAMPLE_CONGA_SAAS_QUOTE, max_rounds=3)
+
+        assert parsed["quote_id"] == "conga-q-001"
+        assert parsed["session_params"]["deal_type"] == "saas_renewal"
+        assert parsed["session_params"]["max_rounds"] == 3
+        assert parsed["session_params"]["conga_quote_id"] == "conga-q-001"
+        assert parsed["session_params"]["conga_account_id"] == "001xx000003DGbY"
+        assert parsed["session_params"]["conga_opportunity_id"] == "006xx000004TqVQ"
+
+    def test_a2cn_terms_to_conga_quote_converts_cents_to_dollars(self):
+        terms = conga_quote_to_a2cn_terms(SAMPLE_CONGA_SAAS_QUOTE)
+
+        payload = a2cn_terms_to_conga_quote(
+            terms,
+            quote_id="conga-q-001",
+            agreement_id="clm-agreement-001",
+        )
+
+        assert payload["quoteId"] == "conga-q-001"
+        assert payload["agreementId"] == "clm-agreement-001"
+        assert payload["totalAmount"] == 100_000.0
+        assert payload["seatCount"] == 100
+        assert payload["termMonths"] == 12
+        assert payload["lineItems"][0]["id"] == "qli-001"
+        assert payload["lineItems"][0]["productId"] == "prod-001"
+        assert payload["lineItems"][0]["unitPrice"] == 950.0
+        assert payload["lineItems"][0]["totalPrice"] == 95_000.0
+        assert payload["paymentTerms"] == "Net 45"
+
+    def test_goods_terms_to_conga_quote_includes_delivery_days(self):
+        terms = conga_quote_to_a2cn_terms(SAMPLE_CONGA_GOODS_QUOTE)
+
+        payload = a2cn_terms_to_conga_quote(terms, quote_id="a1Qxx0000009abc")
+
+        assert payload["deliveryDays"] == 21
+        assert payload["lineItems"][0]["id"] == "a2Lxx0000001"
+        assert payload["lineItems"][0]["unitOfMeasure"] == "EA"
+
+    def test_agreement_update_payload_links_a2cn_record(self):
+        payload = conga_agreement_update_payload(
+            agreement_id="clm-agreement-001",
+            a2cn_session_id="sess-001",
+            record_hash="record-hash",
+        )
+
+        assert payload == {
+            "agreementId": "clm-agreement-001",
+            "status": "Ready for Contracting",
+            "externalReferences": {
+                "a2cn_session_id": "sess-001",
+                "a2cn_record_hash": "record-hash",
+            },
+        }
+
+
+class TestCongaAuthHelpers:
+    def test_conga_auth_headers(self):
+        headers = conga_auth_headers("access-token")
+
+        assert headers["Authorization"] == "Bearer access-token"
+        assert headers["Accept"] == "application/json"
+        assert headers["Content-Type"] == "application/json"
+
+    @pytest.mark.asyncio
+    async def test_fetch_conga_access_token_requires_env(self):
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in {"CONGA_CLIENT_ID", "CONGA_CLIENT_SECRET", "CONGA_TOKEN_URL"}
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValueError, match="CONGA_CLIENT_ID"):
+                await fetch_conga_access_token()
+
+    @pytest.mark.asyncio
+    async def test_fetch_conga_access_token_uses_client_credentials(self):
+        mock_cm, mock_client = _make_async_client_mock({"access_token": "token-123"})
+        with patch("adapters.conga_adapter.httpx.AsyncClient", return_value=mock_cm):
+            with patch.dict(os.environ, {
+                "CONGA_CLIENT_ID": "client-id",
+                "CONGA_CLIENT_SECRET": "client-secret",
+                "CONGA_TOKEN_URL": "https://auth.example.com/oauth2/token",
+            }):
+                token = await fetch_conga_access_token()
+
+        assert token == "token-123"
+        _, kwargs = mock_client.post.call_args
+        assert kwargs["data"] == {"grant_type": "client_credentials"}
+        assert kwargs["auth"] == ("client-id", "client-secret")
+
+    @pytest.mark.asyncio
+    async def test_fetch_conga_access_token_includes_scope_when_present(self):
+        mock_cm, mock_client = _make_async_client_mock({"access_token": "token-123"})
+        with patch("adapters.conga_adapter.httpx.AsyncClient", return_value=mock_cm):
+            with patch.dict(os.environ, {
+                "CONGA_CLIENT_ID": "client-id",
+                "CONGA_CLIENT_SECRET": "client-secret",
+                "CONGA_SCOPE": "api cpq",
+            }):
+                token = await fetch_conga_access_token(
+                    token_url="https://auth.example.com/oauth2/token"
+                )
+
+        assert token == "token-123"
+        _, kwargs = mock_client.post.call_args
+        assert kwargs["data"] == {
+            "grant_type": "client_credentials",
+            "scope": "api cpq",
+        }

--- a/reference-implementation/python/tests/test_conga_adapter.py
+++ b/reference-implementation/python/tests/test_conga_adapter.py
@@ -87,7 +87,8 @@ class TestCongaQuoteToTerms:
         assert terms["total_value"] == 10_000_000
         assert terms["seat_count"] == 100
         assert terms["subscription_tier"] == "Enterprise Subscription License"
-        assert terms["contract_term_months"] == 12
+        assert terms["term_months"] == 12
+        assert "contract_term_months" not in terms
         assert terms["payment_terms"]["net_days"] == 45
         assert terms["contract_duration"] == {
             "start_date": "2026-07-01",


### PR DESCRIPTION
## Summary

Implements A2C-88 by adding a Conga CPQ/CLM adapter for sell-side quote and agreement workflows:

- Adds `conga_quote_to_a2cn_terms()` for translating Conga CPQ quote/cart payloads into A2CN `saas_renewal` or `goods_procurement` terms.
- Adds `a2cn_terms_to_conga_quote()` for converting agreed A2CN terms back into Conga quote-update payloads, preserving line-item and product IDs.
- Adds `CongaAdapter.quote_to_session_inputs()` plus a CLM agreement metadata payload helper.
- Adds OAuth client-credentials helpers for Conga/Salesforce or Advantage Platform deployments.
- Adds `CONGA_INTEGRATION.md` covering CPQ, CLM, Salesforce-native Revenue Cloud synergy, env vars, and live integration limits.
- Adds offline tests for SaaS/goods mappings, cents conversion, schema validation, field-map overrides, Advantage-style casing aliases, write-back payloads, CLM linkage, and token/header helpers.

## Validation

- `uv run pytest tests/test_conga_adapter.py -q` -> 14 passed
- `uv run pytest -q` -> 452 passed
- `uv run python -m py_compile adapters/conga_adapter.py tests/test_conga_adapter.py`
- `git diff --cached --check`