### PR TITLE
fix: lowercase post-commitment message types

### DIFF
--- a/reference-implementation/python/a2cn/messages.py
+++ b/reference-implementation/python/a2cn/messages.py
@@ -525,7 +525,7 @@ class DeliveryNoticeMessage:
     References the transaction record by hash. Required for Level 3
     conformance in A2CN v0.2.0.
 
-    DELIVERY_NOTICE closes the seller's obligation under the agreed terms
+    A `delivery_notice` closes the seller's obligation under the agreed terms
     and triggers the buyer's acknowledgment window.
     """
     message_id: str
@@ -535,7 +535,7 @@ class DeliveryNoticeMessage:
     delivery_reference: str | None = None  # Tracking number, PO ref, etc.
     notes: str | None = None
     protocol_version: str = "0.2"
-    message_type: str = "DELIVERY_NOTICE"
+    message_type: str = "delivery_notice"
 
     def to_dict(self) -> dict:
         return _drop_none({
@@ -553,21 +553,21 @@ class DeliveryNoticeMessage:
 @dataclass
 class DeliveryAcknowledgedMessage:
     """
-    Sent by the buyer to acknowledge receipt of a DELIVERY_NOTICE.
+    Sent by the buyer to acknowledge receipt of a `delivery_notice`.
     Closes the post-commitment lifecycle when accepted=True.
     When accepted=False, triggers DISPUTED status on the session.
 
-    References both the DELIVERY_NOTICE and the transaction record.
+    References both the `delivery_notice` and the transaction record.
     """
     message_id: str
     session_id: str
     transaction_record_hash: str      # Must match agreed transaction record
-    delivery_notice_message_id: str   # References the DELIVERY_NOTICE
+    delivery_notice_message_id: str   # References the delivery_notice
     acknowledgment_timestamp: str     # ISO 8601
     accepted: bool                    # True = delivery accepted, False = disputed
     notes: str | None = None
     protocol_version: str = "0.2"
-    message_type: str = "DELIVERY_ACKNOWLEDGED"
+    message_type: str = "delivery_acknowledged"
 
     def to_dict(self) -> dict:
         return _drop_none({
@@ -605,7 +605,7 @@ class DisputeNoticeMessage:
     resolution_requested: str | None = None  # "renegotiate" | "cancel" | "neutral_review"
     dispute_timestamp: str = None  # ISO 8601, auto-set on creation
     protocol_version: str = "0.2"
-    message_type: str = "DISPUTE_NOTICE"
+    message_type: str = "dispute_notice"
 
     def __post_init__(self):
         if self.evidence_references is None:
@@ -636,11 +636,11 @@ class DisputeNoticeMessage:
 class DisputeResolvedMessage:
     """
     Sent by the neutral resolver (or agreed party) to record the outcome
-    of a dispute opened by DISPUTE_NOTICE. Closes the post-commitment
+    of a dispute opened by `dispute_notice`. Closes the post-commitment
     dispute lifecycle.
 
     Anchored to both the original transaction record hash and the
-    DISPUTE_NOTICE message_id. The resolution_outcome field records
+    `dispute_notice` message_id. The resolution_outcome field records
     who prevailed; resolver_did identifies the neutral party that
     issued the resolution.
 
@@ -654,7 +654,7 @@ class DisputeResolvedMessage:
     message_id: str
     session_id: str
     transaction_record_hash: str  # Must match the agreed transaction record
-    dispute_notice_message_id: str  # References the DISPUTE_NOTICE being resolved
+    dispute_notice_message_id: str  # References the dispute_notice being resolved
     resolution_outcome: str  # "buyer_prevails" | "seller_prevails" |
                               # "mutual_settlement"
     resolver_did: str  # DID of the neutral resolver
@@ -662,7 +662,7 @@ class DisputeResolvedMessage:
     resolution_notes: str | None = None
     evidence_references: list[str] = None  # Supporting evidence for the ruling
     protocol_version: str = "0.2"
-    message_type: str = "DISPUTE_RESOLVED"
+    message_type: str = "dispute_resolved"
 
     def __post_init__(self):
         if self.evidence_references is None:

--- a/reference-implementation/python/a2cn/server.py
+++ b/reference-implementation/python/a2cn/server.py
@@ -576,6 +576,14 @@ async def post_delivery_notice(session_id: str, request: Request,
                                "session_id in request body does not match URL path",
                                400, session_id=session_id)
 
+    if body.get("message_type") != "delivery_notice":
+        return error_response(
+            "WRONG_MESSAGE_TYPE",
+            "message_type must be 'delivery_notice'",
+            400,
+            session_id=session_id,
+        )
+
     if session.state != SessionState.COMPLETED:
         return error_response(
             "SESSION_WRONG_STATE",
@@ -621,6 +629,14 @@ async def post_delivery_acknowledged(session_id: str, request: Request,
         return error_response("SESSION_ID_MISMATCH",
                                "session_id in request body does not match URL path",
                                400, session_id=session_id)
+
+    if body.get("message_type") != "delivery_acknowledged":
+        return error_response(
+            "WRONG_MESSAGE_TYPE",
+            "message_type must be 'delivery_acknowledged'",
+            400,
+            session_id=session_id,
+        )
 
     pc_data = _session_store.get(session_id) or {}
 
@@ -683,6 +699,14 @@ async def post_dispute_notice(session_id: str, request: Request,
                                "session_id in request body does not match URL path",
                                400, session_id=session_id)
 
+    if body.get("message_type") != "dispute_notice":
+        return error_response(
+            "WRONG_MESSAGE_TYPE",
+            "message_type must be 'dispute_notice'",
+            400,
+            session_id=session_id,
+        )
+
     pc_data = _session_store.get(session_id) or {}
 
     if session.state != SessionState.COMPLETED and "delivery_notice" not in pc_data:
@@ -732,10 +756,10 @@ async def post_dispute_resolved(session_id: str, request: Request,
                                "session_id in request body does not match URL path",
                                400, session_id=session_id)
 
-    if body.get("message_type") != "DISPUTE_RESOLVED":
+    if body.get("message_type") != "dispute_resolved":
         return error_response(
             "WRONG_MESSAGE_TYPE",
-            "message_type must be 'DISPUTE_RESOLVED'",
+            "message_type must be 'dispute_resolved'",
             400,
             session_id=session_id,
         )
@@ -745,7 +769,7 @@ async def post_dispute_resolved(session_id: str, request: Request,
     if pc_data.get("post_commitment_status") != "DISPUTED":
         return error_response(
             "NOT_IN_DISPUTED_STATUS",
-            "DISPUTE_RESOLVED requires an open DISPUTE_NOTICE",
+            "dispute_resolved requires an open dispute_notice",
             400,
             session_id=session_id,
             spec_ref="Section 11",

--- a/reference-implementation/python/tests/test_post_commitment.py
+++ b/reference-implementation/python/tests/test_post_commitment.py
@@ -44,7 +44,7 @@ async def _create_session(client) -> str:
 def _delivery_notice_body(session_id: str, record_hash: str, msg_id: str | None = None) -> dict:
     mid = msg_id or str(uuid.uuid4())
     return {
-        "message_type": "DELIVERY_NOTICE",
+        "message_type": "delivery_notice",
         "message_id": mid,
         "session_id": session_id,
         "transaction_record_hash": record_hash,
@@ -58,7 +58,7 @@ def _delivery_ack_body(session_id: str, record_hash: str,
                        msg_id: str | None = None) -> dict:
     mid = msg_id or str(uuid.uuid4())
     return {
-        "message_type": "DELIVERY_ACKNOWLEDGED",
+        "message_type": "delivery_acknowledged",
         "message_id": mid,
         "session_id": session_id,
         "transaction_record_hash": record_hash,
@@ -71,7 +71,7 @@ def _delivery_ack_body(session_id: str, record_hash: str,
 def _dispute_notice_body(session_id: str, record_hash: str, msg_id: str | None = None) -> dict:
     mid = msg_id or str(uuid.uuid4())
     return {
-        "message_type": "DISPUTE_NOTICE",
+        "message_type": "dispute_notice",
         "message_id": mid,
         "session_id": session_id,
         "transaction_record_hash": record_hash,
@@ -94,7 +94,7 @@ class TestDeliveryNoticeDataclass:
             transaction_record_hash="a" * 64,
             delivery_timestamp="2026-04-02T08:00:00Z",
         )
-        assert msg.message_type == "DELIVERY_NOTICE"
+        assert msg.message_type == "delivery_notice"
         assert msg.protocol_version == "0.2"
         assert msg.delivery_reference is None
 
@@ -108,7 +108,7 @@ class TestDeliveryNoticeDataclass:
         d = msg.to_dict()
         assert "delivery_reference" not in d
         assert "notes" not in d
-        assert d["message_type"] == "DELIVERY_NOTICE"
+        assert d["message_type"] == "delivery_notice"
 
     def test_optional_fields_included_when_set(self):
         msg = DeliveryNoticeMessage(
@@ -138,7 +138,7 @@ class TestDeliveryAcknowledgedDataclass:
             acknowledgment_timestamp="2026-04-03T09:00:00Z",
             accepted=True,
         )
-        assert msg.message_type == "DELIVERY_ACKNOWLEDGED"
+        assert msg.message_type == "delivery_acknowledged"
         assert msg.accepted is True
         assert msg.notes is None
 
@@ -169,7 +169,7 @@ class TestDisputeNoticeDataclass:
             dispute_type="non_delivery",
             description="Goods not received.",
         )
-        assert msg.message_type == "DISPUTE_NOTICE"
+        assert msg.message_type == "dispute_notice"
         assert msg.evidence_references == []
         assert msg.resolution_requested is None
         assert msg.dispute_timestamp is not None
@@ -233,7 +233,7 @@ class TestJsonSchemaValidation:
         import pathlib
         schema_path = pathlib.Path(__file__).parents[3] / "spec" / "schemas" / "delivery_notice.schema.json"
         schema = json.loads(schema_path.read_text())
-        assert schema["properties"]["message_type"]["const"] == "DELIVERY_NOTICE"
+        assert schema["properties"]["message_type"]["const"] == "delivery_notice"
         assert "transaction_record_hash" in schema["required"]
         assert schema["additionalProperties"] is False
 
@@ -242,7 +242,7 @@ class TestJsonSchemaValidation:
         import pathlib
         schema_path = pathlib.Path(__file__).parents[3] / "spec" / "schemas" / "delivery_acknowledged.schema.json"
         schema = json.loads(schema_path.read_text())
-        assert schema["properties"]["message_type"]["const"] == "DELIVERY_ACKNOWLEDGED"
+        assert schema["properties"]["message_type"]["const"] == "delivery_acknowledged"
         assert "accepted" in schema["required"]
         assert schema["additionalProperties"] is False
 
@@ -251,7 +251,7 @@ class TestJsonSchemaValidation:
         import pathlib
         schema_path = pathlib.Path(__file__).parents[3] / "spec" / "schemas" / "dispute_notice.schema.json"
         schema = json.loads(schema_path.read_text())
-        assert schema["properties"]["message_type"]["const"] == "DISPUTE_NOTICE"
+        assert schema["properties"]["message_type"]["const"] == "dispute_notice"
         assert "raised_by" in schema["required"]
         assert "dispute_type" in schema["required"]
         valid_types = schema["properties"]["dispute_type"]["enum"]
@@ -261,7 +261,7 @@ class TestJsonSchemaValidation:
 
 
 # ---------------------------------------------------------------------------
-# Server endpoint tests: DELIVERY_NOTICE
+# Server endpoint tests: delivery_notice
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
@@ -297,9 +297,19 @@ class TestDeliveryNoticeEndpoint:
         assert r.status_code == 409
         assert r.json()["error"]["code"] == "INVALID_RECORD_HASH"
 
+    async def test_delivery_notice_wrong_message_type_rejected(self, test_client, responder_test_client):
+        session_id, record_hash = await _complete_session(test_client, responder_test_client)
+        body = _delivery_notice_body(session_id, record_hash)
+        body["message_type"] = "DELIVERY_NOTICE"
+        r = await test_client.post(
+            f"/sessions/{session_id}/delivery-notice", json=body, headers=_h(body["message_id"])
+        )
+        assert r.status_code == 400
+        assert r.json()["error"]["code"] == "WRONG_MESSAGE_TYPE"
+
 
 # ---------------------------------------------------------------------------
-# Server endpoint tests: DELIVERY_ACKNOWLEDGED
+# Server endpoint tests: delivery_acknowledged
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
@@ -353,9 +363,21 @@ class TestDeliveryAcknowledgedEndpoint:
         assert r.status_code == 409
         assert r.json()["error"]["code"] == "NO_DELIVERY_NOTICE"
 
+    async def test_delivery_acknowledged_wrong_message_type_rejected(
+        self, test_client, responder_test_client
+    ):
+        session_id, record_hash, notice_id = await self._setup(test_client, responder_test_client)
+        body = _delivery_ack_body(session_id, record_hash, notice_id, accepted=True)
+        body["message_type"] = "DELIVERY_ACKNOWLEDGED"
+        r = await test_client.post(
+            f"/sessions/{session_id}/delivery-acknowledged", json=body, headers=_h(body["message_id"])
+        )
+        assert r.status_code == 400
+        assert r.json()["error"]["code"] == "WRONG_MESSAGE_TYPE"
+
 
 # ---------------------------------------------------------------------------
-# Server endpoint tests: DISPUTE_NOTICE
+# Server endpoint tests: dispute_notice
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
@@ -406,6 +428,16 @@ class TestDisputeNoticeEndpoint:
             f"/sessions/{session_id}/dispute-notice", json=body, headers=_h(body["message_id"])
         )
         assert "neutral resolver" in r.json()["note"]
+
+    async def test_dispute_notice_wrong_message_type_rejected(self, test_client, responder_test_client):
+        session_id, record_hash = await _complete_session(test_client, responder_test_client)
+        body = _dispute_notice_body(session_id, record_hash)
+        body["message_type"] = "DISPUTE_NOTICE"
+        r = await test_client.post(
+            f"/sessions/{session_id}/dispute-notice", json=body, headers=_h(body["message_id"])
+        )
+        assert r.status_code == 400
+        assert r.json()["error"]["code"] == "WRONG_MESSAGE_TYPE"
 
 
 # ---------------------------------------------------------------------------
@@ -501,7 +533,7 @@ async def _complete_session(
 async def _setup_disputed_session(
     initiator_client, responder_client
 ) -> tuple[str, str, str]:
-    """Complete a session and open a DISPUTE_NOTICE. Returns (session_id, record_hash, dispute_notice_id)."""
+    """Complete a session and open a dispute_notice. Returns (session_id, record_hash, dispute_notice_id)."""
     session_id, record_hash = await _complete_session(initiator_client, responder_client)
     body = _dispute_notice_body(session_id, record_hash)
     r = await initiator_client.post(
@@ -521,7 +553,7 @@ def _dispute_resolved_body(
 ) -> dict:
     mid = msg_id or str(uuid.uuid4())
     return {
-        "message_type": "DISPUTE_RESOLVED",
+        "message_type": "dispute_resolved",
         "message_id": mid,
         "session_id": session_id,
         "transaction_record_hash": record_hash,
@@ -546,7 +578,7 @@ class TestDisputeResolvedDataclass:
             resolution_outcome="buyer_prevails",
             resolver_did="did:web:resolver.example",
         )
-        assert msg.message_type == "DISPUTE_RESOLVED"
+        assert msg.message_type == "dispute_resolved"
         assert msg.protocol_version == "0.2"
         assert msg.evidence_references == []
         assert msg.resolution_notes is None
@@ -600,7 +632,7 @@ class TestDisputeResolvedDataclass:
         assert d["resolution_outcome"] == "mutual_settlement"
         assert d["resolver_did"] == "did:web:resolver.example"
         assert d["dispute_notice_message_id"] == "msg-3"
-        assert d["message_type"] == "DISPUTE_RESOLVED"
+        assert d["message_type"] == "dispute_resolved"
 
     def test_to_dict_omits_none_resolution_notes(self):
         msg = DisputeResolvedMessage(
@@ -639,7 +671,7 @@ class TestDisputeResolvedSchema:
         import pathlib
         schema_path = pathlib.Path(__file__).parents[3] / "spec" / "schemas" / "dispute_resolved.schema.json"
         schema = json.loads(schema_path.read_text())
-        assert schema["properties"]["message_type"]["const"] == "DISPUTE_RESOLVED"
+        assert schema["properties"]["message_type"]["const"] == "dispute_resolved"
         assert "transaction_record_hash" in schema["required"]
         assert "dispute_notice_message_id" in schema["required"]
         assert "resolver_did" in schema["required"]
@@ -652,7 +684,7 @@ class TestDisputeResolvedSchema:
 
 
 # ---------------------------------------------------------------------------
-# Server endpoint tests: DISPUTE_RESOLVED
+# Server endpoint tests: dispute_resolved
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
@@ -816,7 +848,7 @@ class TestDisputeResolvedEndpoint:
             test_client, responder_test_client
         )
         body = _dispute_resolved_body(session_id, record_hash, notice_id)
-        body["message_type"] = "DISPUTE_NOTICE"
+        body["message_type"] = "dispute_notice"
         r = await test_client.post(
             f"/sessions/{session_id}/dispute-resolved", json=body, headers=_h(body["message_id"])
         )

--- a/spec/a2cn-spec-v0.2.0.md
+++ b/spec/a2cn-spec-v0.2.0.md
@@ -1929,19 +1929,19 @@ overlay records delivery, closure, dispute, and resolution status.
 ```text
 COMPLETED
     │
-    │ DELIVERY_NOTICE
+    │ delivery_notice
     ▼
 DELIVERY_NOTICE_RECORDED
     │
-    ├─ DELIVERY_ACKNOWLEDGED accepted=true ───────────────▶ CLOSED
+    ├─ delivery_acknowledged accepted=true ───────────────▶ CLOSED
     │
-    ├─ DELIVERY_ACKNOWLEDGED accepted=false ──────────────▶ DISPUTED
+    ├─ delivery_acknowledged accepted=false ──────────────▶ DISPUTED
     │
-    └─ DISPUTE_NOTICE ───────────────────────────────────▶ DISPUTED
+    └─ dispute_notice ───────────────────────────────────▶ DISPUTED
 
-COMPLETED ── DISPUTE_NOTICE ─────────────────────────────▶ DISPUTED
+COMPLETED ── dispute_notice ─────────────────────────────▶ DISPUTED
 
-DISPUTED ── DISPUTE_RESOLVED ────────────────────────────▶ RESOLVED
+DISPUTED ── dispute_resolved ────────────────────────────▶ RESOLVED
 ```
 
 All post-commitment messages MUST reference the `session_id` and
@@ -1949,16 +1949,16 @@ All post-commitment messages MUST reference the `session_id` and
 reject a post-commitment message whose `transaction_record_hash` does not match
 the locally generated transaction record hash for the session.
 
-#### 10.6.1 DELIVERY_NOTICE
+#### 10.6.1 delivery_notice
 
-`DELIVERY_NOTICE` is sent by the seller or obligated delivery party to record
+`delivery_notice` is sent by the seller or obligated delivery party to record
 delivery against a completed session.
 
 Normative fields:
 
 | Field | Requirement |
 | --- | --- |
-| `message_type` | MUST be `DELIVERY_NOTICE` |
+| `message_type` | MUST be `delivery_notice` |
 | `message_id` | Unique message identifier |
 | `session_id` | A2CN session being delivered against |
 | `transaction_record_hash` | Hash of the agreed transaction record |
@@ -1969,40 +1969,40 @@ Normative fields:
 The corresponding JSON Schema is
 `spec/schemas/delivery_notice.schema.json`.
 
-#### 10.6.2 DELIVERY_ACKNOWLEDGED
+#### 10.6.2 delivery_acknowledged
 
-`DELIVERY_ACKNOWLEDGED` is sent by the buyer or delivery recipient in response
-to a `DELIVERY_NOTICE`.
+`delivery_acknowledged` is sent by the buyer or delivery recipient in response
+to a `delivery_notice`.
 
 Normative fields:
 
 | Field | Requirement |
 | --- | --- |
-| `message_type` | MUST be `DELIVERY_ACKNOWLEDGED` |
+| `message_type` | MUST be `delivery_acknowledged` |
 | `message_id` | Unique message identifier |
 | `session_id` | A2CN session being acknowledged |
 | `transaction_record_hash` | Hash of the agreed transaction record |
-| `delivery_notice_message_id` | `message_id` of the `DELIVERY_NOTICE` being acknowledged |
+| `delivery_notice_message_id` | `message_id` of the `delivery_notice` being acknowledged |
 | `acknowledgment_timestamp` | ISO 8601 timestamp of acknowledgment |
 | `accepted` | `true` closes the lifecycle as `CLOSED`; `false` moves the lifecycle to `DISPUTED` |
 | `notes` | Optional human-readable acknowledgment or rejection notes |
 
-An implementation MUST reject `DELIVERY_ACKNOWLEDGED` if the referenced
-`delivery_notice_message_id` does not match a recorded `DELIVERY_NOTICE` for the
+An implementation MUST reject `delivery_acknowledged` if the referenced
+`delivery_notice_message_id` does not match a recorded `delivery_notice` for the
 same session. The corresponding JSON Schema is
 `spec/schemas/delivery_acknowledged.schema.json`.
 
-#### 10.6.3 DISPUTE_NOTICE
+#### 10.6.3 dispute_notice
 
-`DISPUTE_NOTICE` is sent by either party to open a post-commitment dispute. It
-MAY be sent directly after `COMPLETED` or after a `DELIVERY_NOTICE` /
-`DELIVERY_ACKNOWLEDGED accepted=false` path.
+`dispute_notice` is sent by either party to open a post-commitment dispute. It
+MAY be sent directly after `COMPLETED` or after a `delivery_notice` /
+`delivery_acknowledged accepted=false` path.
 
 Normative fields:
 
 | Field | Requirement |
 | --- | --- |
-| `message_type` | MUST be `DISPUTE_NOTICE` |
+| `message_type` | MUST be `dispute_notice` |
 | `message_id` | Unique message identifier |
 | `session_id` | A2CN session being disputed |
 | `transaction_record_hash` | Hash of the agreed transaction record |
@@ -2013,40 +2013,40 @@ Normative fields:
 | `evidence_references` | Optional list of document references, content hashes, or URLs supporting the dispute |
 | `resolution_requested` | Optional requested path: `renegotiate`, `cancel`, or `neutral_review` |
 
-Recording a valid `DISPUTE_NOTICE` moves the post-commitment lifecycle to
+Recording a valid `dispute_notice` moves the post-commitment lifecycle to
 `DISPUTED`. The corresponding JSON Schema is
 `spec/schemas/dispute_notice.schema.json`.
 
-#### 10.6.4 DISPUTE_RESOLVED
+#### 10.6.4 dispute_resolved
 
-`DISPUTE_RESOLVED` is sent by the neutral resolver, or by another resolver
+`dispute_resolved` is sent by the neutral resolver, or by another resolver
 explicitly accepted by both parties, to record the outcome of a dispute opened
-by `DISPUTE_NOTICE`. This message closes the disputed post-commitment lifecycle.
+by `dispute_notice`. This message closes the disputed post-commitment lifecycle.
 
 Normative fields:
 
 | Field | Requirement |
 | --- | --- |
-| `message_type` | MUST be `DISPUTE_RESOLVED` |
+| `message_type` | MUST be `dispute_resolved` |
 | `message_id` | Unique message identifier |
 | `session_id` | A2CN session whose dispute is being resolved |
 | `transaction_record_hash` | Hash of the agreed transaction record |
-| `dispute_notice_message_id` | `message_id` of the `DISPUTE_NOTICE` being closed |
+| `dispute_notice_message_id` | `message_id` of the `dispute_notice` being closed |
 | `resolution_outcome` | MUST be one of `buyer_prevails`, `seller_prevails`, or `mutual_settlement` |
 | `resolver_did` | DID of the neutral resolver |
 | `resolution_timestamp` | ISO 8601 timestamp when the resolution was issued |
 | `resolution_notes` | Optional human-readable explanation from the resolver |
 | `evidence_references` | Optional list of supporting evidence references for the ruling |
 
-An implementation MUST reject `DISPUTE_RESOLVED` unless the session has an open
-`DISPUTE_NOTICE` and the `dispute_notice_message_id` matches the recorded
+An implementation MUST reject `dispute_resolved` unless the session has an open
+`dispute_notice` and the `dispute_notice_message_id` matches the recorded
 dispute notice for the same session. It MUST reject any `resolution_outcome`
 outside the enum above. The corresponding JSON Schema is
 `spec/schemas/dispute_resolved.schema.json`.
 
 #### 10.6.5 Concordia Composition
 
-A2CN's `DISPUTE_RESOLVED` message can compose with a Concordia fulfillment
+A2CN's `dispute_resolved` message can compose with a Concordia fulfillment
 attestation. The A2CN message supplies the commercial dispute outcome and binds
 it to both the transaction record and the original dispute notice. Section 16.2
 documents the cross-protocol `references[]` relationship vocabulary and
@@ -3070,7 +3070,7 @@ with their resolution version rather than being renumbered.
 | OQ-011 | A2CN as A2A extension | Open — profile scoped | Extension URI defined as `https://a2cn.io/extensions/commercial-negotiation/v1`. Section 16.2 documents AgentCard declaration, A2CN/Concordia/BidAngel substrate split, and starter `references[]` relationship vocabulary. Formal A2A governance outcome pending. |
 | OQ-012 | Reverse auction / multi-party invitation | Open | Fairmarkit's reverse auction model involves one buyer inviting multiple competing suppliers. Session Invitation (Component 8) covers bilateral invitation. Multi-party sourcing events where multiple supplier sessions run concurrently are out of scope for v0.2. |
 | OQ-013 | DID VC mandate for hosted endpoints | Open | When a neutral hosted endpoint provider hosts an A2CN endpoint on behalf of a supplier, the mandate is Tier 1 (Declared) by design. Whether the provider can issue a Tier 2 (DID VC) mandate on behalf of a supplier requires further analysis of the trust model. |
-| OQ-017 | Post-commitment lifecycle messages | **Resolved — v0.2.0** | Resolved: DELIVERY_NOTICE, DELIVERY_ACKNOWLEDGED, DISPUTE_NOTICE, and DISPUTE_RESOLVED are normative at Level 3 conformance as of v0.2.0; see Section 10.6. Rationale: a non-normative dispute path prevents reputation infrastructure (e.g. Verascore) from distinguishing 'commitment honored' from 'commitment abandoned', breaking reputation accuracy in the procurement vertical. |
+| OQ-017 | Post-commitment lifecycle messages | **Resolved — v0.2.0** | Resolved: delivery_notice, delivery_acknowledged, dispute_notice, and dispute_resolved are normative at Level 3 conformance as of v0.2.0; see Section 10.6. Rationale: a non-normative dispute path prevents reputation infrastructure (e.g. Verascore) from distinguishing 'commitment honored' from 'commitment abandoned', breaking reputation accuracy in the procurement vertical. |
 | OQ-018 | ApprovalReceipt expiry handling | Open | Proposed: if an ApprovalReceipt expires before the paused act is sent or accepted, the session remains in or re-enters `AWAITING_HUMAN_APPROVAL`; it does not terminate solely because of receipt expiry. |
 | OQ-019 | Human approval threshold shape | Open | Proposed v0.3: `requires_human_approval_above` remains a global scalar on the mandate. Per-counterparty tiers are a v0.4 extension point. |
 | OQ-020 | Mandate revocation signal | Open | Decide whether revocation is represented by a dedicated `MANDATE_REVOKED` message type or by absence of a fresh approval/mandate receipt. |
@@ -3203,7 +3203,7 @@ when reading or forwarding `references[]`. Unknown relationship values MUST NOT
 be dropped, rewritten, or treated as authorization grants unless the
 implementation explicitly recognizes their semantics.
 
-**Concordia adapter composition:** A2CN's `DISPUTE_RESOLVED` message can compose
+**Concordia adapter composition:** A2CN's `dispute_resolved` message can compose
 with a Concordia fulfillment attestation. The A2CN message records the dispute
 resolution outcome and binds it to the transaction record; the Concordia artifact
 can then reference the A2CN session, transaction record, and dispute resolution
@@ -3626,13 +3626,13 @@ messages that validate against these schemas.
 ### Patch 2026-05-19 — Post-commitment lifecycle documentation
 
 - Section 10.6 added: documents the Level 3 post-commitment lifecycle from
-  `DELIVERY_NOTICE` through `DELIVERY_ACKNOWLEDGED`, `DISPUTE_NOTICE`, and
-  `DISPUTE_RESOLVED`.
-- `DISPUTE_RESOLVED` fields documented normatively, including
+  `delivery_notice` through `delivery_acknowledged`, `dispute_notice`, and
+  `dispute_resolved`.
+- `dispute_resolved` fields documented normatively, including
   `transaction_record_hash`, `dispute_notice_message_id`, `resolution_outcome`,
   `resolver_did`, and `resolution_timestamp`.
 - OQ-017 updated to point to the normative Section 10.6 lifecycle definition.
-- Concordia composition cross-reference added for `DISPUTE_RESOLVED`.
+- Concordia composition cross-reference added for `dispute_resolved`.
 
 ### Patch 2026-05-19 — EU AI Act Article 14 oversight mapping
 
@@ -3653,7 +3653,7 @@ messages that validate against these schemas.
 - Documented the A2CN / Concordia / BidAngel substrate split.
 - Added starter cross-protocol `references[]` relationship vocabulary and
   forward-compatibility rule for unknown relationship values.
-- Documented `DISPUTE_RESOLVED` composition with Concordia fulfillment
+- Documented `dispute_resolved` composition with Concordia fulfillment
   attestations.
 - Updated OQ-011 status to reflect the scoped URI/profile while governance
   outcome remains pending.

--- a/spec/schemas/delivery_acknowledged.schema.json
+++ b/spec/schemas/delivery_acknowledged.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://a2cn.dev/schemas/delivery-acknowledged/0.2",
   "title": "A2CN DeliveryAcknowledgedMessage",
-  "description": "Buyer acknowledgment of a DELIVERY_NOTICE. accepted=true closes the lifecycle; accepted=false triggers DISPUTED status. Normative at Level 3 conformance as of v0.2.0 (OQ-017 resolved).",
+  "description": "Buyer acknowledgment of a delivery_notice. accepted=true closes the lifecycle; accepted=false triggers DISPUTED status. Normative at Level 3 conformance as of v0.2.0 (OQ-017 resolved).",
   "type": "object",
   "required": [
     "message_id",
@@ -14,7 +14,7 @@
     "message_type"
   ],
   "properties": {
-    "message_type": { "type": "string", "const": "DELIVERY_ACKNOWLEDGED" },
+    "message_type": { "type": "string", "const": "delivery_acknowledged" },
     "message_id": { "type": "string", "format": "uuid" },
     "session_id": { "type": "string" },
     "transaction_record_hash": {
@@ -24,7 +24,7 @@
     },
     "delivery_notice_message_id": {
       "type": "string",
-      "description": "message_id of the corresponding DELIVERY_NOTICE"
+      "description": "message_id of the corresponding delivery_notice"
     },
     "acknowledgment_timestamp": {
       "type": "string",

--- a/spec/schemas/delivery_notice.schema.json
+++ b/spec/schemas/delivery_notice.schema.json
@@ -12,7 +12,7 @@
     "message_type"
   ],
   "properties": {
-    "message_type": { "type": "string", "const": "DELIVERY_NOTICE" },
+    "message_type": { "type": "string", "const": "delivery_notice" },
     "message_id": { "type": "string", "format": "uuid" },
     "session_id": { "type": "string" },
     "transaction_record_hash": {

--- a/spec/schemas/dispute_notice.schema.json
+++ b/spec/schemas/dispute_notice.schema.json
@@ -15,7 +15,7 @@
     "message_type"
   ],
   "properties": {
-    "message_type": { "type": "string", "const": "DISPUTE_NOTICE" },
+    "message_type": { "type": "string", "const": "dispute_notice" },
     "message_id": { "type": "string", "format": "uuid" },
     "session_id": { "type": "string" },
     "transaction_record_hash": {

--- a/spec/schemas/dispute_resolved.schema.json
+++ b/spec/schemas/dispute_resolved.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://a2cn.dev/schemas/dispute-resolved/0.2",
   "title": "A2CN DisputeResolvedMessage",
-  "description": "Resolution of a dispute opened by DISPUTE_NOTICE. Closes the post-commitment dispute lifecycle. Normative at Level 3 conformance as of v0.2.0 (OQ-017 resolved).",
+  "description": "Resolution of a dispute opened by dispute_notice. Closes the post-commitment dispute lifecycle. Normative at Level 3 conformance as of v0.2.0 (OQ-017 resolved).",
   "type": "object",
   "required": [
     "message_id",
@@ -15,7 +15,7 @@
     "message_type"
   ],
   "properties": {
-    "message_type": { "type": "string", "const": "DISPUTE_RESOLVED" },
+    "message_type": { "type": "string", "const": "dispute_resolved" },
     "message_id": { "type": "string", "format": "uuid" },
     "session_id": { "type": "string" },
     "transaction_record_hash": {
@@ -25,7 +25,7 @@
     },
     "dispute_notice_message_id": {
       "type": "string",
-      "description": "message_id of the DISPUTE_NOTICE being resolved"
+      "description": "message_id of the dispute_notice being resolved"
     },
     "resolution_outcome": {
       "type": "string",


### PR DESCRIPTION
## Summary

Implements A2C-74 by aligning post-commitment `message_type` values with the lowercase wire-format convention used by the core protocol messages.

- Changes post-commitment dataclass defaults to `delivery_notice`, `delivery_acknowledged`, `dispute_notice`, and `dispute_resolved`.
- Updates HTTP handlers to reject the old uppercase message types with `WRONG_MESSAGE_TYPE` where they validate the post-commitment body.
- Aligns schemas, spec text, and post-commitment tests with the lowercase values.
- Adds regression coverage for uppercase values being rejected by delivery notice, delivery acknowledged, and dispute notice endpoints; existing dispute resolved coverage was updated to the new expected value.

A2C-82 note: the version-story fix for post-commitment v0.2.0 labels is already covered by PR #52, so this PR stays focused on A2C-74.

## Validation

- `uv run pytest tests/test_post_commitment.py -q` → 54 passed
- `uv run pytest -q` → 469 passed

The suite still emits existing pytest-asyncio / Python 3.14 deprecation warnings.