### PR TITLE
Fix Acceptance signing bugs in invitation_flow and keelvar_demo examples

### DIFF
--- a/a2cn_ts/examples/invitation_flow.ts
+++ b/a2cn_ts/examples/invitation_flow.ts
@@ -504,22 +504,21 @@ async function main(): Promise<void> {
   // Supplier acceptance message
   const ts = sessionNow();
   const msgId = randomUUID();
-  // Acceptance uses current round (3), not a new round; sequence advances
-  const act = {
-    protocol_version: "0.2",
+  // Acceptance uses current round (3), not a new round; sequence advances.
+  // Signed payload is the 5-field acceptance object (Section 7.4), not a
+  // full protocol act — Acceptance messages carry no terms/expires_at.
+  const acceptancePayload = {
     session_id: sessionId,
     round_number: 3,
     sequence_number: 4,
     accepted_offer_id: r3Offer.message_id,
     accepted_protocol_act_hash: r3Offer.protocol_act_hash,
-    message_type: "acceptance",
-    sender_did: SUPPLIER_DID,
-    timestamp: ts,
-    expires_at: nowFixed(900),
-    terms: termsR3,
   };
-  const pah = hashObject(act);
-  const pas = signJws(pah, supplierPriv, `${SUPPLIER_DID}#key-1`);
+  const acceptanceSignature = signJws(
+    hashObject(acceptancePayload),
+    supplierPriv,
+    `${SUPPLIER_DID}#key-1`,
+  );
   const supplierAcceptance = {
     message_type: "acceptance",
     message_id: msgId,
@@ -533,10 +532,7 @@ async function main(): Promise<void> {
     sender_agent_id: "supply-agent-ts-001",
     sender_verification_method: `${SUPPLIER_DID}#key-1`,
     timestamp: ts,
-    expires_at: nowFixed(900),
-    terms: termsR3,
-    protocol_act_hash: pah,
-    protocol_act_signature: pas,
+    acceptance_signature: acceptanceSignature,
   };
   serverCtx.manager.processMessage(sessionObj, supplierAcceptance);
   client.processIncoming(sessionId, supplierAcceptance);

--- a/a2cn_ts/examples/keelvar_demo.ts
+++ b/a2cn_ts/examples/keelvar_demo.ts
@@ -294,7 +294,7 @@ async function main(): Promise<void> {
   const exp = nowFixed(900);
   const msgIdR2 = randomUUID();
   const actR2 = {
-    protocol_version: "0.1",
+    protocol_version: "0.2",
     session_id: sessionId,
     round_number: 2,
     sequence_number: 2,
@@ -366,21 +366,20 @@ async function main(): Promise<void> {
   const r3Offer = client._sessions[sessionId].latest_offer as Dict;
   ts = sessionNow();
   const msgIdAcc = randomUUID();
-  const actAcc = {
-    protocol_version: "0.1",
+  // Signed payload is the 5-field acceptance object (Section 7.4), not a
+  // full protocol act — Acceptance messages carry no terms/expires_at.
+  const acceptancePayload = {
     session_id: sessionId,
     round_number: 3,
     sequence_number: 4,
     accepted_offer_id: r3Offer.message_id,
     accepted_protocol_act_hash: r3Offer.protocol_act_hash,
-    message_type: "acceptance",
-    sender_did: SUPPLIER_DID,
-    timestamp: ts,
-    expires_at: nowFixed(900),
-    terms: termsR3,
   };
-  const pahAcc = hashObject(actAcc);
-  const pasAcc = signJws(pahAcc, supplierPriv, `${SUPPLIER_DID}#key-1`);
+  const acceptanceSignature = signJws(
+    hashObject(acceptancePayload),
+    supplierPriv,
+    `${SUPPLIER_DID}#key-1`,
+  );
   const supplierAcceptance = {
     message_type: "acceptance",
     message_id: msgIdAcc,
@@ -394,10 +393,7 @@ async function main(): Promise<void> {
     sender_agent_id: "supply-agent-ts-001",
     sender_verification_method: `${SUPPLIER_DID}#key-1`,
     timestamp: ts,
-    expires_at: nowFixed(900),
-    terms: termsR3,
-    protocol_act_hash: pahAcc,
-    protocol_act_signature: pasAcc,
+    acceptance_signature: acceptanceSignature,
   };
   serverCtx.manager.processMessage(sessionObj, supplierAcceptance);
   client.processIncoming(sessionId, supplierAcceptance);

--- a/reference-implementation/python/examples/invitation_flow.py
+++ b/reference-implementation/python/examples/invitation_flow.py
@@ -498,21 +498,18 @@ async def main() -> None:
         ts = session_now()
         msg_id = str(uuid.uuid4())
         # Acceptance uses current round (3), not a new round; sequence advances
-        act = {
-            "protocol_version": "0.2",
+        # Signed payload is the 5-field acceptance object (Section 7.4), not a
+        # full protocol act — Acceptance messages carry no terms/expires_at.
+        acceptance_payload = {
             "session_id": session_id,
             "round_number": 3,
             "sequence_number": 4,
             "accepted_offer_id": r3_offer["message_id"],
             "accepted_protocol_act_hash": r3_offer["protocol_act_hash"],
-            "message_type": "acceptance",
-            "sender_did": SUPPLIER_DID,
-            "timestamp": ts,
-            "expires_at": _now_fixed(900),
-            "terms": terms_r3,
         }
-        pah = hash_object(act)
-        pas_ = sign_jws(pah, supplier_priv, kid=f"{SUPPLIER_DID}#key-1")
+        acceptance_signature = sign_jws(
+            hash_object(acceptance_payload), supplier_priv, kid=f"{SUPPLIER_DID}#key-1"
+        )
         supplier_acceptance = {
             "message_type": "acceptance",
             "message_id": msg_id,
@@ -526,10 +523,7 @@ async def main() -> None:
             "sender_agent_id": "supply-agent-ts-001",
             "sender_verification_method": f"{SUPPLIER_DID}#key-1",
             "timestamp": ts,
-            "expires_at": _now_fixed(900),
-            "terms": terms_r3,
-            "protocol_act_hash": pah,
-            "protocol_act_signature": pas_,
+            "acceptance_signature": acceptance_signature,
         }
         manager.process_message(session_obj, supplier_acceptance)
         client.process_incoming(session_id, supplier_acceptance)

--- a/reference-implementation/python/examples/keelvar_demo.py
+++ b/reference-implementation/python/examples/keelvar_demo.py
@@ -362,7 +362,7 @@ async def main() -> None:
         exp = _now_fixed(900)
         msg_id_r2 = str(uuid.uuid4())
         act_r2 = {
-            "protocol_version": "0.1",
+            "protocol_version": "0.2",
             "session_id": session_id,
             "round_number": 2,
             "sequence_number": 2,
@@ -438,21 +438,18 @@ async def main() -> None:
         r3_offer = client._sessions[session_id]["latest_offer"]
         ts = session_now()
         msg_id_acc = str(uuid.uuid4())
-        act_acc = {
-            "protocol_version": "0.1",
+        # Signed payload is the 5-field acceptance object (Section 7.4), not a
+        # full protocol act — Acceptance messages carry no terms/expires_at.
+        acceptance_payload = {
             "session_id": session_id,
             "round_number": 3,
             "sequence_number": 4,
             "accepted_offer_id": r3_offer["message_id"],
             "accepted_protocol_act_hash": r3_offer["protocol_act_hash"],
-            "message_type": "acceptance",
-            "sender_did": SUPPLIER_DID,
-            "timestamp": ts,
-            "expires_at": _now_fixed(900),
-            "terms": terms_r3,
         }
-        pah_acc = hash_object(act_acc)
-        pas_acc = sign_jws(pah_acc, supplier_priv, kid=f"{SUPPLIER_DID}#key-1")
+        acceptance_signature = sign_jws(
+            hash_object(acceptance_payload), supplier_priv, kid=f"{SUPPLIER_DID}#key-1"
+        )
         supplier_acceptance = {
             "message_type": "acceptance",
             "message_id": msg_id_acc,
@@ -466,10 +463,7 @@ async def main() -> None:
             "sender_agent_id": "supply-agent-ts-001",
             "sender_verification_method": f"{SUPPLIER_DID}#key-1",
             "timestamp": ts,
-            "expires_at": _now_fixed(900),
-            "terms": terms_r3,
-            "protocol_act_hash": pah_acc,
-            "protocol_act_signature": pas_acc,
+            "acceptance_signature": acceptance_signature,
         }
         manager.process_message(session_obj, supplier_acceptance)
         client.process_incoming(session_id, supplier_acceptance)


### PR DESCRIPTION
## Summary

PR #63 (the a2cn_ts TypeScript port) explicitly flagged two pre-existing Python example bugs and reproduced them bug-for-bug rather than fixing them, noting "Happy to fix both sides in a follow-up PR." This is that follow-up.

## Bugs fixed

1. `invitation_flow.py`/`.ts` — the supplier's negotiation `Acceptance` message was built like an `Offer` (with `protocol_version`, `terms`, `expires_at`, hashed and stored under `protocol_act_signature`) instead of signing the 5-field acceptance payload (`session_id`, `round_number`, `sequence_number`, `accepted_offer_id`, `accepted_protocol_act_hash`) under `acceptance_signature`, per spec Section 7.4. The server's `Acceptance` handler only ever checks `acceptance_signature`, so the demo crashed with `Missing sender_verification_method or acceptance_signature`.

2. `keelvar_demo.py`/`.ts` — the round-2 counteroffer was signed with `protocol_version: "0.1"`, but the server always recomputes the protocol act hash using the literal `"0.2"` (Section 7.3.1), so the hash never matched and the demo crashed with `Protocol act hash does not match message fields`. The round-4 acceptance had the same signing bug as (1), which would have surfaced next once the round-2 issue was fixed.

Both bugs are fixed identically in the Python reference implementation and the TypeScript port to keep them in parity, per the MIGRATION.md guidance not to fix one side only.

## Validation

- `reference-implementation/python/examples/invitation_flow.py` and `keelvar_demo.py` now run to completion (record_hash match, WebhookPayload emitted)
- `a2cn_ts/examples/invitation_flow.ts` and `keelvar_demo.ts` now run to completion
- Python suite: 474 passed
- TS suite: 499 passed, tsc --noEmit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
