### PR TITLE
docs: refresh public status claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A2CN defines neutral infrastructure for agent-to-agent commercial negotiation.
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Spec Version](https://img.shields.io/badge/Spec-v0.2.0-green.svg)](spec/a2cn-spec-v0.2.0.md)
-[![Tests](https://img.shields.io/badge/Tests-390%20passing-brightgreen.svg)](reference-implementation/python/tests)
+[![Tests](https://img.shields.io/badge/Tests-469%20passing-brightgreen.svg)](reference-implementation/python/tests)
 [![Status](https://img.shields.io/badge/Status-Partner%20Ready-orange.svg)]()
 
 ---
@@ -81,6 +81,18 @@ The invitation is signed using the inviter's DID key (ES256 by default, EdDSA/Ed
 
 **Nue.io:** `NueEventParser` translates Nue pricing and subscription data into A2CN `saas_renewal` terms, and translates agreed terms into Nue order creation (`POST {NUE_BASE_URL}/orders`) with `externalReference: a2cn-session-{id}` for audit linkage.
 
+**SAP Ariba:** `AribaEventParser` translates Event Management and Discovery RFx publication payloads into A2CN `goods_procurement` terms, then builds bid and acknowledgement payloads for write-back.
+
+**JAGGAER:** `JaggaerEventParser` translates ASO sourcing events and CHES API event payloads into `goods_procurement` terms, preserving item and lot identifiers for supplier responses.
+
+**Conga:** `CongaQuoteParser` translates CPQ/CLM quote and agreement data into A2CN terms for SaaS renewals or goods procurement, with Salesforce-native write-back shapes.
+
+**Ironclad:** `IroncladWebhookVerifier` and workflow translators map signed workflow events into A2CN terms and write agreed metadata back to Ironclad workflows and records.
+
+**Vendr:** Vendr benchmark pricing maps into A2CN `saas_renewal` terms for renewal intelligence and produces audit summaries after agreement.
+
+**DocuSign:** DocuSign post-commitment helpers generate envelope payloads from completed A2CN transaction records and verify Connect HMAC callbacks.
+
 ### Deal-type-specific terms schemas
 
 Two registered deal types now have normative JSON schemas:
@@ -116,7 +128,7 @@ negotiation trail while keeping human oversight explicit and auditable.
 | **Session state machine** | Phases, turn-taking, round limits, timeouts, impasse detection, human approval pauses |
 | **Transaction record** | Immutable, content-addressed, dual-signed by both parties |
 | **Audit log** | Structured EU AI Act compliance output for every terminal session state |
-| **Post-commitment lifecycle** | DELIVERY_NOTICE (seller confirms delivery), DELIVERY_ACKNOWLEDGED (buyer closes or disputes), DISPUTE_NOTICE (neutral evidence anchoring) — v0.3 |
+| **Post-commitment lifecycle** | `delivery_notice`, `delivery_acknowledged`, `dispute_notice`, and `dispute_resolved` — normative at Level 3 in v0.2.0 |
 
 ### What A2CN is not
 
@@ -182,7 +194,7 @@ python examples/invitation_flow.py
 ```bash
 pip install -r requirements.txt
 pytest tests/ -v
-# 390 passed
+# 469 passed
 ```
 
 ---
@@ -256,9 +268,9 @@ rather than platform-local implementation details.
 
 ## The spec
 
-Full protocol specification: [`spec/a2cn-spec-v0.2.0.md`](spec/a2cn-spec-v0.2.0.md) — 3,300+ lines covering eight protocol components with normative JSON schemas, platform integration patterns for Fairmarkit, Salesforce Revenue Cloud, Dynamics 365, Luminance, and A2A, and a complete four-round SaaS renewal walkthrough with concrete message envelopes.
+Full protocol specification: [`spec/a2cn-spec-v0.2.0.md`](spec/a2cn-spec-v0.2.0.md) — 3,300+ lines covering eight protocol components with normative JSON schemas, platform integration patterns across procurement, revenue, CLM, CPQ, renewal, and eSignature systems, and a complete four-round SaaS renewal walkthrough with concrete message envelopes.
 
-**Spec status:** v0.2.0. Passed four independent critique cycles. Verified against reference implementation (390 tests).
+**Spec status:** v0.2.0. Passed four independent critique cycles. Verified against reference implementation (469 tests).
 
 ---
 
@@ -287,7 +299,13 @@ A2CN/
         │   ├── keelvar_adapter.py       # Keelvar → A2CN translation
         │   ├── revenue_cloud_adapter.py # Revenue Cloud → A2CN translation
         │   ├── dealhub_adapter.py       # DealHub → A2CN translation
-        │   └── nue_adapter.py           # Nue.io → A2CN translation
+        │   ├── nue_adapter.py           # Nue.io → A2CN translation
+        │   ├── ariba_adapter.py         # SAP Ariba → A2CN translation
+        │   ├── jaggaer_adapter.py       # JAGGAER ASO → A2CN translation
+        │   ├── conga_adapter.py         # Conga CPQ/CLM → A2CN translation
+        │   ├── ironclad_adapter.py      # Ironclad workflow → A2CN translation
+        │   ├── vendr_adapter.py         # Vendr benchmark → A2CN translation
+        │   └── docusign_adapter.py      # A2CN record → DocuSign envelope
         ├── tests/
         │   ├── test_invitations.py
         │   ├── test_deal_type_terms.py
@@ -309,9 +327,9 @@ A2CN/
 | Milestone | Status |
 |-----------|--------|
 | Protocol spec v0.2.0 | ✓ Complete — 3,300+ lines, 8 components |
-| Reference implementation (Python) | ✓ Complete — 390 tests passing |
+| Reference implementation (Python) | ✓ Complete — 469 tests passing |
 | Session Invitation (Component 8) | ✓ Complete — signed invitations, lifecycle, hosted endpoint pattern |
-| Platform adapters | ✓ Complete — Fairmarkit, Salesforce Revenue Cloud, Keelvar, DealHub, Nue.io |
+| Platform adapters | ✓ Complete — 11 adapters: Fairmarkit, Keelvar, Salesforce Revenue Cloud, DealHub, Nue.io, SAP Ariba, JAGGAER, Conga, Ironclad, Vendr, DocuSign |
 | LLM agent skills file | ✓ Complete — `reference-implementation/skills/a2cn-negotiation.md` |
 | End-to-end bilateral demo | ✓ Working — matching record hashes |
 | Invitation flow demo | ✓ Working — Fairmarkit BID_CREATED pattern |
@@ -320,7 +338,7 @@ A2CN/
 | Deal type registry | ✓ Published — `a2cn.dev/registry/deal-types` |
 | A2A extension proposal | 🔄 In progress — joint proposal with Concordia Protocol |
 | Neutral third-party record custody | 📋 Planned — v0.3 |
-| Post-commitment lifecycle (DELIVERY_NOTICE / DELIVERY_ACKNOWLEDGED / DISPUTE_NOTICE / DISPUTE_RESOLVED) | ✓ Complete — v0.2.1 |
+| Post-commitment lifecycle (`delivery_notice` / `delivery_acknowledged` / `dispute_notice` / `dispute_resolved`) | ✓ Complete — v0.2.0 |
 | SessionStore interface (pluggable persistence for Redis / PostgreSQL) | ✓ Complete — InMemorySessionStore default shipped |
 | UBL 2.1 invoice export from transaction records | 📋 Planned — v0.3 |
 | TypeScript reference implementation | 📋 Planned |

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ The invitation is signed using the inviter's DID key (ES256 by default, EdDSA/Ed
 
 **JAGGAER:** `JaggaerEventParser` translates ASO sourcing events and CHES API event payloads into `goods_procurement` terms, preserving item and lot identifiers for supplier responses.
 
-**Conga:** `CongaQuoteParser` translates CPQ/CLM quote and agreement data into A2CN terms for SaaS renewals or goods procurement, with Salesforce-native write-back shapes.
+**Conga:** `CongaAdapter` translates CPQ/CLM quote and agreement data into A2CN terms for SaaS renewals or goods procurement, with Salesforce-native write-back shapes.
 
-**Ironclad:** `IroncladWebhookVerifier` and workflow translators map signed workflow events into A2CN terms and write agreed metadata back to Ironclad workflows and records.
+**Ironclad:** `IroncladWebhookParser` and workflow translators map signed workflow events into A2CN terms and write agreed metadata back to Ironclad workflows and records.
 
 **Vendr:** Vendr benchmark pricing maps into A2CN `saas_renewal` terms for renewal intelligence and produces audit summaries after agreement.
 

--- a/RELEASE_NOTES_v0.2.0.md
+++ b/RELEASE_NOTES_v0.2.0.md
@@ -2,7 +2,7 @@
 
 **Released:** April 2026  
 **Spec:** v0.2.0 (3,300+ lines)  
-**Tests:** 390 passing
+**Tests:** 469 passing
 **License:** Apache 2.0
 
 ## What's new in v0.2.0
@@ -16,6 +16,12 @@ Solves the cold-start problem. A buyer agent can now invite a supplier who has n
 - **Keelvar** — SOURCING_EVENTS_FEED_UPDATED webhook → A2CN session translation.
 - **DealHub** — DealHubEventParser translates quoteReady webhook payloads into A2CN saas_renewal terms and translates agreed terms back into DealHub Actions API calls to mark the quote as externally signed.
 - **Nue.io** — NueEventParser translates Nue pricing and subscription data into A2CN saas_renewal terms and translates agreed terms into Nue order creation with externalReference linkage for audit.
+- **SAP Ariba** — Event Management and Discovery RFx publication payloads → A2CN goods_procurement terms, with bid and acknowledgement write-back helpers.
+- **JAGGAER** — ASO sourcing events and CHES API events → A2CN goods_procurement terms, preserving item and lot IDs for supplier responses.
+- **Conga** — CPQ/CLM quote and agreement data → A2CN saas_renewal or goods_procurement terms, with Salesforce-native write-back payloads.
+- **Ironclad** — Signed workflow events → A2CN terms, plus workflow metadata and record write-back helpers.
+- **Vendr** — Renewal benchmark pricing → A2CN saas_renewal terms and post-agreement audit summaries.
+- **DocuSign** — Completed A2CN transaction records → eSignature envelope payloads, with Connect HMAC verification.
 
 ### Deal-type-specific terms schemas
 - `goods_procurement` — delivery_days, unit_of_measure, manufacturer and internal part numbers
@@ -57,7 +63,7 @@ python examples/keelvar_demo.py
 ```bash
 pip install -r requirements.txt
 pytest tests/ -v
-# 390 passed
+# 469 passed
 ```
 
 ## What's next (v0.3)

--- a/docs.html
+++ b/docs.html
@@ -628,7 +628,7 @@
         </div>
       </div>
       <div class="callout">
-        <strong>Canonical implementation:</strong> the Python reference server is the executable model for v0.2.0 behavior and currently ships with 465 passing tests.
+        <strong>Canonical implementation:</strong> the Python reference server is the executable model for v0.2.0 behavior and currently ships with 469 passing tests.
         Source, tests, and deeper implementation detail remain available in the
         <a class="plausible-event-name=GitHub+Click" href="https://github.com/A2CN-protocol/A2CN" target="_blank" rel="noopener">GitHub repository</a>.
       </div>
@@ -1216,7 +1216,7 @@ assert ok is True</code></pre>
 <footer>
   <div class="footer-inner">
     <span>A2CN developer docs</span>
-    <span>Apache 2.0 - spec v0.2.0 - 465 tests passing</span>
+    <span>Apache 2.0 - spec v0.2.0 - 469 tests passing</span>
   </div>
 </footer>
 

--- a/index.html
+++ b/index.html
@@ -1579,7 +1579,7 @@
             <div class="tl-dot"></div>
             <div class="tl-content">
               <div class="tl-title">A2CN v0.2.0 — you are here</div>
-              <div class="tl-desc">Open, neutral protocol for commercial negotiation between agents from different organizations. 8 components, 465 tests, 11 platform adapters, MCP server, A2A extension proposal submitted.</div>
+              <div class="tl-desc">Open, neutral protocol for commercial negotiation between agents from different organizations. 8 components, 469 tests, 11 platform adapters, MCP server, A2A extension proposal submitted.</div>
             </div>
           </div>
 
@@ -2081,7 +2081,7 @@
     <h2 class="section-heading">Built. Being proposed. Still to come.</h2>
     <p class="section-lede">
       A2CN is an open protocol with a complete Python reference implementation,
-      465 passing tests, 11 platform adapters, and an A2A extension proposal in review.
+      469 passing tests, 11 platform adapters, and an A2A extension proposal in review.
     </p>
 
     <div class="status-split">
@@ -2092,7 +2092,7 @@
         </div>
         <ul>
           <li>Protocol spec v0.2.0 <span class="detail">3,700+ lines, 8 components, Apache 2.0</span></li>
-          <li>Reference implementation <span class="detail">Python, 465 tests passing</span></li>
+          <li>Reference implementation <span class="detail">Python, 469 tests passing</span></li>
           <li>Session invitation <span class="detail">cold-start adoption solved</span></li>
           <li>Platform adapters <span class="detail">Fairmarkit, Keelvar, Ariba, JAGGAER, Revenue Cloud, DealHub, Nue.io, Conga, Ironclad, DocuSign, Vendr</span></li>
           <li>MCP server <span class="detail">Claude Desktop, LangChain, LangGraph, Agentforce, Cursor</span></li>
@@ -2185,7 +2185,7 @@
         <div class="involve-title">Build on it</div>
         <div class="involve-body">
           Start from the developer docs, then drop into the Python reference
-          implementation with 465 passing tests. Apache 2.0 license.
+          implementation with 469 passing tests. Apache 2.0 license.
         </div>
         <a class="involve-link plausible-event-name=Docs+Click" href="docs.html">docs.html →</a>
       </div>
@@ -2216,7 +2216,7 @@
 <footer>
   <div class="footer-inner">
     <span class="footer-brand">A2CN</span>
-    <span class="footer-meta">Apache 2.0 · spec v0.2.0 · 465 tests passing</span>
+    <span class="footer-meta">Apache 2.0 · spec v0.2.0 · 469 tests passing</span>
   </div>
 </footer>
 

--- a/reference-implementation/python/README.md
+++ b/reference-implementation/python/README.md
@@ -3,7 +3,7 @@
 **The canonical Python implementation of the A2CN protocol.**
 
 [![Python](https://img.shields.io/badge/Python-3.11%2B-blue.svg)](https://python.org)
-[![Tests](https://img.shields.io/badge/Tests-390%20passing-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/Tests-469%20passing-brightgreen.svg)](tests/)
 [![Spec](https://img.shields.io/badge/Spec-v0.2.0-green.svg)](../../spec/a2cn-spec-v0.2.0.md)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.115-009688.svg)](https://fastapi.tiangolo.com)
 
@@ -303,7 +303,7 @@ Fork it, modify it, or build your own from scratch.
 ## Running the tests
 
 ```bash
-pytest tests/ -v   # 390 passed
+pytest tests/ -v   # 469 passed
 ```
 
 | Test file | What it covers |


### PR DESCRIPTION
## Summary

Bundles the public-doc residue from the latest reviews:

- A2C-82: updates README post-commitment lifecycle references to the lowercase v0.2.0 wire message names: `delivery_notice`, `delivery_acknowledged`, `dispute_notice`, and `dispute_resolved`.
- A2C-73 follow-up: refreshes public test-count claims from stale 390/465 values to the current 469 passing suite.
- A2C-81 follow-up: updates README and release notes adapter coverage from the older 5-adapter view to the current 11-adapter surface.

No protocol or implementation behavior changes; this is public documentation/status alignment only.

## Validation

- `git diff --check`
- `uv run pytest -q` → 469 passed

The suite still emits existing pytest-asyncio / Python 3.14 deprecation warnings.