### PR TITLE
docs: add NegotiationGroup extension path

### DIFF
--- a/reference-implementation/python/a2cn/crypto.py
+++ b/reference-implementation/python/a2cn/crypto.py
@@ -6,7 +6,7 @@ Implements:
 - RFC 8785 JCS canonicalization
 - SHA-256 hashing of JCS-canonicalized objects (base64url output)
 - JWS signing/verification of protocol act hashes using ES256 or EdDSA
-- JWT creation and verification for request authentication (Section 11.1.4)
+- JWT creation and verification for request authentication (Section 12.1.4)
 """
 
 import base64
@@ -224,7 +224,7 @@ def create_jwt(
     exp_seconds: int = 60,
 ) -> str:
     """
-    Create a signed JWT per Section 11.1.4.
+    Create a signed JWT per Section 12.1.4.
 
     Fields: iss, aud, iat, exp, jti, purpose (optional), session_id (optional)
     Algorithm: ES256 for P-256 keys, EdDSA for Ed25519 keys

--- a/reference-implementation/python/a2cn/messages.py
+++ b/reference-implementation/python/a2cn/messages.py
@@ -500,7 +500,7 @@ class WebhookPayload:
 
 
 # ---------------------------------------------------------------------------
-# v0.2.0: Invitation error codes (Section 12.2 extension)
+# v0.2.0: Invitation error codes (Section 11.7 extension)
 # ---------------------------------------------------------------------------
 
 INVITATION_EXPIRED = "INVITATION_EXPIRED"

--- a/reference-implementation/python/a2cn/server.py
+++ b/reference-implementation/python/a2cn/server.py
@@ -1,5 +1,5 @@
 """
-A2CN Responder — FastAPI server (Section 11.1.1)
+A2CN Responder — FastAPI server (Section 12.1.1)
 
 Endpoints:
   POST   /sessions                              — SessionInit
@@ -15,7 +15,7 @@ Endpoints:
   POST   /invitations/{invitation_id}/decline  — Decline invitation (v0.2.0)
   GET    /invitations/{invitation_id}          — Get invitation status (v0.2.0)
 
-JWT authentication is enforced on all state-modifying endpoints (Section 11.1.4).
+JWT authentication is enforced on all state-modifying endpoints (Section 12.1.4).
 All endpoints return Content-Type: application/a2cn+json.
 """
 
@@ -172,7 +172,7 @@ async def content_type_middleware(request: Request, call_next) -> Response:
 
 
 # ---------------------------------------------------------------------------
-# JWT auth — Section 11.1.4
+# JWT auth — Section 12.1.4
 # ---------------------------------------------------------------------------
 
 # This server's own DID, used as JWT audience.  Override with A2CN_SERVER_DID env var

--- a/reference-implementation/python/a2cn/session.py
+++ b/reference-implementation/python/a2cn/session.py
@@ -972,24 +972,24 @@ class SessionManager:
 # ---------------------------------------------------------------------------
 
 # Error codes used in this implementation and their spec references:
-#   SESSION_NOT_FOUND       — 404  — spec Section 12.2
-#   SESSION_WRONG_STATE     — 409  — spec Section 12.2
-#   NOT_YOUR_TURN           — 409  — spec Section 12.2
-#   SEQUENCE_ERROR          — 422  — spec Section 12.2
-#   OFFER_HASH_MISMATCH     — 400  — spec Section 12.2
-#   OFFER_EXPIRED           — 422  — spec Section 12.2
-#   ROUND_LIMIT_EXCEEDED    — 422  — spec Section 12.2
-#   WRONG_MESSAGE_TYPE      — 422  — spec Section 12.2
-#   INVALID_SIGNATURE       — 400  — spec Section 12.2
-#   DEAL_TYPE_NOT_SUPPORTED — 403  — spec Section 12.2
-#   MANDATE_INVALID         — 403  — spec Section 12.2
+#   SESSION_NOT_FOUND       — 404  — spec Section 12.3
+#   SESSION_WRONG_STATE     — 409  — spec Section 12.3
+#   NOT_YOUR_TURN           — 409  — spec Section 12.3
+#   SEQUENCE_ERROR          — 422  — spec Section 12.3
+#   OFFER_HASH_MISMATCH     — 400  — spec Section 12.3
+#   OFFER_EXPIRED           — 422  — spec Section 12.3
+#   ROUND_LIMIT_EXCEEDED    — 422  — spec Section 12.3
+#   WRONG_MESSAGE_TYPE      — 422  — spec Section 12.3
+#   INVALID_SIGNATURE       — 400  — spec Section 12.3
+#   DEAL_TYPE_NOT_SUPPORTED — 403  — spec Section 12.3
+#   MANDATE_INVALID         — 403  — spec Section 12.3
 #   NOT_IN_AWAITING_HUMAN_APPROVAL — 409 — human approval extension
 #   APPROVAL_RECEIPT_INVALID — 400 — human approval extension
 #   APPROVAL_RECEIPT_EXPIRED — 422 — human approval extension
 #   UNAUTHORIZED_APPROVER   — 403  — human approval extension
-#   PROTOCOL_VERSION_MISMATCH — 400 — spec Section 12.2
-#   UNAUTHORIZED_SENDER     — 403  — spec Section 12.2
-#   INVALID_REQUEST         — 400  — extension (not in spec Section 12.2 table);
+#   PROTOCOL_VERSION_MISMATCH — 400 — spec Section 12.3
+#   UNAUTHORIZED_SENDER     — 403  — spec Section 12.3
+#   INVALID_REQUEST         — 400  — extension (not in spec Section 12.3 table);
 #                                     used for malformed input that fails basic
 #                                     validation before any protocol logic runs
 

--- a/reference-implementation/python/tests/conformance/test_conformance.py
+++ b/reference-implementation/python/tests/conformance/test_conformance.py
@@ -119,7 +119,7 @@ async def test_turn_taking_enforced(test_client, responder_test_client, responde
 
 
 # ---------------------------------------------------------------------------
-# CONF-003: JWT authentication enforcement (Section 11.1.4)
+# CONF-003: JWT authentication enforcement (Section 12.1.4)
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio

--- a/spec/a2cn-spec-v0.2.0.md
+++ b/spec/a2cn-spec-v0.2.0.md
@@ -2076,6 +2076,37 @@ pre-session handshake that enables adoption by parties without pre-deployed
 endpoints. Once both endpoints are known, the standard A2CN session protocol
 applies unchanged.
 
+### 11.1.1 NegotiationGroup Extension Path *(non-normative)*
+
+A2CN v0.2.0 is deliberately bilateral: one session has one initiator, one
+responder, one turn order, and one independently reproducible transaction
+record. This keeps the base protocol tractable for initial enterprise
+validation.
+
+Multi-party sourcing events can extend the bilateral model without changing the
+base session semantics. The proposed extension is a **NegotiationGroup**: a
+coordination object that binds several independent bilateral A2CN sessions under
+one buyer-side sourcing event.
+
+A NegotiationGroup would let one buyer invite N sellers, typically 3-7, through
+parallel `SessionInvitation` flows. Each seller negotiates in its own bilateral
+session with its own turn order, mandate checks, signatures, timeouts, and
+transaction record. The coordination layer can then express buyer-side award
+logic, such as:
+
+- single award to one seller,
+- split award across multiple sellers,
+- per-party sequencing constraints when the sourcing workflow requires a
+  specific seller order, and
+- group-level status and audit references that point to the underlying
+  bilateral session IDs and transaction record hashes.
+
+This extension path follows the reverse-auction and multi-supplier framing
+raised by Ali Eren Aytekin (Spaceflow): the base protocol stays bilateral, while
+the sourcing platform or neutral coordination layer owns the group-level policy.
+OQ-012 tracks the open design questions for the group object shape, award
+semantics, and cross-session audit model.
+
 ### 11.2 SessionInvitation Message
 
 A `SessionInvitation` is a signed JSON document transmitted to a counterparty
@@ -3068,7 +3099,7 @@ with their resolution version rather than being renumbered.
 | OQ-009 | Platform DID proxy model | Open | Buyer-side platforms (Pactum, Fairmarkit, Zip) negotiate on behalf of enterprise customers whose DID is not the platform's own DID. Proposed: allow `did:web:platform.ai:customers:{customer-id}` pattern; platform serves the DID document; mandate credential scopes to customer organization. v0.3. |
 | OQ-010 | MESO (Multiple Equivalent Simultaneous Offers) | Open | Pactum's negotiation model presents bundled packages where the counterparty chooses between equivalent options (e.g., lower price vs. longer payment terms). Current offer schema is single-option. Proposed: `alternatives` array on Offer model. v0.3. |
 | OQ-011 | A2CN as A2A extension | Open — profile scoped | Extension URI defined as `https://a2cn.io/extensions/commercial-negotiation/v1`. Section 16.2 documents AgentCard declaration, A2CN/Concordia/BidAngel substrate split, and starter `references[]` relationship vocabulary. Formal A2A governance outcome pending. |
-| OQ-012 | Reverse auction / multi-party invitation | Open | Fairmarkit's reverse auction model involves one buyer inviting multiple competing suppliers. Session Invitation (Component 8) covers bilateral invitation. Multi-party sourcing events where multiple supplier sessions run concurrently are out of scope for v0.2. |
+| OQ-012 | NegotiationGroup multi-party sourcing extension | Open | A2CN v0.2.0 is deliberately bilateral. Multi-party sourcing can extend the base protocol through a NegotiationGroup coordination object: one buyer invites N sellers (typically 3-7) into parallel bilateral sessions, then records group-level award policy such as single award, split award, and per-party sequencing. See Section 11.1.1. |
 | OQ-013 | DID VC mandate for hosted endpoints | Open | When a neutral hosted endpoint provider hosts an A2CN endpoint on behalf of a supplier, the mandate is Tier 1 (Declared) by design. Whether the provider can issue a Tier 2 (DID VC) mandate on behalf of a supplier requires further analysis of the trust model. |
 | OQ-017 | Post-commitment lifecycle messages | **Resolved — v0.2.0** | Resolved: delivery_notice, delivery_acknowledged, dispute_notice, and dispute_resolved are normative at Level 3 conformance as of v0.2.0; see Section 10.6. Rationale: a non-normative dispute path prevents reputation infrastructure (e.g. Verascore) from distinguishing 'commitment honored' from 'commitment abandoned', breaking reputation accuracy in the procurement vertical. |
 | OQ-018 | ApprovalReceipt expiry handling | Open | Proposed: if an ApprovalReceipt expires before the paused act is sent or accepted, the session remains in or re-enters `AWAITING_HUMAN_APPROVAL`; it does not terminate solely because of receipt expiry. |
@@ -3598,6 +3629,13 @@ messages that validate against these schemas.
 
 ## 19. Changelog
 
+### Patch 2026-06-01 — NegotiationGroup extension path
+
+- Section 11.1.1 added: documents the non-normative NegotiationGroup extension
+  path for reverse-auction and multi-supplier sourcing workflows.
+- OQ-012 updated to name NegotiationGroup and scope multi-party sourcing as a
+  coordination layer over parallel bilateral A2CN sessions.
+
 ### Patch 2026-05-20 — DID-key JWS webhook signing
 
 - Section 11.1.6 updated to make Level 2 webhook callbacks DID-key JWS signed
@@ -3810,7 +3848,8 @@ Sections substantially rewritten and expanded with concrete integration patterns
 - OQ-010: MESO (Multiple Equivalent Simultaneous Offers) terms extension for
   Pactum-style bundle negotiations
 - OQ-011: A2CN as A2A extension — formal proposal filed, outcome pending
-- OQ-012: Multi-party invitation for reverse auction contexts
+- OQ-012: NegotiationGroup multi-party sourcing extension for reverse-auction
+  contexts
 - OQ-013: DID VC mandate for neutral hosted endpoints
 
 **Introduction updated:**

--- a/spec/a2cn-spec-v0.2.0.md
+++ b/spec/a2cn-spec-v0.2.0.md
@@ -2101,11 +2101,11 @@ logic, such as:
 - group-level status and audit references that point to the underlying
   bilateral session IDs and transaction record hashes.
 
-This extension path follows the reverse-auction and multi-supplier framing
-raised by Ali Eren Aytekin (Spaceflow): the base protocol stays bilateral, while
-the sourcing platform or neutral coordination layer owns the group-level policy.
-OQ-012 tracks the open design questions for the group object shape, award
-semantics, and cross-session audit model.
+This extension path follows reverse-auction and multi-supplier sourcing
+workflows: the base protocol stays bilateral, while the sourcing platform or
+neutral coordination layer owns the group-level policy. OQ-012 tracks the open
+design questions for the group object shape, award semantics, and cross-session
+audit model.
 
 ### 11.2 SessionInvitation Message
 
@@ -2332,12 +2332,12 @@ at the protocol level.
 
 ## 12. Transport Binding
 
-### 11.1 HTTP/REST Binding (Normative)
+### 12.1 HTTP/REST Binding (Normative)
 
 A2CN v0.1 defines one normative transport: HTTP/REST. All implementations MUST
 support this binding.
 
-#### 11.1.1 Endpoints
+#### 12.1.1 Endpoints
 
 | Method | Path | Purpose |
 |--------|------|---------|
@@ -2348,20 +2348,20 @@ support this binding.
 | GET | `/sessions/{id}/record` | Get transaction record (COMPLETED only) |
 | GET | `/sessions/{id}/audit` | Get audit log (any terminal state) |
 
-#### 11.1.2 Pagination
+#### 12.1.2 Pagination
 
 `GET /sessions/{id}/messages` MUST support cursor-based pagination:
 - `?after_sequence={n}` returns messages with `sequence_number` > n
 - Response MUST include a `next_cursor` field (null if no more messages)
 - Page size SHOULD default to 50 and MUST be configurable via `?limit={n}`
 
-#### 11.1.3 Idempotency Keys
+#### 12.1.3 Idempotency Keys
 
 All `POST` requests MUST include an `Idempotency-Key` header equal to the
 `message_id` of the message being sent. Servers MUST use this header (alongside
 the message body's `message_id`) to implement idempotency per Section 6.1.
 
-#### 11.1.4 Authentication
+#### 12.1.4 Authentication
 
 Every request MUST include `Authorization: Bearer {jwt}`.
 
@@ -2386,7 +2386,7 @@ the JWT against the verification method referenced in the sender's discovery
 document. Receivers MUST NOT verify JWTs using keys embedded in the discovery
 document directly.
 
-#### 11.1.5 HTTP Status Codes
+#### 12.1.5 HTTP Status Codes
 
 | Status | Meaning in A2CN context |
 |--------|------------------------|
@@ -2402,7 +2402,7 @@ document directly.
 | 429 | Rate limited |
 | 503 | DID resolution failure (temporary) |
 
-#### 11.1.6 Webhook Callbacks (RECOMMENDED; REQUIRED at Level 2)
+#### 12.1.6 Webhook Callbacks (RECOMMENDED; REQUIRED at Level 2)
 
 Implementations SHOULD support webhook callbacks to avoid polling overhead.
 Level 2 and Level 3 implementations MUST support webhook callbacks for terminal
@@ -2449,7 +2449,7 @@ also accepted when the sender's verification method uses an Ed25519 key.
 Webhook delivery is best-effort. The polling endpoint remains the authoritative
 source. Implementations MUST NOT rely exclusively on webhooks.
 
-#### 11.1.7 Version Negotiation
+#### 12.1.7 Version Negotiation
 
 The `protocol_version` field in SessionInit declares the initiator's version.
 If the responder does not support the declared version, it MUST reject with
@@ -2459,7 +2459,7 @@ an unsupported version.
 Backward compatibility expectations: minor versions within 0.x are not guaranteed
 compatible. v1.0 and beyond will define compatibility guarantees.
 
-#### 11.1.8 Content Type
+#### 12.1.8 Content Type
 
 All A2CN requests and responses MUST use `Content-Type: application/a2cn+json`.
 Servers MUST return `406 Not Acceptable` if a client requests a different type
@@ -2469,7 +2469,7 @@ via `Accept` header for a content type that is not supported.
 
 ## 12. Error Handling
 
-### 12.1 Error Response Format
+### 12.2 Error Response Format
 
 All A2CN errors use a single format regardless of whether they occur during
 session initiation or message exchange:
@@ -2490,7 +2490,7 @@ session initiation or message exchange:
 SessionReject messages also use this format via the `error_code` and
 `error_message` fields for consistency.
 
-### 12.2 Error Code Reference
+### 12.3 Error Code Reference
 
 | Code | HTTP | Permanent? | Description |
 |------|------|------------|-------------|
@@ -3549,7 +3549,7 @@ Copilot Studio agents without additional adapter code.
 
 A software system is a **conformant A2CN implementation** if it:
 
-1. Implements the HTTP/REST transport binding (Section 11.1)
+1. Implements the HTTP/REST transport binding (Section 12.1)
 2. Implements discovery document publishing and consumption (Section 4)
 3. Correctly implements all state machine transitions (Section 8)
 4. Implements turn-taking enforcement per Section 3.2
@@ -3638,7 +3638,7 @@ messages that validate against these schemas.
 
 ### Patch 2026-05-20 — DID-key JWS webhook signing
 
-- Section 11.1.6 updated to make Level 2 webhook callbacks DID-key JWS signed
+- Section 12.1.6 updated to make Level 2 webhook callbacks DID-key JWS signed
   instead of HMAC-SHA256/shared-secret signed.
 - Webhook signature headers now include sender DID, sender verification method,
   body hash, and compact JWS over the body hash.
@@ -4006,7 +4006,7 @@ Section 1.4 Scope updated to enumerate v0.2 additions over v0.1.
   (0.1.2) tracks editorial revisions. Wire protocol version (`protocol_version`,
   `a2cn_version`) remains `"0.1"` for all 0.1.x revisions.
 
-- **Fixed webhook JWT authentication (Section 11.1.6).** Added explicit rule:
+- **Fixed webhook JWT authentication (Section 12.1.6).** Added explicit rule:
   webhook JWTs MUST have `iss` = sender's DID and `aud` = receiver's DID.
   Previously the spec said "include Authorization header" without specifying
   the DID routing.
@@ -4018,7 +4018,7 @@ Section 1.4 Scope updated to enumerate v0.2 additions over v0.1.
 - **Fixed `REJECTED_FINAL` terminal notation (Section 8.2).** Changed "No→Yes"
   to "Yes" in the terminal state table.
 
-- **Added 406 to HTTP status code table (Section 11.1.5).**
+- **Added 406 to HTTP status code table (Section 12.1.5).**
 
 **Improvements:**
 


### PR DESCRIPTION
## Summary

Implements A2C-14 by documenting the multi-party sourcing roadmap path in the v0.2.0 spec.

- Adds non-normative Section 11.1.1, `NegotiationGroup Extension Path`.
- Names the proposed extension model as parallel bilateral A2CN sessions coordinated by a group object.
- Captures the Spaceflow framing: one buyer, typically 3-7 sellers, single award, split award, and per-party sequencing constraints.
- Updates OQ-012 to reference NegotiationGroup and keep v0.2.0 deliberately bilateral.
- Adds a changelog note.

No implementation behavior changes.

## Validation

- `git diff --check`