### PR TITLE
Publish the transport verification method the buyer profile already names

### DIFF
--- a/.well-known/did.json
+++ b/.well-known/did.json
@@ -32,11 +32,26 @@
         "alg": "ES256",
         "kid": "a2cn-buyer-agent-mandate-av1"
       }
+    },
+    {
+      "id": "did:web:a2cn.io#a2cn-buyer-agent-transport-av1",
+      "type": "JsonWebKey2020",
+      "controller": "did:web:a2cn.io",
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "P-256",
+        "x": "5zcmZsDdk1zhfRtWXUPI4neYQycw5rKOUgGAApsJfOA",
+        "y": "L-EoSyP2IxYRrrObXs6T4D2JegPyd51I0XY1rJGGSh8",
+        "alg": "ES256",
+        "use": "sig",
+        "kid": "a2cn-buyer-agent-transport-av1"
+      }
     }
   ],
   "authentication": [
     "did:web:a2cn.io#a2cn-buyer-agent-mandate-v1",
-    "did:web:a2cn.io#a2cn-buyer-agent-mandate-av1"
+    "did:web:a2cn.io#a2cn-buyer-agent-mandate-av1",
+    "did:web:a2cn.io#a2cn-buyer-agent-transport-av1"
   ],
   "assertionMethod": [
     "did:web:a2cn.io#a2cn-buyer-agent-mandate-v1",


### PR DESCRIPTION
## Summary
- Add `a2cn-buyer-agent-transport-av1` to the `did:web:a2cn.io` verification methods
- Register the transport key in `authentication` so it matches the buyer profile reference

## Test plan
- [ ] Verify `.well-known/did.json` resolves and includes the new transport verification method
- [ ] Confirm the buyer profile transport key id matches the published DID document entry


Made with [Cursor](https://cursor.com)