### PR TITLE
Add DocuSign formalization adapter

### DIFF
--- a/reference-implementation/python/adapters/DOCUSIGN_INTEGRATION.md
+++ b/reference-implementation/python/adapters/DOCUSIGN_INTEGRATION.md
@@ -1,0 +1,156 @@
+# DocuSign eSignature / Connect - A2CN Integration Guide
+
+DocuSign is a formalization layer for A2CN agreements. A2CN produces the
+neutral, dual-signed transaction record; DocuSign executes the signature package
+and can notify A2CN middleware when the envelope is completed, declined, or
+voided.
+
+Public docs used:
+
+- DocuSign eSignature REST API
+  - `POST /restapi/v2.1/accounts/{accountId}/envelopes`
+  - envelope definitions with `status`, `emailSubject`, `documents`, and
+    `recipients`
+- DocuSign Connect
+  - envelope event notifications
+  - envelope completed events
+  - HMAC signatures for message validation
+- DocuSign OAuth
+  - JWT bearer grant using integration key, user ID, and RSA private key
+
+This adapter does not replace the A2CN transaction record. It generates a
+DocuSign envelope that references the A2CN `session_id`, `record_id`, and
+`record_hash` in hidden custom fields and in the generated terms summary.
+
+---
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `DOCUSIGN_INTEGRATION_KEY` | OAuth JWT app / integration key |
+| `DOCUSIGN_USER_ID` | DocuSign user GUID to impersonate |
+| `DOCUSIGN_PRIVATE_KEY` | RSA private key PEM for the JWT grant |
+| `DOCUSIGN_SCOPE` | Optional scope, defaults to `signature impersonation` |
+| `DOCUSIGN_AUTH_BASE_URI` | Auth host, e.g. `https://account-d.docusign.com` |
+| `DOCUSIGN_ACCOUNT_ID` | eSignature account ID |
+| `DOCUSIGN_BASE_URI` | eSignature REST base URI |
+| `DOCUSIGN_CONNECT_SECRET` | Optional Connect HMAC secret |
+
+---
+
+## Path A - A2CN Record to Envelope
+
+```python
+from adapters.docusign_adapter import a2cn_record_to_docusign_envelope
+
+envelope = a2cn_record_to_docusign_envelope(
+    transaction_record,
+    signer_contacts={
+        "did:web:buyer.example": {
+            "name": "Buyer Legal",
+            "email": "legal@buyer.example",
+        },
+        "did:web:seller.example": {
+            "name": "Seller Legal",
+            "email": "legal@seller.example",
+        },
+    },
+    connect_url="https://middleware.example.com/docusign/connect",
+)
+```
+
+The envelope contains:
+
+- a generated text document summarizing the A2CN agreed terms
+- two signers, one for each party DID
+- hidden custom fields for `a2cn_session_id`, `a2cn_record_id`, and
+  `a2cn_record_hash`
+- optional envelope event notification configuration for Connect
+
+Create it with:
+
+```text
+POST /restapi/v2.1/accounts/{accountId}/envelopes
+```
+
+Use `docusign_envelope_create_request()` to build the request URL and payload
+shape for middleware.
+
+---
+
+## Path B - Connect Completion to A2CN Status
+
+```python
+from adapters.docusign_adapter import DocuSignConnectParser
+
+update = DocuSignConnectParser.parse_envelope_event(connect_payload)
+```
+
+The parser returns:
+
+- `envelope_id`
+- `envelope_status`
+- `post_commitment_status`
+- `a2cn_session_id`
+- `a2cn_record_hash`
+- `completed`
+
+Middleware can then update its local post-commitment state for the matching
+A2CN transaction record. Core protocol state does not need to change.
+
+When a Connect HMAC secret is configured, validate the raw request body before
+processing:
+
+```python
+valid = DocuSignConnectParser.verify_hmac_signature(
+    payload_bytes,
+    signature_header,
+    secret,
+)
+```
+
+---
+
+## OAuth
+
+`fetch_docusign_access_token()` implements the JWT bearer grant:
+
+- `iss`: integration key
+- `sub`: user ID
+- `aud`: DocuSign auth host
+- `scope`: `signature impersonation` by default
+- grant type: `urn:ietf:params:oauth:grant-type:jwt-bearer`
+
+For developer accounts, use the demo auth host:
+
+```text
+https://account-d.docusign.com
+```
+
+For production, use:
+
+```text
+https://account.docusign.com
+```
+
+---
+
+## Navigator / CLM Notes
+
+Navigator and CLM can be used downstream to discover, store, or route executed
+contract records. The A2CN adapter keeps that as middleware responsibility:
+DocuSign owns envelope execution and CLM workflow, while A2CN owns the neutral
+bilateral transaction record and record hash.
+
+---
+
+## Known Limitations
+
+- The adapter generates a deterministic text summary document, not a full legal
+  contract template. Production deployments can replace the generated document
+  with a CLM template while preserving the A2CN custom fields.
+- Party DIDs do not inherently contain signer email addresses. Middleware must
+  provide a DID-to-contact mapping.
+- This module does not perform envelope creation or Connect acknowledgement
+  network calls except for the OAuth token helper.

--- a/reference-implementation/python/adapters/docusign_adapter.py
+++ b/reference-implementation/python/adapters/docusign_adapter.py
@@ -268,7 +268,7 @@ class DocuSignConnectParser:
             or payload.get("event")
             or ""
         )
-        status_normalized = str(status).lower()
+        status_normalized = _normalize_envelope_status(status)
         custom_fields = _custom_fields_from_payload(data, envelope_summary, payload)
         event_name = payload.get("event") or payload.get("eventName") or ""
         return {
@@ -288,11 +288,7 @@ def _custom_fields_from_payload(*sections: dict) -> dict:
     fields: dict[str, str] = {}
     for section in sections:
         custom_fields = section.get("customFields", {})
-        text_fields = (
-            custom_fields.get("textCustomFields")
-            or section.get("customFields", {}).get("textCustomFields")
-            or []
-        )
+        text_fields = custom_fields.get("textCustomFields") or []
         if isinstance(text_fields, dict):
             text_fields = text_fields.get("textCustomField", [])
         for item in text_fields:
@@ -301,6 +297,13 @@ def _custom_fields_from_payload(*sections: dict) -> dict:
             if name:
                 fields[str(name)] = "" if value is None else str(value)
     return fields
+
+
+def _normalize_envelope_status(status: Any) -> str:
+    normalized = str(status).lower()
+    if normalized.startswith("envelope-"):
+        normalized = normalized.removeprefix("envelope-")
+    return normalized
 
 
 def _post_commitment_status(envelope_status: str) -> str:

--- a/reference-implementation/python/adapters/docusign_adapter.py
+++ b/reference-implementation/python/adapters/docusign_adapter.py
@@ -1,0 +1,388 @@
+"""
+DocuSign eSignature/CLM -> A2CN formalization adapter.
+
+Translates an A2CN transaction record into a DocuSign eSignature envelope
+definition, and translates DocuSign Connect webhook notifications into a small
+post-commitment status update shape.
+
+Public documentation used for this adapter:
+  eSignature REST API:
+    POST /restapi/v2.1/accounts/{accountId}/envelopes
+    EnvelopeDefinition: status, emailSubject, documents, recipients
+  DocuSign Connect:
+    envelope event notifications, completed envelope events, HMAC signatures
+  OAuth:
+    JWT bearer grant with integration key, user ID, account ID, and RSA key
+
+No core protocol changes are required. A2CN remains the neutral bilateral
+transaction record; DocuSign executes signature and downstream CLM workflow.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import time
+from typing import Any
+
+import httpx
+import jwt as pyjwt
+
+
+DOCUSIGN_JWT_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+DOCUSIGN_DEMO_AUTH_BASE_URI = "https://account-d.docusign.com"
+DOCUSIGN_PROD_AUTH_BASE_URI = "https://account.docusign.com"
+
+
+def _money_to_decimal(cents: Any) -> float:
+    if cents is None or cents == "":
+        return 0.0
+    return int(cents) / 100.0
+
+
+def _party_label(role: str, party: dict) -> str:
+    organization = party.get("organization_name") or role.title()
+    did = party.get("did", "")
+    return f"{organization} ({did})" if did else organization
+
+
+def _get_contact(
+    party: dict,
+    signer_contacts: dict[str, dict] | None,
+) -> dict:
+    did = party.get("did", "")
+    contact = (signer_contacts or {}).get(did, {})
+    name = contact.get("name") or party.get("organization_name") or did
+    email = contact.get("email") or party.get("email")
+    if not email:
+        raise ValueError(f"Missing signer email for party DID {did!r}.")
+    return {"name": name, "email": email}
+
+
+def _terms_summary_text(record: dict) -> str:
+    terms = record.get("agreed_terms", {})
+    parties = record.get("parties", {})
+    lines = [
+        "A2CN Transaction Terms Summary",
+        "",
+        f"Session ID: {record.get('session_id', '')}",
+        f"Record Hash: {record.get('record_hash', '')}",
+        f"Deal Type: {record.get('deal_type', '')}",
+        f"Currency: {record.get('currency', terms.get('currency', ''))}",
+        f"Total Value: {_money_to_decimal(terms.get('total_value', 0)):.2f}",
+        "",
+        "Parties:",
+        f"- Initiator: {_party_label('initiator', parties.get('initiator', {}))}",
+        f"- Responder: {_party_label('responder', parties.get('responder', {}))}",
+        "",
+        "Agreed Terms:",
+    ]
+    if terms.get("seat_count") is not None:
+        lines.append(f"- Seat count: {terms['seat_count']}")
+    if terms.get("subscription_tier"):
+        lines.append(f"- Subscription tier: {terms['subscription_tier']}")
+    if terms.get("term_months") is not None:
+        lines.append(f"- Term months: {terms['term_months']}")
+    if terms.get("delivery_days") is not None:
+        lines.append(f"- Delivery days: {terms['delivery_days']}")
+    if terms.get("payment_terms", {}).get("net_days") is not None:
+        lines.append(f"- Payment terms: Net {terms['payment_terms']['net_days']}")
+    if terms.get("contract_duration"):
+        duration = terms["contract_duration"]
+        lines.append(
+            f"- Contract duration: {duration.get('start_date', '')} to "
+            f"{duration.get('end_date', '')}"
+        )
+    line_items = terms.get("line_items", [])
+    if line_items:
+        lines.append("")
+        lines.append("Line Items:")
+        for item in line_items:
+            lines.append(
+                "- "
+                f"{item.get('description', '')}: "
+                f"qty {item.get('quantity', 1)}, "
+                f"unit {_money_to_decimal(item.get('unit_price', 0)):.2f}, "
+                f"total {_money_to_decimal(item.get('total', 0)):.2f}"
+            )
+    lines.extend([
+        "",
+        "This document is generated from the A2CN dual-signed transaction record.",
+        "\\s1\\",
+        "\\s2\\",
+    ])
+    return "\n".join(lines)
+
+
+def a2cn_record_to_docusign_envelope(
+    record: dict,
+    signer_contacts: dict[str, dict],
+    *,
+    email_subject: str | None = None,
+    status: str = "sent",
+    connect_url: str | None = None,
+) -> dict:
+    """
+    Build a DocuSign eSignature envelope definition for an A2CN record.
+
+    ``signer_contacts`` maps party DID to ``{"name": ..., "email": ...}``.
+    The record itself remains the canonical agreement; the envelope signs a
+    generated terms-summary document that references the A2CN record hash.
+    """
+    parties = record.get("parties", {})
+    initiator = parties.get("initiator", {})
+    responder = parties.get("responder", {})
+    initiator_contact = _get_contact(initiator, signer_contacts)
+    responder_contact = _get_contact(responder, signer_contacts)
+    summary_text = _terms_summary_text(record)
+    document_b64 = base64.b64encode(summary_text.encode("utf-8")).decode("ascii")
+
+    envelope: dict = {
+        "emailSubject": email_subject or (
+            f"A2CN agreement for session {record.get('session_id', '')}"
+        ),
+        "status": status,
+        "documents": [
+            {
+                "documentBase64": document_b64,
+                "name": "A2CN Transaction Terms Summary.txt",
+                "fileExtension": "txt",
+                "documentId": "1",
+            }
+        ],
+        "recipients": {
+            "signers": [
+                {
+                    "email": initiator_contact["email"],
+                    "name": initiator_contact["name"],
+                    "recipientId": "1",
+                    "routingOrder": "1",
+                    "tabs": {
+                        "signHereTabs": [
+                            {
+                                "anchorString": "\\s1\\",
+                                "anchorUnits": "pixels",
+                                "anchorXOffset": "0",
+                                "anchorYOffset": "0",
+                            }
+                        ]
+                    },
+                },
+                {
+                    "email": responder_contact["email"],
+                    "name": responder_contact["name"],
+                    "recipientId": "2",
+                    "routingOrder": "1",
+                    "tabs": {
+                        "signHereTabs": [
+                            {
+                                "anchorString": "\\s2\\",
+                                "anchorUnits": "pixels",
+                                "anchorXOffset": "0",
+                                "anchorYOffset": "0",
+                            }
+                        ]
+                    },
+                },
+            ]
+        },
+        "customFields": {
+            "textCustomFields": [
+                {
+                    "name": "a2cn_session_id",
+                    "value": record.get("session_id", ""),
+                    "show": "false",
+                },
+                {
+                    "name": "a2cn_record_hash",
+                    "value": record.get("record_hash", ""),
+                    "show": "false",
+                },
+                {
+                    "name": "a2cn_record_id",
+                    "value": record.get("record_id", ""),
+                    "show": "false",
+                },
+            ]
+        },
+    }
+    if connect_url:
+        envelope["eventNotification"] = {
+            "url": connect_url,
+            "loggingEnabled": "true",
+            "requireAcknowledgment": "true",
+            "includeDocuments": "false",
+            "includeCertificateOfCompletion": "true",
+            "envelopeEvents": [
+                {"envelopeEventStatusCode": "completed"},
+                {"envelopeEventStatusCode": "declined"},
+                {"envelopeEventStatusCode": "voided"},
+            ],
+        }
+    return envelope
+
+
+class DocuSignConnectParser:
+    """
+    Parses DocuSign Connect webhook notifications into A2CN status updates.
+    """
+
+    @staticmethod
+    def verify_hmac_signature(
+        payload_bytes: bytes,
+        signature_header: str,
+        secret: str | bytes,
+    ) -> bool:
+        if not payload_bytes or not signature_header or not secret:
+            return False
+        key = secret.encode("utf-8") if isinstance(secret, str) else secret
+        expected = base64.b64encode(
+            hmac.new(key, payload_bytes, hashlib.sha256).digest()
+        ).decode("ascii")
+        candidates = [
+            part.strip()
+            for part in signature_header.replace(",", " ").split()
+            if part.strip()
+        ]
+        return any(hmac.compare_digest(expected, candidate) for candidate in candidates)
+
+    @staticmethod
+    def parse_envelope_event(payload: dict) -> dict:
+        """
+        Parse a DocuSign Connect JSON payload into a post-commitment update.
+        """
+        data = payload.get("data") or {}
+        envelope_summary = data.get("envelopeSummary") or payload.get("envelopeSummary") or {}
+        envelope_id = (
+            data.get("envelopeId")
+            or envelope_summary.get("envelopeId")
+            or payload.get("envelopeId")
+            or ""
+        )
+        status = (
+            data.get("envelopeStatus")
+            or envelope_summary.get("status")
+            or payload.get("status")
+            or payload.get("event")
+            or ""
+        )
+        status_normalized = str(status).lower()
+        custom_fields = _custom_fields_from_payload(data, envelope_summary, payload)
+        event_name = payload.get("event") or payload.get("eventName") or ""
+        return {
+            "provider": "docusign",
+            "event": event_name,
+            "envelope_id": envelope_id,
+            "envelope_status": status_normalized,
+            "post_commitment_status": _post_commitment_status(status_normalized),
+            "a2cn_session_id": custom_fields.get("a2cn_session_id", ""),
+            "a2cn_record_hash": custom_fields.get("a2cn_record_hash", ""),
+            "completed": status_normalized == "completed",
+            "raw_payload": payload,
+        }
+
+
+def _custom_fields_from_payload(*sections: dict) -> dict:
+    fields: dict[str, str] = {}
+    for section in sections:
+        custom_fields = section.get("customFields", {})
+        text_fields = (
+            custom_fields.get("textCustomFields")
+            or section.get("customFields", {}).get("textCustomFields")
+            or []
+        )
+        if isinstance(text_fields, dict):
+            text_fields = text_fields.get("textCustomField", [])
+        for item in text_fields:
+            name = item.get("name")
+            value = item.get("value")
+            if name:
+                fields[str(name)] = "" if value is None else str(value)
+    return fields
+
+
+def _post_commitment_status(envelope_status: str) -> str:
+    if envelope_status == "completed":
+        return "signature_completed"
+    if envelope_status == "declined":
+        return "signature_declined"
+    if envelope_status == "voided":
+        return "signature_voided"
+    return "signature_pending"
+
+
+def docusign_envelope_create_request(
+    account_id: str,
+    envelope_definition: dict,
+    base_uri: str | None = None,
+) -> dict:
+    """
+    Build the documented eSignature create-envelope request shape.
+    """
+    resolved_base_uri = (base_uri or os.environ.get("DOCUSIGN_BASE_URI") or "").rstrip("/")
+    if not resolved_base_uri:
+        raise ValueError("DOCUSIGN_BASE_URI or base_uri is required.")
+    return {
+        "method": "POST",
+        "url": f"{resolved_base_uri}/restapi/v2.1/accounts/{account_id}/envelopes",
+        "json": envelope_definition,
+    }
+
+
+def docusign_auth_headers(access_token: str) -> dict:
+    return {
+        "Authorization": f"Bearer {access_token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+
+async def fetch_docusign_access_token(
+    auth_base_uri: str | None = None,
+    now: int | None = None,
+) -> str:
+    """
+    Fetch a DocuSign OAuth JWT bearer token.
+    """
+    integration_key = os.environ.get("DOCUSIGN_INTEGRATION_KEY")
+    user_id = os.environ.get("DOCUSIGN_USER_ID")
+    private_key = os.environ.get("DOCUSIGN_PRIVATE_KEY")
+    scope = os.environ.get("DOCUSIGN_SCOPE", "signature impersonation")
+    resolved_auth_base_uri = (
+        auth_base_uri
+        or os.environ.get("DOCUSIGN_AUTH_BASE_URI")
+        or DOCUSIGN_DEMO_AUTH_BASE_URI
+    ).rstrip("/")
+    if not integration_key or not user_id or not private_key:
+        raise ValueError(
+            "DOCUSIGN_INTEGRATION_KEY, DOCUSIGN_USER_ID, and "
+            "DOCUSIGN_PRIVATE_KEY are required."
+        )
+
+    issued_at = int(now if now is not None else time.time())
+    audience = resolved_auth_base_uri.removeprefix("https://")
+    assertion = pyjwt.encode(
+        {
+            "iss": integration_key,
+            "sub": user_id,
+            "aud": audience,
+            "iat": issued_at,
+            "exp": issued_at + 3600,
+            "scope": scope,
+        },
+        private_key,
+        algorithm="RS256",
+    )
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{resolved_auth_base_uri}/oauth/token",
+            data={
+                "grant_type": DOCUSIGN_JWT_GRANT_TYPE,
+                "assertion": assertion,
+            },
+            headers={"Accept": "application/json"},
+        )
+    response.raise_for_status()
+    return response.json()["access_token"]

--- a/reference-implementation/python/tests/test_docusign_adapter.py
+++ b/reference-implementation/python/tests/test_docusign_adapter.py
@@ -1,0 +1,300 @@
+"""Tests for DocuSign eSignature / Connect adapter."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import jwt as pyjwt
+import pytest
+from adapters.docusign_adapter import (
+    DOCUSIGN_JWT_GRANT_TYPE,
+    DocuSignConnectParser,
+    a2cn_record_to_docusign_envelope,
+    docusign_auth_headers,
+    docusign_envelope_create_request,
+    fetch_docusign_access_token,
+)
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+SAMPLE_RECORD = {
+    "record_type": "a2cn_transaction_record",
+    "record_id": "record-001",
+    "session_id": "sess-001",
+    "record_hash": "abc123" * 10,
+    "deal_type": "saas_renewal",
+    "currency": "USD",
+    "parties": {
+        "initiator": {
+            "organization_name": "Buyer Co",
+            "did": "did:web:buyer.example",
+        },
+        "responder": {
+            "organization_name": "Seller Co",
+            "did": "did:web:seller.example",
+        },
+    },
+    "agreed_terms": {
+        "total_value": 10_000_000,
+        "currency": "USD",
+        "seat_count": 100,
+        "subscription_tier": "Enterprise",
+        "term_months": 12,
+        "payment_terms": {"net_days": 45},
+        "line_items": [
+            {
+                "description": "Enterprise Subscription",
+                "quantity": 100,
+                "unit_price": 95_000,
+                "total": 9_500_000,
+            },
+            {
+                "description": "Premium Support",
+                "quantity": 1,
+                "unit_price": 500_000,
+                "total": 500_000,
+            },
+        ],
+    },
+}
+
+SIGNER_CONTACTS = {
+    "did:web:buyer.example": {
+        "name": "Buyer Legal",
+        "email": "legal@buyer.example",
+    },
+    "did:web:seller.example": {
+        "name": "Seller Legal",
+        "email": "legal@seller.example",
+    },
+}
+
+
+def _make_async_client_mock(json_data: dict):
+    mock_response = MagicMock()
+    mock_response.json.return_value = json_data
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+    return mock_cm, mock_client
+
+
+def _private_key_pem() -> str:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+
+
+class TestDocuSignEnvelopeMapping:
+    def test_record_to_envelope_maps_documents_recipients_and_custom_fields(self):
+        envelope = a2cn_record_to_docusign_envelope(
+            SAMPLE_RECORD,
+            SIGNER_CONTACTS,
+            connect_url="https://middleware.example.com/docusign/connect",
+        )
+
+        assert envelope["status"] == "sent"
+        assert envelope["emailSubject"] == "A2CN agreement for session sess-001"
+        assert envelope["documents"][0]["documentId"] == "1"
+        assert envelope["documents"][0]["fileExtension"] == "txt"
+        signers = envelope["recipients"]["signers"]
+        assert signers[0]["email"] == "legal@buyer.example"
+        assert signers[0]["name"] == "Buyer Legal"
+        assert signers[1]["email"] == "legal@seller.example"
+        assert signers[1]["name"] == "Seller Legal"
+        fields = envelope["customFields"]["textCustomFields"]
+        assert {"name": "a2cn_session_id", "value": "sess-001", "show": "false"} in fields
+        assert {"name": "a2cn_record_hash", "value": SAMPLE_RECORD["record_hash"], "show": "false"} in fields
+        assert envelope["eventNotification"]["url"] == "https://middleware.example.com/docusign/connect"
+
+    def test_generated_document_contains_record_hash_and_terms(self):
+        envelope = a2cn_record_to_docusign_envelope(SAMPLE_RECORD, SIGNER_CONTACTS)
+        document_text = base64.b64decode(
+            envelope["documents"][0]["documentBase64"]
+        ).decode("utf-8")
+
+        assert "A2CN Transaction Terms Summary" in document_text
+        assert "Session ID: sess-001" in document_text
+        assert f"Record Hash: {SAMPLE_RECORD['record_hash']}" in document_text
+        assert "Seat count: 100" in document_text
+        assert "Term months: 12" in document_text
+        assert "\\s1\\" in document_text
+        assert "\\s2\\" in document_text
+
+    def test_missing_signer_email_is_rejected(self):
+        with pytest.raises(ValueError, match="Missing signer email"):
+            a2cn_record_to_docusign_envelope(
+                SAMPLE_RECORD,
+                {"did:web:buyer.example": {"email": "legal@buyer.example"}},
+            )
+
+    def test_envelope_create_request_uses_v21_account_path(self):
+        envelope = a2cn_record_to_docusign_envelope(SAMPLE_RECORD, SIGNER_CONTACTS)
+
+        request = docusign_envelope_create_request(
+            account_id="acct-001",
+            envelope_definition=envelope,
+            base_uri="https://demo.docusign.net/",
+        )
+
+        assert request["method"] == "POST"
+        assert request["url"] == "https://demo.docusign.net/restapi/v2.1/accounts/acct-001/envelopes"
+        assert request["json"] == envelope
+
+
+class TestDocuSignConnectParser:
+    def test_parse_completed_envelope_event(self):
+        payload = {
+            "event": "envelope-completed",
+            "data": {
+                "envelopeId": "env-001",
+                "envelopeSummary": {
+                    "status": "completed",
+                    "customFields": {
+                        "textCustomFields": [
+                            {"name": "a2cn_session_id", "value": "sess-001"},
+                            {"name": "a2cn_record_hash", "value": "hash-001"},
+                        ]
+                    },
+                },
+            },
+        }
+
+        update = DocuSignConnectParser.parse_envelope_event(payload)
+
+        assert update["provider"] == "docusign"
+        assert update["event"] == "envelope-completed"
+        assert update["envelope_id"] == "env-001"
+        assert update["envelope_status"] == "completed"
+        assert update["post_commitment_status"] == "signature_completed"
+        assert update["a2cn_session_id"] == "sess-001"
+        assert update["a2cn_record_hash"] == "hash-001"
+        assert update["completed"] is True
+
+    def test_parse_declined_envelope_event(self):
+        update = DocuSignConnectParser.parse_envelope_event({
+            "event": "envelope-declined",
+            "data": {
+                "envelopeId": "env-002",
+                "envelopeStatus": "declined",
+            },
+        })
+
+        assert update["post_commitment_status"] == "signature_declined"
+        assert update["completed"] is False
+
+    def test_verify_hmac_signature_accepts_valid_signature(self):
+        payload_bytes = json.dumps({"event": "envelope-completed"}).encode("utf-8")
+        signature = base64.b64encode(
+            hmac.new(b"secret", payload_bytes, hashlib.sha256).digest()
+        ).decode("ascii")
+
+        assert DocuSignConnectParser.verify_hmac_signature(
+            payload_bytes,
+            signature,
+            "secret",
+        )
+
+    def test_verify_hmac_signature_rejects_tampered_payload(self):
+        payload_bytes = json.dumps({"event": "envelope-completed"}).encode("utf-8")
+        signature = base64.b64encode(
+            hmac.new(b"secret", payload_bytes, hashlib.sha256).digest()
+        ).decode("ascii")
+
+        assert not DocuSignConnectParser.verify_hmac_signature(
+            b'{"event":"envelope-voided"}',
+            signature,
+            "secret",
+        )
+
+
+class TestDocuSignAuthHelpers:
+    def test_docusign_auth_headers(self):
+        headers = docusign_auth_headers("access-token")
+
+        assert headers == {
+            "Authorization": "Bearer access-token",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+    @pytest.mark.asyncio
+    async def test_fetch_docusign_access_token_uses_jwt_bearer_grant(self):
+        mock_cm, mock_client = _make_async_client_mock({"access_token": "token-123"})
+        private_key = _private_key_pem()
+        with patch("adapters.docusign_adapter.httpx.AsyncClient", return_value=mock_cm):
+            with patch.dict(os.environ, {
+                "DOCUSIGN_INTEGRATION_KEY": "integration-key",
+                "DOCUSIGN_USER_ID": "user-guid",
+                "DOCUSIGN_PRIVATE_KEY": private_key,
+                "DOCUSIGN_AUTH_BASE_URI": "https://account-d.docusign.com",
+            }):
+                token = await fetch_docusign_access_token(now=1_700_000_000)
+
+        assert token == "token-123"
+        _, kwargs = mock_client.post.call_args
+        assert kwargs["data"]["grant_type"] == DOCUSIGN_JWT_GRANT_TYPE
+        decoded = pyjwt.decode(
+            kwargs["data"]["assertion"],
+            options={"verify_signature": False},
+        )
+        assert decoded["iss"] == "integration-key"
+        assert decoded["sub"] == "user-guid"
+        assert decoded["aud"] == "account-d.docusign.com"
+        assert decoded["scope"] == "signature impersonation"
+        assert kwargs["headers"] == {"Accept": "application/json"}
+
+    @pytest.mark.asyncio
+    async def test_fetch_docusign_access_token_uses_custom_scope_and_auth_uri(self):
+        mock_cm, mock_client = _make_async_client_mock({"access_token": "token-123"})
+        private_key = _private_key_pem()
+        with patch("adapters.docusign_adapter.httpx.AsyncClient", return_value=mock_cm):
+            with patch.dict(os.environ, {
+                "DOCUSIGN_INTEGRATION_KEY": "integration-key",
+                "DOCUSIGN_USER_ID": "user-guid",
+                "DOCUSIGN_PRIVATE_KEY": private_key,
+                "DOCUSIGN_SCOPE": "signature impersonation click.manage",
+            }):
+                token = await fetch_docusign_access_token(
+                    auth_base_uri="https://account.docusign.com",
+                    now=1_700_000_000,
+                )
+
+        assert token == "token-123"
+        _, kwargs = mock_client.post.call_args
+        decoded = pyjwt.decode(
+            kwargs["data"]["assertion"],
+            options={"verify_signature": False},
+        )
+        assert decoded["aud"] == "account.docusign.com"
+        assert decoded["scope"] == "signature impersonation click.manage"
+        assert mock_client.post.call_args.args[0] == "https://account.docusign.com/oauth/token"
+
+    @pytest.mark.asyncio
+    async def test_fetch_docusign_access_token_requires_env(self):
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in {
+                "DOCUSIGN_INTEGRATION_KEY",
+                "DOCUSIGN_USER_ID",
+                "DOCUSIGN_PRIVATE_KEY",
+            }
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValueError, match="DOCUSIGN_INTEGRATION_KEY"):
+                await fetch_docusign_access_token()

--- a/reference-implementation/python/tests/test_docusign_adapter.py
+++ b/reference-implementation/python/tests/test_docusign_adapter.py
@@ -197,6 +197,18 @@ class TestDocuSignConnectParser:
         assert update["post_commitment_status"] == "signature_declined"
         assert update["completed"] is False
 
+    def test_parse_completed_event_name_without_explicit_status(self):
+        update = DocuSignConnectParser.parse_envelope_event({
+            "event": "envelope-completed",
+            "data": {
+                "envelopeId": "env-003",
+            },
+        })
+
+        assert update["envelope_status"] == "completed"
+        assert update["post_commitment_status"] == "signature_completed"
+        assert update["completed"] is True
+
     def test_verify_hmac_signature_accepts_valid_signature(self):
         payload_bytes = json.dumps({"event": "envelope-completed"}).encode("utf-8")
         signature = base64.b64encode(


### PR DESCRIPTION
## Summary

Implements A2C-89 by adding a DocuSign formalization adapter for the A2CN transaction-record handoff:

- Adds `a2cn_record_to_docusign_envelope()` to convert an A2CN transaction record into a DocuSign eSignature envelope definition with generated terms summary document, two signers, hidden A2CN custom fields, and optional Connect event notification config.
- Adds `DocuSignConnectParser` for parsing envelope completion/decline/void Connect events into post-commitment status updates.
- Adds Connect HMAC verification using the raw payload body and `X-DocuSign-Signature-*` style base64 HMAC-SHA256 values.
- Adds eSignature create-envelope request and auth-header helpers.
- Adds `fetch_docusign_access_token()` for DocuSign OAuth JWT bearer grant using `DOCUSIGN_*` env vars.
- Adds `DOCUSIGN_INTEGRATION.md` framing A2CN as the neutral bilateral record and DocuSign as the signature/CLM execution layer.
- Adds offline tests for record-to-envelope mapping, generated document contents, missing contact validation, Connect parsing, HMAC verification, request construction, and JWT grant behavior.

## Validation

- `uv run pytest tests/test_docusign_adapter.py -q` -> 12 passed
- `uv run pytest -q` -> 464 passed
- `uv run python -m py_compile adapters/docusign_adapter.py tests/test_docusign_adapter.py`
- `git diff --cached --check`