### PR TITLE
[codex] Make MCP dependency optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A2CN defines neutral infrastructure for agent-to-agent commercial negotiation.
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Spec Version](https://img.shields.io/badge/Spec-v0.2.0-green.svg)](spec/a2cn-spec-v0.2.0.md)
-[![Tests](https://img.shields.io/badge/Tests-474%20passing-brightgreen.svg)](reference-implementation/python/tests)
+[![Tests](https://img.shields.io/badge/Tests-476%20passing-brightgreen.svg)](reference-implementation/python/tests)
 [![Status](https://img.shields.io/badge/Status-Partner%20Ready-orange.svg)]()
 
 ---
@@ -197,7 +197,7 @@ python examples/invitation_flow.py
 ```bash
 pip install -e '.[dev]'
 pytest tests/ -v
-# 474 passed
+# 476 passed
 ```
 
 ---
@@ -273,7 +273,7 @@ rather than platform-local implementation details.
 
 Full protocol specification: [`spec/a2cn-spec-v0.2.0.md`](spec/a2cn-spec-v0.2.0.md) — 3,300+ lines covering eight protocol components with normative JSON schemas, platform integration patterns across procurement, revenue, CLM, CPQ, renewal, and eSignature systems, and a complete four-round SaaS renewal walkthrough with concrete message envelopes.
 
-**Spec status:** v0.2.0. Passed four independent critique cycles. Verified against reference implementation (474 tests).
+**Spec status:** v0.2.0. Passed four independent critique cycles. Verified against reference implementation (476 tests).
 
 ---
 
@@ -330,7 +330,7 @@ A2CN/
 | Milestone | Status |
 |-----------|--------|
 | Protocol spec v0.2.0 | ✓ Complete — 3,300+ lines, 8 components |
-| Reference implementation (Python) | ✓ Complete — 474 tests passing |
+| Reference implementation (Python) | ✓ Complete — 476 tests passing |
 | Session Invitation (Component 8) | ✓ Complete — signed invitations, lifecycle, hosted endpoint pattern |
 | Platform adapters | ✓ Complete — 11 adapters: Fairmarkit, Keelvar, Salesforce Revenue Cloud, DealHub, Nue.io, SAP Ariba, JAGGAER, Conga, Ironclad, Vendr, DocuSign |
 | LLM agent skills file | ✓ Complete — `reference-implementation/skills/a2cn-negotiation.md` |

--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ git clone https://github.com/A2CN-protocol/A2CN.git
 cd A2CN/reference-implementation/python
 pip install -e .
 
+# Optional: install MCP server support
+pip install -e '.[mcp]'
+
 # SaaS renewal demo (4-round bilateral negotiation)
 python examples/saas_renewal.py
 
@@ -192,7 +195,7 @@ python examples/invitation_flow.py
 ### Run the test suite
 
 ```bash
-pip install -r requirements.txt
+pip install -e '.[dev]'
 pytest tests/ -v
 # 474 passed
 ```

--- a/reference-implementation/README.md
+++ b/reference-implementation/README.md
@@ -18,8 +18,11 @@ This is the reference implementation of the [A2CN protocol](../../spec/v0.1.3.md
 git clone https://github.com/A2CN-protocol/A2CN.git
 cd A2CN/reference-implementation/python
 
-# Install
+# Install core A2CN runtime
 python -m pip install -e .
+
+# Optional: install MCP server support
+python -m pip install -e '.[mcp]'
 
 # Run the bilateral negotiation demo
 python examples/saas_renewal.py
@@ -276,7 +279,7 @@ client.process_incoming(response)
 ## Running the tests
 
 ```bash
-pip install -r requirements.txt
+pip install -e '.[dev]'
 pytest tests/ -v
 ```
 
@@ -361,12 +364,13 @@ httpx==0.27.0          # Async HTTP client
 PyJWT==2.9.0           # JWT/JWS signing (ES256)
 cryptography==43.0.0   # P-256 key generation and operations
 jcs==0.2.1             # RFC 8785 JSON Canonicalization Scheme
-mcp==1.12.4            # MCP server and tool registration
 pytest==8.3.0          # Test runner
 pytest-asyncio==0.24.0 # Async test support
 ```
 
-Install: `pip install -r requirements.txt`
+Install the core runtime with `pip install -e .`. Install MCP server support
+only when needed with `pip install -e '.[mcp]'`, or install test tooling with
+`pip install -e '.[dev]'`.
 
 ---
 

--- a/reference-implementation/python/README.md
+++ b/reference-implementation/python/README.md
@@ -18,6 +18,9 @@ git clone https://github.com/A2CN-protocol/A2CN.git
 cd A2CN/reference-implementation/python
 pip install -e .
 
+# Optional: install MCP server support
+pip install -e '.[mcp]'
+
 # Run the bilateral SaaS renewal demo
 python examples/saas_renewal.py
 

--- a/reference-implementation/python/mcp_server.py
+++ b/reference-implementation/python/mcp_server.py
@@ -44,11 +44,11 @@ from typing import Any
 import httpx
 try:
     from mcp.server.fastmcp import FastMCP
-except ImportError as exc:  # pragma: no cover - exercised when optional extra is absent.
+except ImportError:  # pragma: no cover - only reachable when the mcp extra is absent.
     raise SystemExit(
         "The A2CN MCP server requires the optional MCP dependencies. "
         "Install them with: pip install -e '.[mcp]'"
-    ) from exc
+    ) from None
 
 from a2cn.client import A2CNClient
 from a2cn.crypto import (

--- a/reference-implementation/python/mcp_server.py
+++ b/reference-implementation/python/mcp_server.py
@@ -42,7 +42,13 @@ import uuid
 from typing import Any
 
 import httpx
-from mcp.server.fastmcp import FastMCP
+try:
+    from mcp.server.fastmcp import FastMCP
+except ImportError as exc:  # pragma: no cover - exercised when optional extra is absent.
+    raise SystemExit(
+        "The A2CN MCP server requires the optional MCP dependencies. "
+        "Install them with: pip install -e '.[mcp]'"
+    ) from exc
 
 from a2cn.client import A2CNClient
 from a2cn.crypto import (

--- a/reference-implementation/python/pyproject.toml
+++ b/reference-implementation/python/pyproject.toml
@@ -20,7 +20,7 @@ mcp = [
     "mcp==1.12.4",
 ]
 dev = [
-    "mcp==1.12.4",
+    "a2cn[mcp]",
     "pytest==8.3.0",
     "pytest-asyncio==0.24.0",
     "python-multipart==0.0.12",

--- a/reference-implementation/python/pyproject.toml
+++ b/reference-implementation/python/pyproject.toml
@@ -13,11 +13,14 @@ dependencies = [
     "PyJWT==2.9.0",
     "cryptography==43.0.0",
     "jcs==0.2.1",
-    "mcp==1.12.4",
 ]
 
 [project.optional-dependencies]
+mcp = [
+    "mcp==1.12.4",
+]
 dev = [
+    "mcp==1.12.4",
     "pytest==8.3.0",
     "pytest-asyncio==0.24.0",
     "python-multipart==0.0.12",

--- a/reference-implementation/python/requirements.txt
+++ b/reference-implementation/python/requirements.txt
@@ -4,7 +4,6 @@ httpx==0.27.0
 PyJWT==2.9.0
 cryptography==43.0.0
 jcs==0.2.1
-mcp==1.12.4
 pytest==8.3.0
 pytest-asyncio==0.24.0
 python-multipart==0.0.12

--- a/reference-implementation/python/tests/test_mcp_server.py
+++ b/reference-implementation/python/tests/test_mcp_server.py
@@ -17,6 +17,8 @@ import pytest
 import pytest_asyncio
 import respx
 
+pytest.importorskip("mcp")
+
 # mcp_server lives at reference-implementation/python/mcp_server.py (one level up)
 _REPO_PY = Path(__file__).parent.parent
 if str(_REPO_PY) not in sys.path:

--- a/reference-implementation/python/tests/test_packaging.py
+++ b/reference-implementation/python/tests/test_packaging.py
@@ -9,6 +9,15 @@ def _project_metadata() -> dict:
     return tomllib.loads(pyproject.read_text())
 
 
+def _requirements() -> list[str]:
+    requirements = Path(__file__).parents[1] / "requirements.txt"
+    return [
+        line.strip()
+        for line in requirements.read_text().splitlines()
+        if line.strip() and not line.startswith("#")
+    ]
+
+
 def test_mcp_is_optional_not_core_dependency() -> None:
     project = _project_metadata()["project"]
 
@@ -16,5 +25,9 @@ def test_mcp_is_optional_not_core_dependency() -> None:
     optional_dependencies = project["optional-dependencies"]
 
     assert not any(dep.startswith("mcp") for dep in dependencies)
-    assert optional_dependencies["mcp"] == ["mcp==1.12.4"]
-    assert "mcp==1.12.4" in optional_dependencies["dev"]
+    assert any(dep.startswith("mcp") for dep in optional_dependencies["mcp"])
+    assert "a2cn[mcp]" in optional_dependencies["dev"]
+
+
+def test_requirements_txt_does_not_install_mcp_server() -> None:
+    assert not any(dep.startswith("mcp") for dep in _requirements())

--- a/reference-implementation/python/tests/test_packaging.py
+++ b/reference-implementation/python/tests/test_packaging.py
@@ -1,0 +1,20 @@
+"""Packaging guardrails for optional integrations."""
+
+from pathlib import Path
+import tomllib
+
+
+def _project_metadata() -> dict:
+    pyproject = Path(__file__).parents[1] / "pyproject.toml"
+    return tomllib.loads(pyproject.read_text())
+
+
+def test_mcp_is_optional_not_core_dependency() -> None:
+    project = _project_metadata()["project"]
+
+    dependencies = project["dependencies"]
+    optional_dependencies = project["optional-dependencies"]
+
+    assert not any(dep.startswith("mcp") for dep in dependencies)
+    assert optional_dependencies["mcp"] == ["mcp==1.12.4"]
+    assert "mcp==1.12.4" in optional_dependencies["dev"]


### PR DESCRIPTION
## Summary

- Move `mcp==1.12.4` out of the core Python runtime dependencies and into a dedicated `mcp` extra.
- Keep MCP installed for developer/test environments through the `dev` extra via `a2cn[mcp]`, so the MCP pin lives in one place.
- Add packaging guardrail tests so MCP does not drift back into core dependencies or `requirements.txt`.
- Make `test_mcp_server.py` skip gracefully when MCP is not installed.
- Add an actionable error for users who run `mcp_server.py` without installing `.[mcp]`.
- Update install docs to use `pip install -e .`, `pip install -e '.[mcp]'`, and `pip install -e '.[dev]'` as appropriate.

## Why

A2C-102 calls out the fresh-clone friction around packaging and dependency shape. Core A2CN installs should not require the MCP server package unless the user explicitly wants MCP tooling, and bare installs should not fail pytest collection because MCP is absent.

## Validation

- `venv/bin/python -m pytest tests/test_packaging.py -q`
- `venv/bin/python -m pytest tests/test_mcp_server.py -q`
- `venv/bin/python -m pytest tests/ -q`