### PR TITLE
feat: emit Concordia fulfillment attestations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A2CN defines neutral infrastructure for agent-to-agent commercial negotiation.
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Spec Version](https://img.shields.io/badge/Spec-v0.2.0-green.svg)](spec/a2cn-spec-v0.2.0.md)
-[![Tests](https://img.shields.io/badge/Tests-469%20passing-brightgreen.svg)](reference-implementation/python/tests)
+[![Tests](https://img.shields.io/badge/Tests-474%20passing-brightgreen.svg)](reference-implementation/python/tests)
 [![Status](https://img.shields.io/badge/Status-Partner%20Ready-orange.svg)]()
 
 ---
@@ -194,7 +194,7 @@ python examples/invitation_flow.py
 ```bash
 pip install -r requirements.txt
 pytest tests/ -v
-# 469 passed
+# 474 passed
 ```
 
 ---
@@ -270,7 +270,7 @@ rather than platform-local implementation details.
 
 Full protocol specification: [`spec/a2cn-spec-v0.2.0.md`](spec/a2cn-spec-v0.2.0.md) — 3,300+ lines covering eight protocol components with normative JSON schemas, platform integration patterns across procurement, revenue, CLM, CPQ, renewal, and eSignature systems, and a complete four-round SaaS renewal walkthrough with concrete message envelopes.
 
-**Spec status:** v0.2.0. Passed four independent critique cycles. Verified against reference implementation (469 tests).
+**Spec status:** v0.2.0. Passed four independent critique cycles. Verified against reference implementation (474 tests).
 
 ---
 
@@ -327,7 +327,7 @@ A2CN/
 | Milestone | Status |
 |-----------|--------|
 | Protocol spec v0.2.0 | ✓ Complete — 3,300+ lines, 8 components |
-| Reference implementation (Python) | ✓ Complete — 469 tests passing |
+| Reference implementation (Python) | ✓ Complete — 474 tests passing |
 | Session Invitation (Component 8) | ✓ Complete — signed invitations, lifecycle, hosted endpoint pattern |
 | Platform adapters | ✓ Complete — 11 adapters: Fairmarkit, Keelvar, Salesforce Revenue Cloud, DealHub, Nue.io, SAP Ariba, JAGGAER, Conga, Ironclad, Vendr, DocuSign |
 | LLM agent skills file | ✓ Complete — `reference-implementation/skills/a2cn-negotiation.md` |

--- a/RELEASE_NOTES_v0.2.0.md
+++ b/RELEASE_NOTES_v0.2.0.md
@@ -2,7 +2,7 @@
 
 **Released:** April 2026  
 **Spec:** v0.2.0 (3,300+ lines)  
-**Tests:** 469 passing
+**Tests:** 474 passing
 **License:** Apache 2.0
 
 ## What's new in v0.2.0
@@ -36,6 +36,11 @@ Reference skills file for LLM agents participating in A2CN sessions. Covers warm
 ### Webhooks at Level 2
 Terminal state webhooks (COMPLETED, REJECTED_FINAL, WITHDRAWN, IMPASSE, TIMED_OUT) promoted from RECOMMENDED to REQUIRED for Level 2 conformance. Async delivery with exponential backoff retry.
 
+### Concordia fulfillment attestations
+Post-commitment delivery acceptance and dispute resolution can now emit a
+Concordia-shaped `FulfillmentAttestation`, signed with Ed25519 and linked back
+to the A2CN session through `references[]`.
+
 ## Installation
 
 ```bash
@@ -63,7 +68,7 @@ python examples/keelvar_demo.py
 ```bash
 pip install -r requirements.txt
 pytest tests/ -v
-# 469 passed
+# 474 passed
 ```
 
 ## What's next (v0.3)

--- a/docs.html
+++ b/docs.html
@@ -628,7 +628,7 @@
         </div>
       </div>
       <div class="callout">
-        <strong>Canonical implementation:</strong> the Python reference server is the executable model for v0.2.0 behavior and currently ships with 469 passing tests.
+        <strong>Canonical implementation:</strong> the Python reference server is the executable model for v0.2.0 behavior and currently ships with 474 passing tests.
         Source, tests, and deeper implementation detail remain available in the
         <a class="plausible-event-name=GitHub+Click" href="https://github.com/A2CN-protocol/A2CN" target="_blank" rel="noopener">GitHub repository</a>.
       </div>
@@ -889,6 +889,11 @@ python examples/saas_renewal.py --deal-type goods_procurement
               <td><span class="badge">Bearer JWT</span></td>
             </tr>
             <tr>
+              <td><code>GET /sessions/{session_id}/fulfillment-attestation</code></td>
+              <td>Fetch the Concordia-shaped fulfillment attestation emitted after clean delivery acceptance or dispute resolution.</td>
+              <td><span class="badge">Bearer JWT</span></td>
+            </tr>
+            <tr>
               <td><code>POST /invitations</code></td>
               <td>Receive a signed session invitation at cold start.</td>
               <td><span class="badge">invitation signature</span></td>
@@ -942,6 +947,14 @@ python examples/saas_renewal.py --deal-type goods_procurement
         offer-chain hash, and both party signatures. This makes the record usable
         as a neutral artifact for CLM, signature, payment, custody, and dispute
         workflows.
+      </p>
+      <p>
+        When post-commitment fulfillment reaches a terminal state, the reference
+        server can also expose a Concordia-shaped
+        <code>FulfillmentAttestation</code>. A clean
+        <code>delivery_acknowledged</code> emits <code>fulfilled_clean</code>;
+        <code>dispute_resolved</code> emits <code>fulfilled_with_mediation</code>
+        with resolver metadata.
       </p>
       <div class="code-card">
         <div class="code-head">
@@ -1216,7 +1229,7 @@ assert ok is True</code></pre>
 <footer>
   <div class="footer-inner">
     <span>A2CN developer docs</span>
-    <span>Apache 2.0 - spec v0.2.0 - 469 tests passing</span>
+    <span>Apache 2.0 - spec v0.2.0 - 474 tests passing</span>
   </div>
 </footer>
 

--- a/index.html
+++ b/index.html
@@ -1579,7 +1579,7 @@
             <div class="tl-dot"></div>
             <div class="tl-content">
               <div class="tl-title">A2CN v0.2.0 — you are here</div>
-              <div class="tl-desc">Open, neutral protocol for commercial negotiation between agents from different organizations. 8 components, 469 tests, 11 platform adapters, MCP server, A2A extension proposal submitted.</div>
+              <div class="tl-desc">Open, neutral protocol for commercial negotiation between agents from different organizations. 8 components, 474 tests, 11 platform adapters, MCP server, A2A extension proposal submitted.</div>
             </div>
           </div>
 
@@ -2081,7 +2081,7 @@
     <h2 class="section-heading">Built. Being proposed. Still to come.</h2>
     <p class="section-lede">
       A2CN is an open protocol with a complete Python reference implementation,
-      469 passing tests, 11 platform adapters, and an A2A extension proposal in review.
+      474 passing tests, 11 platform adapters, and an A2A extension proposal in review.
     </p>
 
     <div class="status-split">
@@ -2092,7 +2092,7 @@
         </div>
         <ul>
           <li>Protocol spec v0.2.0 <span class="detail">3,700+ lines, 8 components, Apache 2.0</span></li>
-          <li>Reference implementation <span class="detail">Python, 469 tests passing</span></li>
+          <li>Reference implementation <span class="detail">Python, 474 tests passing</span></li>
           <li>Session invitation <span class="detail">cold-start adoption solved</span></li>
           <li>Platform adapters <span class="detail">Fairmarkit, Keelvar, Ariba, JAGGAER, Revenue Cloud, DealHub, Nue.io, Conga, Ironclad, DocuSign, Vendr</span></li>
           <li>MCP server <span class="detail">Claude Desktop, LangChain, LangGraph, Agentforce, Cursor</span></li>
@@ -2185,7 +2185,7 @@
         <div class="involve-title">Build on it</div>
         <div class="involve-body">
           Start from the developer docs, then drop into the Python reference
-          implementation with 469 passing tests. Apache 2.0 license.
+          implementation with 474 passing tests. Apache 2.0 license.
         </div>
         <a class="involve-link plausible-event-name=Docs+Click" href="docs.html">docs.html →</a>
       </div>
@@ -2216,7 +2216,7 @@
 <footer>
   <div class="footer-inner">
     <span class="footer-brand">A2CN</span>
-    <span class="footer-meta">Apache 2.0 · spec v0.2.0 · 469 tests passing</span>
+    <span class="footer-meta">Apache 2.0 · spec v0.2.0 · 474 tests passing</span>
   </div>
 </footer>
 

--- a/reference-implementation/python/README.md
+++ b/reference-implementation/python/README.md
@@ -3,7 +3,7 @@
 **The canonical Python implementation of the A2CN protocol.**
 
 [![Python](https://img.shields.io/badge/Python-3.11%2B-blue.svg)](https://python.org)
-[![Tests](https://img.shields.io/badge/Tests-469%20passing-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/Tests-474%20passing-brightgreen.svg)](tests/)
 [![Spec](https://img.shields.io/badge/Spec-v0.2.0-green.svg)](../../spec/a2cn-spec-v0.2.0.md)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.115-009688.svg)](https://fastapi.tiangolo.com)
 
@@ -187,6 +187,7 @@ acceptance = store.accept_invitation(
 | `POST /sessions/{id}/messages` | Offer / counteroffer / acceptance / rejection / withdrawal |
 | `GET /sessions/{id}/record` | Transaction record (COMPLETED only) |
 | `GET /sessions/{id}/audit` | Audit log (any terminal state) |
+| `GET /sessions/{id}/fulfillment-attestation` | Concordia FulfillmentAttestation after clean delivery or dispute resolution |
 | `POST /invitations` | Receive inbound invitation |
 | `POST /invitations/create` | Create outbound invitation |
 | `POST /invitations/{id}/accept` | Accept invitation |
@@ -194,6 +195,11 @@ acceptance = store.accept_invitation(
 
 Webhooks fire asynchronously on all terminal transitions with DID-key JWS
 signatures and 1s/4s/16s retry backoff.
+
+Post-commitment fulfillment can also compose with Concordia. Configure
+`fulfillment_private_key` with an Ed25519 key to emit a signed
+`FulfillmentAttestation` when `delivery_acknowledged.accepted=true` or when a
+`dispute_resolved` message closes a mediated fulfillment path.
 
 ### Production session stores
 
@@ -303,7 +309,7 @@ Fork it, modify it, or build your own from scratch.
 ## Running the tests
 
 ```bash
-pytest tests/ -v   # 469 passed
+pytest tests/ -v   # 474 passed
 ```
 
 | Test file | What it covers |

--- a/reference-implementation/python/a2cn/fulfillment.py
+++ b/reference-implementation/python/a2cn/fulfillment.py
@@ -1,0 +1,258 @@
+"""
+Concordia FulfillmentAttestation composition helpers.
+
+The A2CN session remains the agreement pointer; this module emits the
+Concordia-shaped fulfillment artifact that downstream Concordia tooling can
+verify.
+"""
+
+from __future__ import annotations
+
+import base64
+import copy
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from a2cn.crypto import canonicalize
+
+
+FULFILLMENT_ATTESTATION_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "urn:concordia:schema:fulfillment_attestation:v0.5",
+    "title": "Concordia Fulfillment Attestation",
+    "description": (
+        "A standalone signed artifact emitted after settlement, recording whether "
+        "an agreement was honored. Distinct from the in-line `fulfillment` block "
+        "on a reputation attestation (SPEC.md Section 9.6.4) - this is the A2CN-aligned "
+        "shape emitted on a discrete DELIVERY_ACKNOWLEDGED boundary, linking back "
+        "to the agreement attestation via `references[]` with `relationship: "
+        "\"fulfills\"`. Introduced in v0.5 per A2A Discussion #1737. See "
+        "docs/A2CN_FULFILLMENT.md for the integrator walkthrough and SPEC.md "
+        "Section 9.6.4 for the relationship with the in-line fulfillment block."
+    ),
+    "type": "object",
+    "required": [
+        "attestation_type",
+        "id",
+        "issued_at",
+        "agreement_attestation_id",
+        "fulfillment",
+        "references",
+        "signature",
+    ],
+    "properties": {
+        "attestation_type": {
+            "type": "string",
+            "const": "FulfillmentAttestation",
+        },
+        "id": {"type": "string", "minLength": 1},
+        "issued_at": {"type": "string", "format": "date-time"},
+        "agreement_attestation_id": {"type": "string", "minLength": 1},
+        "fulfillment": {
+            "type": "object",
+            "required": ["status"],
+            "additionalProperties": True,
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "fulfilled_clean",
+                        "fulfilled_with_mediation",
+                        "failed",
+                        "disputed_unresolved",
+                    ],
+                },
+                "settled_at": {"type": "string", "format": "date-time"},
+            },
+        },
+        "references": {
+            "type": "array",
+            "minItems": 1,
+            "contains": {
+                "type": "object",
+                "required": ["relationship"],
+                "properties": {"relationship": {"const": "fulfills"}},
+            },
+            "items": {
+                "type": "object",
+                "required": ["id", "type", "relationship"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "type": {"type": "string"},
+                    "relationship": {"type": "string"},
+                },
+                "additionalProperties": True,
+            },
+        },
+        "meta": {
+            "type": "object",
+            "additionalProperties": True,
+            "properties": {
+                "mediator_invoked": {"type": "boolean"},
+                "resolution_outcome": {"type": "string"},
+                "resolver_did": {"type": "string"},
+                "resolution_timestamp": {"type": "string", "format": "date-time"},
+                "fulfillment_evidence": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+            },
+        },
+        "signature": {
+            "type": "object",
+            "required": ["alg", "value"],
+            "additionalProperties": True,
+            "properties": {
+                "alg": {"type": "string", "enum": ["Ed25519"]},
+                "value": {"type": "string", "minLength": 1},
+                "signer_did": {"type": "string"},
+            },
+        },
+    },
+    "allOf": [
+        {
+            "if": {
+                "properties": {
+                    "fulfillment": {
+                        "properties": {
+                            "status": {"const": "fulfilled_with_mediation"},
+                        },
+                        "required": ["status"],
+                    },
+                },
+                "required": ["fulfillment"],
+            },
+            "then": {
+                "properties": {
+                    "meta": {
+                        "type": "object",
+                        "properties": {"mediator_invoked": {"const": True}},
+                        "required": ["mediator_invoked"],
+                    },
+                },
+                "required": ["meta"],
+            },
+        },
+    ],
+    "additionalProperties": True,
+}
+
+
+def build_fulfillment_attestation(
+    session_record: dict[str, Any],
+    *,
+    private_key: Ed25519PrivateKey,
+    signer_did: str | None = None,
+    dispute_resolved_message: dict[str, Any] | None = None,
+    issued_at: str | None = None,
+) -> dict[str, Any]:
+    """
+    Build and Ed25519-sign a Concordia FulfillmentAttestation.
+
+    `session_record["session_id"]` is used as Concordia's
+    agreement_attestation_id pointer for the A2CN composition.
+    """
+    if not isinstance(private_key, Ed25519PrivateKey):
+        raise ValueError("FulfillmentAttestation signing requires an Ed25519 private key")
+
+    session_id = session_record.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        raise ValueError("session_record must include a non-empty session_id")
+
+    now = issued_at or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    fulfillment: dict[str, Any] = {
+        "status": _fulfillment_status(dispute_resolved_message),
+    }
+
+    if dispute_resolved_message is not None:
+        settled_at = dispute_resolved_message.get("resolution_timestamp")
+    else:
+        delivery_ack = session_record.get("delivery_acknowledged") or {}
+        settled_at = delivery_ack.get("acknowledgment_timestamp")
+    if isinstance(settled_at, str) and settled_at:
+        fulfillment["settled_at"] = settled_at
+
+    attestation: dict[str, Any] = {
+        "attestation_type": "FulfillmentAttestation",
+        "id": f"urn:concordia:fulfillment:{uuid.uuid4()}",
+        "issued_at": now,
+        "agreement_attestation_id": session_id,
+        "fulfillment": fulfillment,
+        "references": [
+            {"type": "receipt", "id": session_id, "relationship": "fulfills"},
+            {
+                "type": "chain_session",
+                "id": f"urn:a2cn:session:{session_id}",
+                "relationship": "references",
+            },
+        ],
+    }
+
+    meta = _meta_from_dispute_resolution(dispute_resolved_message)
+    if meta:
+        attestation["meta"] = meta
+
+    attestation["signature"] = _sign_attestation(attestation, private_key, signer_did)
+    validate_fulfillment_attestation(attestation)
+    return attestation
+
+
+def validate_fulfillment_attestation(attestation: dict[str, Any]) -> None:
+    """Validate against the Concordia schema when jsonschema is installed."""
+    try:
+        import jsonschema
+    except ImportError:
+        return
+    jsonschema.validate(attestation, FULFILLMENT_ATTESTATION_SCHEMA)
+
+
+def _fulfillment_status(dispute_resolved_message: dict[str, Any] | None) -> str:
+    if dispute_resolved_message is None:
+        return "fulfilled_clean"
+
+    outcome = dispute_resolved_message.get("resolution_outcome")
+    if outcome in {"buyer_prevails", "seller_prevails", "mutual_settlement"}:
+        return "fulfilled_with_mediation"
+    raise ValueError(f"Unsupported resolution_outcome for fulfillment attestation: {outcome!r}")
+
+
+def _meta_from_dispute_resolution(
+    dispute_resolved_message: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if dispute_resolved_message is None:
+        return None
+
+    meta: dict[str, Any] = {"mediator_invoked": True}
+    for source_key, target_key in (
+        ("resolution_outcome", "resolution_outcome"),
+        ("resolver_did", "resolver_did"),
+        ("resolution_timestamp", "resolution_timestamp"),
+        ("evidence_references", "fulfillment_evidence"),
+    ):
+        value = dispute_resolved_message.get(source_key)
+        if value:
+            meta[target_key] = value
+    return meta
+
+
+def _sign_attestation(
+    attestation: dict[str, Any],
+    private_key: Ed25519PrivateKey,
+    signer_did: str | None,
+) -> dict[str, Any]:
+    unsigned = copy.deepcopy(attestation)
+    unsigned.pop("signature", None)
+    signature = {
+        "alg": "Ed25519",
+        "value": _b64url(private_key.sign(canonicalize(unsigned))),
+    }
+    if signer_did:
+        signature["signer_did"] = signer_did
+    return signature
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")

--- a/reference-implementation/python/a2cn/messages.py
+++ b/reference-implementation/python/a2cn/messages.py
@@ -689,6 +689,34 @@ class DisputeResolvedMessage:
         })
 
 
+@dataclass
+class FulfillmentAttestation:
+    """
+    Concordia-shaped artifact emitted when A2CN post-commitment fulfillment
+    reaches a clean or mediated terminal state.
+    """
+    attestation_type: str
+    id: str
+    issued_at: str
+    agreement_attestation_id: str
+    fulfillment: dict[str, Any]
+    references: list[dict[str, Any]]
+    signature: dict[str, Any]
+    meta: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict:
+        return _drop_none({
+            "attestation_type": self.attestation_type,
+            "id": self.id,
+            "issued_at": self.issued_at,
+            "agreement_attestation_id": self.agreement_attestation_id,
+            "fulfillment": self.fulfillment,
+            "references": self.references,
+            "signature": self.signature,
+            "meta": self.meta,
+        })
+
+
 def validate_deal_type_terms(deal_type: str, terms: dict) -> list[str]:
     """
     Validates terms dict against deal-type-specific schema.

--- a/reference-implementation/python/a2cn/server.py
+++ b/reference-implementation/python/a2cn/server.py
@@ -39,6 +39,7 @@ from fastapi.responses import JSONResponse
 from a2cn.session import Session, SessionManager, SessionState, A2CNError, _now
 from a2cn.record import generate_transaction_record, generate_audit_log
 from a2cn.invitation import InvitationStore
+from a2cn.fulfillment import build_fulfillment_attestation
 from a2cn.messages import (
     WebhookPayload,
     InvitationStatus,
@@ -108,6 +109,29 @@ def configure_responder(config: dict, session_store: "SessionStore | None" = Non
         )
     if session_store is not None:
         _session_store = session_store
+
+
+def _build_fulfillment_attestation(
+    session_id: str,
+    pc_data: dict[str, Any],
+    dispute_resolved_message: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    agent_info = _responder_config.get("agent_info", {})
+    private_key = (
+        _responder_config.get("fulfillment_private_key")
+        or _responder_config.get("private_key")
+    )
+    if private_key is None:
+        raise ValueError("Server fulfillment private key not configured")
+
+    session_record = dict(pc_data)
+    session_record["session_id"] = session_id
+    return build_fulfillment_attestation(
+        session_record,
+        private_key=private_key,
+        signer_did=agent_info.get("did"),
+        dispute_resolved_message=dispute_resolved_message,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -675,8 +699,21 @@ async def post_delivery_acknowledged(session_id: str, request: Request,
     message_id = body.get("message_id", str(uuid.uuid4()))
 
     pc_data["post_commitment_status"] = post_commitment_status
+    pc_data["delivery_acknowledged"] = body
     if not accepted:
         pc_data["dispute_reason"] = body.get("notes", "")
+    else:
+        try:
+            pc_data["fulfillment_attestation"] = _build_fulfillment_attestation(
+                session_id, pc_data
+            )
+        except ValueError as exc:
+            return error_response(
+                "FULFILLMENT_ATTESTATION_ERROR",
+                str(exc),
+                500,
+                session_id=session_id,
+            )
     pc_data["acknowledgment_message_id"] = message_id
     _session_store.save(session_id, pc_data)
 
@@ -830,6 +867,17 @@ async def post_dispute_resolved(session_id: str, request: Request,
     pc_data["dispute_resolution"] = body
     pc_data["post_commitment_status"] = "RESOLVED"
     pc_data["dispute_resolved_message_id"] = message_id
+    try:
+        pc_data["fulfillment_attestation"] = _build_fulfillment_attestation(
+            session_id, pc_data, dispute_resolved_message=body
+        )
+    except ValueError as exc:
+        return error_response(
+            "FULFILLMENT_ATTESTATION_ERROR",
+            str(exc),
+            500,
+            session_id=session_id,
+        )
     _session_store.save(session_id, pc_data)
 
     return a2cn_response({
@@ -838,6 +886,31 @@ async def post_dispute_resolved(session_id: str, request: Request,
         "resolution_outcome": resolution_outcome,
         "post_commitment_status": "RESOLVED",
     })
+
+
+@app.get("/sessions/{session_id}/fulfillment-attestation")
+async def get_fulfillment_attestation(session_id: str, request: Request,
+                                      _jwt: dict = Depends(verify_jwt_auth)) -> Response:
+    _get_session_or_404(session_id)
+    pc_data = _session_store.get(session_id) or {}
+    attestation = pc_data.get("fulfillment_attestation")
+    if attestation:
+        return a2cn_response(attestation)
+
+    if pc_data.get("post_commitment_status") == "DISPUTED":
+        return error_response(
+            "FULFILLMENT_ATTESTATION_PENDING",
+            "Session is disputed and has no DISPUTE_RESOLVED attestation yet",
+            409,
+            session_id=session_id,
+        )
+
+    return error_response(
+        "FULFILLMENT_ATTESTATION_NOT_FOUND",
+        "No fulfillment attestation has been emitted for this session",
+        404,
+        session_id=session_id,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/reference-implementation/python/a2cn/server.py
+++ b/reference-implementation/python/a2cn/server.py
@@ -115,14 +115,12 @@ def _build_fulfillment_attestation(
     session_id: str,
     pc_data: dict[str, Any],
     dispute_resolved_message: dict[str, Any] | None = None,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
+    """Return a signed FulfillmentAttestation, or None if no Ed25519 key is configured."""
     agent_info = _responder_config.get("agent_info", {})
-    private_key = (
-        _responder_config.get("fulfillment_private_key")
-        or _responder_config.get("private_key")
-    )
+    private_key = _responder_config.get("fulfillment_private_key")
     if private_key is None:
-        raise ValueError("Server fulfillment private key not configured")
+        return None
 
     session_record = dict(pc_data)
     session_record["session_id"] = session_id
@@ -703,17 +701,9 @@ async def post_delivery_acknowledged(session_id: str, request: Request,
     if not accepted:
         pc_data["dispute_reason"] = body.get("notes", "")
     else:
-        try:
-            pc_data["fulfillment_attestation"] = _build_fulfillment_attestation(
-                session_id, pc_data
-            )
-        except ValueError as exc:
-            return error_response(
-                "FULFILLMENT_ATTESTATION_ERROR",
-                str(exc),
-                500,
-                session_id=session_id,
-            )
+        attestation = _build_fulfillment_attestation(session_id, pc_data)
+        if attestation is not None:
+            pc_data["fulfillment_attestation"] = attestation
     pc_data["acknowledgment_message_id"] = message_id
     _session_store.save(session_id, pc_data)
 
@@ -867,17 +857,11 @@ async def post_dispute_resolved(session_id: str, request: Request,
     pc_data["dispute_resolution"] = body
     pc_data["post_commitment_status"] = "RESOLVED"
     pc_data["dispute_resolved_message_id"] = message_id
-    try:
-        pc_data["fulfillment_attestation"] = _build_fulfillment_attestation(
-            session_id, pc_data, dispute_resolved_message=body
-        )
-    except ValueError as exc:
-        return error_response(
-            "FULFILLMENT_ATTESTATION_ERROR",
-            str(exc),
-            500,
-            session_id=session_id,
-        )
+    attestation = _build_fulfillment_attestation(
+        session_id, pc_data, dispute_resolved_message=body
+    )
+    if attestation is not None:
+        pc_data["fulfillment_attestation"] = attestation
     _session_store.save(session_id, pc_data)
 
     return a2cn_response({

--- a/reference-implementation/python/tests/conftest.py
+++ b/reference-implementation/python/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest_asyncio
 import httpx
 from httpx import AsyncClient, ASGITransport
 
-from a2cn.crypto import generate_keypair, public_key_to_jwk, create_jwt
+from a2cn.crypto import generate_keypair, generate_ed25519_keypair, public_key_to_jwk, create_jwt
 
 
 class _BearerAuth(httpx.Auth):
@@ -98,6 +98,7 @@ def responder_did_doc(responder_keypair):
 @pytest.fixture
 def responder_config(responder_keypair):
     priv, pub = responder_keypair
+    fulfillment_priv, _fulfillment_pub = generate_ed25519_keypair()
     return {
         "agent_info": {
             "organization_name": "Acme Corp",
@@ -120,6 +121,7 @@ def responder_config(responder_keypair):
         "deal_types": ["saas_renewal"],
         "max_rounds_by_deal_type": {"saas_renewal": 5},
         "private_key": priv,
+        "fulfillment_private_key": fulfillment_priv,
     }
 
 

--- a/reference-implementation/python/tests/test_post_commitment.py
+++ b/reference-implementation/python/tests/test_post_commitment.py
@@ -15,11 +15,13 @@ import uuid
 import pytest
 
 from a2cn.crypto import hash_object, sign_jws
+from a2cn.fulfillment import FULFILLMENT_ATTESTATION_SCHEMA
 from a2cn.messages import (
     DeliveryNoticeMessage,
     DeliveryAcknowledgedMessage,
     DisputeNoticeMessage,
     DisputeResolvedMessage,
+    FulfillmentAttestation,
 )
 from tests.conftest import make_session_init, INITIATOR_DID, RESPONDER_DID
 
@@ -153,6 +155,27 @@ class TestDeliveryAcknowledgedDataclass:
         )
         d = msg.to_dict()
         assert d["accepted"] is False
+
+
+# ---------------------------------------------------------------------------
+# FulfillmentAttestation dataclass
+# ---------------------------------------------------------------------------
+
+class TestFulfillmentAttestationDataclass:
+    def test_instantiation_with_required_fields(self):
+        msg = FulfillmentAttestation(
+            attestation_type="FulfillmentAttestation",
+            id=f"urn:concordia:fulfillment:{uuid.uuid4()}",
+            issued_at="2026-04-03T09:00:00Z",
+            agreement_attestation_id="sess-1",
+            fulfillment={"status": "fulfilled_clean"},
+            references=[{"type": "receipt", "id": "sess-1", "relationship": "fulfills"}],
+            signature={"alg": "Ed25519", "value": "abc"},
+        )
+        d = msg.to_dict()
+        assert d["attestation_type"] == "FulfillmentAttestation"
+        assert d["references"][0]["relationship"] == "fulfills"
+        assert "meta" not in d
 
 
 # ---------------------------------------------------------------------------
@@ -374,6 +397,93 @@ class TestDeliveryAcknowledgedEndpoint:
         )
         assert r.status_code == 400
         assert r.json()["error"]["code"] == "WRONG_MESSAGE_TYPE"
+
+
+# ---------------------------------------------------------------------------
+# Server endpoint tests: FulfillmentAttestation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestFulfillmentAttestationEndpoint:
+    async def _setup_delivery_notice(self, test_client, responder_test_client):
+        session_id, record_hash = await _complete_session(test_client, responder_test_client)
+        notice_body = _delivery_notice_body(session_id, record_hash)
+        r = await test_client.post(
+            f"/sessions/{session_id}/delivery-notice",
+            json=notice_body,
+            headers=_h(notice_body["message_id"]),
+        )
+        assert r.status_code == 200, r.text
+        return session_id, record_hash, r.json()["delivery_notice_message_id"]
+
+    async def _clean_attestation(self, test_client, responder_test_client):
+        session_id, record_hash, notice_id = await self._setup_delivery_notice(
+            test_client, responder_test_client
+        )
+        body = _delivery_ack_body(session_id, record_hash, notice_id, accepted=True)
+        r = await test_client.post(
+            f"/sessions/{session_id}/delivery-acknowledged",
+            json=body,
+            headers=_h(body["message_id"]),
+        )
+        assert r.status_code == 200, r.text
+        r = await test_client.get(f"/sessions/{session_id}/fulfillment-attestation")
+        assert r.status_code == 200, r.text
+        return r.json()
+
+    async def test_fulfillment_attestation_emitted_on_clean_delivery(
+        self, test_client, responder_test_client
+    ):
+        attestation = await self._clean_attestation(test_client, responder_test_client)
+        assert attestation["attestation_type"] == "FulfillmentAttestation"
+        assert attestation["fulfillment"]["status"] == "fulfilled_clean"
+        assert attestation["references"][0]["relationship"] == "fulfills"
+        assert attestation["signature"]["alg"] == "Ed25519"
+        assert attestation["signature"]["value"]
+
+    async def test_fulfillment_attestation_not_emitted_on_rejected_delivery(
+        self, test_client, responder_test_client
+    ):
+        session_id, record_hash, notice_id = await self._setup_delivery_notice(
+            test_client, responder_test_client
+        )
+        body = _delivery_ack_body(session_id, record_hash, notice_id, accepted=False)
+        r = await test_client.post(
+            f"/sessions/{session_id}/delivery-acknowledged",
+            json=body,
+            headers=_h(body["message_id"]),
+        )
+        assert r.status_code == 200, r.text
+        r = await test_client.get(f"/sessions/{session_id}/fulfillment-attestation")
+        assert r.status_code == 409
+        assert r.json()["error"]["code"] == "FULFILLMENT_ATTESTATION_PENDING"
+
+    async def test_fulfillment_attestation_emitted_after_dispute_resolved(
+        self, test_client, responder_test_client
+    ):
+        session_id, record_hash, notice_id = await _setup_disputed_session(
+            test_client, responder_test_client
+        )
+        body = _dispute_resolved_body(session_id, record_hash, notice_id)
+        r = await test_client.post(
+            f"/sessions/{session_id}/dispute-resolved",
+            json=body,
+            headers=_h(body["message_id"]),
+        )
+        assert r.status_code == 200, r.text
+        r = await test_client.get(f"/sessions/{session_id}/fulfillment-attestation")
+        assert r.status_code == 200, r.text
+        attestation = r.json()
+        assert attestation["fulfillment"]["status"] == "fulfilled_with_mediation"
+        assert attestation["meta"]["mediator_invoked"] is True
+        assert attestation["meta"]["resolver_did"] == "did:web:resolver.neutral.example"
+
+    async def test_fulfillment_attestation_schema_valid(
+        self, test_client, responder_test_client
+    ):
+        jsonschema = pytest.importorskip("jsonschema")
+        attestation = await self._clean_attestation(test_client, responder_test_client)
+        jsonschema.validate(attestation, FULFILLMENT_ATTESTATION_SCHEMA)
 
 
 # ---------------------------------------------------------------------------

--- a/spec/a2cn-spec-v0.2.0.md
+++ b/spec/a2cn-spec-v0.2.0.md
@@ -2046,11 +2046,14 @@ outside the enum above. The corresponding JSON Schema is
 
 #### 10.6.5 Concordia Composition
 
-A2CN's `dispute_resolved` message can compose with a Concordia fulfillment
-attestation. The A2CN message supplies the commercial dispute outcome and binds
-it to both the transaction record and the original dispute notice. Section 16.2
-documents the cross-protocol `references[]` relationship vocabulary and
-Concordia adapter reference for this composition.
+A2CN's post-commitment lifecycle can compose with a Concordia fulfillment
+attestation. A `delivery_acknowledged` message with `accepted=true` supplies the
+clean fulfillment boundary for a `fulfilled_clean` attestation. A
+`dispute_resolved` message supplies the commercial dispute outcome and binds it
+to both the transaction record and the original dispute notice for a
+`fulfilled_with_mediation` attestation. Section 16.2 documents the
+cross-protocol `references[]` relationship vocabulary and Concordia adapter
+reference for this composition.
 
 ---
 
@@ -2347,6 +2350,7 @@ support this binding.
 | GET | `/sessions/{id}/messages` | Get message history (paginated) |
 | GET | `/sessions/{id}/record` | Get transaction record (COMPLETED only) |
 | GET | `/sessions/{id}/audit` | Get audit log (any terminal state) |
+| GET | `/sessions/{id}/fulfillment-attestation` | Get Concordia fulfillment attestation after clean delivery or dispute resolution |
 
 #### 12.1.2 Pagination
 
@@ -3634,6 +3638,14 @@ messages that validate against these schemas.
 ---
 
 ## 19. Changelog
+
+### Patch 2026-06-01 — Concordia fulfillment attestation emission
+
+- Section 10.6.5 updated to cover both clean delivery acceptance and mediated
+  dispute resolution as inputs to Concordia `FulfillmentAttestation` artifacts.
+- Section 12.1.1 endpoint table updated with
+  `GET /sessions/{id}/fulfillment-attestation` for retrieving the emitted
+  fulfillment artifact.
 
 ### Patch 2026-06-01 — NegotiationGroup extension path
 


### PR DESCRIPTION
## Summary

Finishes A2C-61 by wiring A2CN post-commitment lifecycle events to Concordia-shaped fulfillment attestations.

- Adds `a2cn.fulfillment` with `build_fulfillment_attestation()` and an embedded Concordia-compatible schema shape.
- Emits a signed Ed25519 `FulfillmentAttestation` when `delivery_acknowledged.accepted=true` with `fulfillment.status = fulfilled_clean`.
- Emits a signed Ed25519 `FulfillmentAttestation` after `dispute_resolved` with `fulfillment.status = fulfilled_with_mediation` and resolver metadata.
- Adds `GET /sessions/{session_id}/fulfillment-attestation` for retrieving the emitted artifact.
- Adds `FulfillmentAttestation` dataclass coverage and endpoint regression tests.
- Updates spec/docs/release notes and refreshes public test counts to 474.

## Notes

This branch was recovered from the old local A2C-61 worktree, replayed onto current `origin/main`, and reconciled with the newer lowercase post-commitment message-type changes.

## Validation

- `uv run pytest tests/test_post_commitment.py -q` -> 59 passed
- `uv run pytest -q` -> 474 passed
- `uv run python -m py_compile a2cn/fulfillment.py a2cn/server.py a2cn/messages.py tests/test_post_commitment.py`
- `git diff --check HEAD~1 HEAD`

Linear: A2C-61