### PR TITLE
docs: state validation status for platform adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ A2CN/
 | Protocol spec v0.2.0 | ✓ Complete — 3,300+ lines, 8 components |
 | Reference implementation (Python) | ✓ Complete — 474 tests passing |
 | Session Invitation (Component 8) | ✓ Complete — signed invitations, lifecycle, hosted endpoint pattern |
-| Platform adapters | ✓ Complete — 11 adapters: Fairmarkit, Keelvar, Salesforce Revenue Cloud, DealHub, Nue.io, SAP Ariba, JAGGAER, Conga, Ironclad, Vendr, DocuSign |
+| Platform adapters | 11 implemented: Fairmarkit, Keelvar, Salesforce Revenue Cloud, DealHub, Nue.io, SAP Ariba, JAGGAER, Conga, Ironclad, Vendr, DocuSign. Each is built against the platform's published API surface and tested against those schemas; see each adapter's **Validation status** section for what has and has not been exercised against a live instance. |
 | LLM agent skills file | ✓ Complete — `reference-implementation/skills/a2cn-negotiation.md` |
 | End-to-end bilateral demo | ✓ Working — matching record hashes |
 | Invitation flow demo | ✓ Working — Fairmarkit BID_CREATED pattern |

--- a/reference-implementation/python/adapters/ARIBA_INTEGRATION.md
+++ b/reference-implementation/python/adapters/ARIBA_INTEGRATION.md
@@ -5,6 +5,26 @@ SAP Ariba Sourcing / Discovery RFx events into A2CN `goods_procurement` terms
 and maps agreed A2CN terms back into Ariba-shaped bid or acknowledgement
 payloads.
 
+## Validation status
+
+**Built from:** SAP's published Event Management API for SAP Ariba Sourcing and the
+Discovery RFx Publication to External Marketplace API.
+
+**Verified:** Payload translation in both directions against those published
+schemas — 13 tests in `tests/test_ariba_adapter.py`.
+
+**Not verified:** This adapter has not been exercised against a live SAP Ariba tenant. Runtime
+access requires SAP Ariba Developer Portal registration, an application with the
+relevant API package entitlement, environment-specific runtime URLs, OAuth
+credentials and an application key — none of which we currently hold. Field names
+and response shapes should be confirmed against a live environment before
+production use.
+
+If you have access to a live SAP Ariba instance and are willing to validate this
+adapter against it, please open an issue — that is the help we most need.
+
+---
+
 Public docs used:
 
 - Event Management API for SAP Ariba Sourcing

--- a/reference-implementation/python/adapters/CONGA_INTEGRATION.md
+++ b/reference-implementation/python/adapters/CONGA_INTEGRATION.md
@@ -6,6 +6,23 @@ maps agreed A2CN terms back into Conga-shaped quote update payloads. It also
 provides a small CLM agreement metadata payload for linking the final contract
 workflow to an A2CN transaction record.
 
+## Validation status
+
+**Built from:** Conga's published CPQ REST API v5 and CLM REST API documentation.
+
+**Verified:** Payload translation in both directions against those published
+schemas — 14 tests in `tests/test_conga_adapter.py`.
+
+**Not verified:** This adapter has not been exercised against a live Conga org. Runtime access
+requires the credentials listed under Environment Variables below. Field names and
+response shapes should be confirmed against a live environment before production
+use.
+
+If you have access to a live Conga instance and are willing to validate this
+adapter against it, please open an issue — that is the help we most need.
+
+---
+
 Public docs used:
 
 - Conga Documentation Portal

--- a/reference-implementation/python/adapters/DEALHUB_INTEGRATION.md
+++ b/reference-implementation/python/adapters/DEALHUB_INTEGRATION.md
@@ -4,6 +4,23 @@ DealHub is a seller-side CPQ platform. This adapter translates DealHub
 quoteReady webhook events and API responses into A2CN session terms, and
 translates A2CN agreed terms back into DealHub Actions API calls.
 
+## Validation status
+
+**Built from:** DealHub's published API and webhook documentation.
+
+**Verified:** Payload translation in both directions against those published
+schemas — 26 tests in `tests/test_dealhub_adapter.py`.
+
+**Not verified:** This adapter has not been exercised against a live DealHub instance. Runtime
+access requires the credentials listed under Environment Variables below. Quote
+field names and the Headless Simulate Playbook response shape must be verified
+against a live instance — see Limitations — before production use.
+
+If you have access to a live DealHub instance and are willing to validate this
+adapter against it, please open an issue — that is the help we most need.
+
+---
+
 ---
 
 ## Prerequisites

--- a/reference-implementation/python/adapters/DOCUSIGN_INTEGRATION.md
+++ b/reference-implementation/python/adapters/DOCUSIGN_INTEGRATION.md
@@ -5,6 +5,23 @@ neutral, dual-signed transaction record; DocuSign executes the signature package
 and can notify A2CN middleware when the envelope is completed, declined, or
 voided.
 
+## Validation status
+
+**Built from:** DocuSign's published eSignature REST API, Connect and OAuth documentation.
+
+**Verified:** Payload translation in both directions against those published
+schemas — 13 tests in `tests/test_docusign_adapter.py`.
+
+**Not verified:** This adapter has not been exercised against a live DocuSign account. Runtime
+access requires the credentials listed under Environment Variables below. Envelope
+and webhook payload shapes should be confirmed against a live environment before
+production use.
+
+If you have access to a live DocuSign instance and are willing to validate this
+adapter against it, please open an issue — that is the help we most need.
+
+---
+
 Public docs used:
 
 - DocuSign eSignature REST API

--- a/reference-implementation/python/adapters/FAIRMARKIT_INTEGRATION.md
+++ b/reference-implementation/python/adapters/FAIRMARKIT_INTEGRATION.md
@@ -1,0 +1,41 @@
+# Fairmarkit - A2CN Integration Guide
+
+Fairmarkit is a buy-side sourcing and tail-spend platform. This adapter maps
+Fairmarkit webhook payloads and API responses into A2CN message structures, and
+maps agreed A2CN terms back into Fairmarkit-shaped payloads.
+
+## Validation status
+
+**Built from:** Fairmarkit's published webhooks documentation and the self-service
+responses API (`GET /self-service/api/v3/responses/request/{request_id}/`).
+
+**Verified:** Payload translation in both directions against those published
+schemas — 10 tests in `tests/test_adapters.py::TestFairmakitAdapter`.
+
+**Not verified:** This adapter has not been exercised against a live Fairmarkit instance. Runtime
+access requires Fairmarkit API credentials, which we do not currently hold.
+Field names and response shapes should be confirmed against a live environment
+before production use.
+
+If you have access to a live Fairmarkit instance and are willing to validate this
+adapter against it, please open an issue — that is the help we most need.
+
+---
+
+## Module
+
+`adapters/fairmarkit_adapter.py` — pure data translation, no I/O. Every function is
+testable offline against fixture payloads.
+
+Entry points: `FairmakitEventParser.parse_bid_created_webhook()` and related
+parsers. Note the class name is spelled `Fairmakit` — a typo retained here for
+accuracy; see the open issue on renaming.
+
+---
+
+## Scope
+
+This adapter is a translation layer only. It does not perform authentication,
+transport, or retry handling; those belong to the calling integration. It
+converts platform payloads into A2CN terms and converts agreed A2CN terms back
+into platform-shaped payloads.

--- a/reference-implementation/python/adapters/IRONCLAD_INTEGRATION.md
+++ b/reference-implementation/python/adapters/IRONCLAD_INTEGRATION.md
@@ -5,6 +5,23 @@ records, and webhook APIs. This adapter connects Ironclad workflow events to
 A2CN negotiations and writes the final A2CN terms back to Ironclad workflow
 metadata or record properties.
 
+## Validation status
+
+**Built from:** Ironclad's published workflow, records and webhook API documentation.
+
+**Verified:** Payload translation in both directions against those published
+schemas — 10 tests in `tests/test_ironclad_adapter.py`.
+
+**Not verified:** This adapter has not been exercised against a live Ironclad instance. Runtime
+access requires the credentials listed under Environment Variables below. Workflow
+attribute names and record property shapes should be confirmed against a live
+environment before production use.
+
+If you have access to a live Ironclad instance and are willing to validate this
+adapter against it, please open an issue — that is the help we most need.
+
+---
+
 Public docs used:
 
 - `https://developer.ironcladapp.com/llms.txt` - machine-readable docs index.

--- a/reference-implementation/python/adapters/JAGGAER_INTEGRATION.md
+++ b/reference-implementation/python/adapters/JAGGAER_INTEGRATION.md
@@ -5,6 +5,23 @@ Advanced Sourcing Optimizer (ASO) customer-host / sourcing events into A2CN
 `goods_procurement` terms and maps agreed A2CN terms back into
 JAGGAER-shaped bid response payloads.
 
+## Validation status
+
+**Built from:** JAGGAER's published Advanced Sourcing Optimizer (ASO) API documentation.
+
+**Verified:** Payload translation in both directions against those published
+schemas — 12 tests in `tests/test_jaggaer_adapter.py`.
+
+**Not verified:** This adapter has not been exercised against a live JAGGAER instance. Runtime
+access requires the credentials listed under Environment Variables below. Event and
+bid payload shapes should be confirmed against a live environment before production
+use.
+
+If you have access to a live JAGGAER instance and are willing to validate this
+adapter against it, please open an issue — that is the help we most need.
+
+---
+
 Public docs used:
 
 - ASO API documentation

--- a/reference-implementation/python/adapters/KEELVAR_INTEGRATION.md
+++ b/reference-implementation/python/adapters/KEELVAR_INTEGRATION.md
@@ -1,0 +1,42 @@
+# Keelvar Sourcing - A2CN Integration Guide
+
+Keelvar is a buy-side sourcing optimisation platform. This adapter maps Keelvar
+`SOURCING_EVENTS_FEED_UPDATED` webhook payloads and sourcing event data into
+A2CN `goods_procurement` terms, and maps agreed A2CN terms back into
+Keelvar-shaped bid payloads.
+
+## Validation status
+
+**Built from:** Keelvar's published documentation at `docs.keelvar.app`, covering the
+webhooks endpoint, the sourcing-events endpoint and the bids endpoint. The
+full field-by-field mapping is documented in the module docstring.
+
+**Verified:** Payload translation in both directions against those published
+schemas — 17 tests in `tests/test_adapters.py::TestKeelvarAdapter`.
+
+**Not verified:** This adapter has not been exercised against a live Keelvar instance. Runtime
+access requires Keelvar API credentials, which we do not currently hold. Field
+names and response shapes should be confirmed against a live environment before
+production use.
+
+If you have access to a live Keelvar instance and are willing to validate this
+adapter against it, please open an issue — that is the help we most need.
+
+---
+
+## Module
+
+`adapters/keelvar_adapter.py` — pure data translation, no I/O. Every function is
+testable offline against fixture payloads.
+
+Entry points: sourcing-event and bid translation functions; see the
+module docstring for the complete Keelvar → A2CN field mapping table.
+
+---
+
+## Scope
+
+This adapter is a translation layer only. It does not perform authentication,
+transport, or retry handling; those belong to the calling integration. It
+converts platform payloads into A2CN terms and converts agreed A2CN terms back
+into platform-shaped payloads.

--- a/reference-implementation/python/adapters/NUE_INTEGRATION.md
+++ b/reference-implementation/python/adapters/NUE_INTEGRATION.md
@@ -5,6 +5,24 @@ Salesforce-native with a REST API layer. This adapter translates Nue
 pricing and subscription data into A2CN session terms, and translates
 A2CN agreed terms back into Nue order creation.
 
+## Validation status
+
+**Built from:** Nue.io's published REST API documentation and API conventions.
+
+**Verified:** Payload translation in both directions against those published
+schemas — 26 tests in `tests/test_nue_adapter.py`.
+
+**Not verified:** This adapter has not been exercised against a live Nue.io sandbox or production
+org. Runtime access requires the credentials listed under Environment Variables
+below. Some response shapes are auto-detected rather than confirmed — see
+Limitations — and should be verified against a live environment before production
+use.
+
+If you have access to a live Nue.io instance and are willing to validate this
+adapter against it, please open an issue — that is the help we most need.
+
+---
+
 ---
 
 ## Prerequisites

--- a/reference-implementation/python/adapters/REVENUE_CLOUD_INTEGRATION.md
+++ b/reference-implementation/python/adapters/REVENUE_CLOUD_INTEGRATION.md
@@ -1,0 +1,41 @@
+# Salesforce Revenue Cloud - A2CN Integration Guide
+
+Salesforce Revenue Cloud is a sell-side CPQ and billing platform. This adapter
+translates Revenue Cloud Pricing API responses into A2CN terms, and translates
+agreed A2CN terms back into Revenue Cloud order payloads.
+
+## Validation status
+
+**Built from:** Salesforce's published Revenue Cloud API documentation (v65.0+),
+covering the Pricing API and the QOC sales-transactions endpoint.
+
+**Verified:** Payload translation in both directions against those published
+schemas — 7 tests in `tests/test_adapters.py::TestRevenueCloudAdapter`.
+
+**Not verified:** This adapter has not been exercised against a live Salesforce org. Runtime
+access requires a Salesforce org with Revenue Cloud provisioned and a connected
+app with appropriate scopes, which we do not currently hold. Field names and
+response shapes should be confirmed against a live environment before production
+use.
+
+If you have access to a live Salesforce Revenue Cloud instance and are willing to validate this
+adapter against it, please open an issue — that is the help we most need.
+
+---
+
+## Module
+
+`adapters/revenue_cloud_adapter.py` — pure data translation, no I/O. Every function is
+testable offline against fixture payloads.
+
+Entry points: `RevenueCloudAdapter.pricing_response_to_a2cn_terms()` and the
+corresponding write-back function.
+
+---
+
+## Scope
+
+This adapter is a translation layer only. It does not perform authentication,
+transport, or retry handling; those belong to the calling integration. It
+converts platform payloads into A2CN terms and converts agreed A2CN terms back
+into platform-shaped payloads.

--- a/reference-implementation/python/adapters/VENDR_INTEGRATION.md
+++ b/reference-implementation/python/adapters/VENDR_INTEGRATION.md
@@ -13,6 +13,23 @@ negotiation and produce the dual-signed transaction record.
 
 No Vendr platform changes are required.
 
+## Validation status
+
+**Built from:** Vendr's published MCP server and webhook documentation.
+
+**Verified:** Payload translation in both directions against those published
+schemas — 13 tests in `tests/test_vendr_adapter.py`.
+
+**Not verified:** This adapter has not been exercised against a live Vendr instance. Vendr MCP/API
+access requires an access key issued by Vendr. Benchmark response and webhook
+payload shapes should be confirmed against a live environment before production
+use.
+
+If you have access to a live Vendr instance and are willing to validate this
+adapter against it, please open an issue — that is the help we most need.
+
+---
+
 ---
 
 ## Environment Variables


### PR DESCRIPTION
# PR: docs — state validation status for platform adapters

Docs-only. No code, no tests touched. 12 files, +265/-1.

## Why

The Ariba adapter is being described publicly as "a working Ariba adapter."
That is fair as far as the code goes, but the README currently says
`✓ Complete — 11 adapters` with nothing distinguishing "implemented against
published API specs and tested against those schemas" from "run against a live
tenant." A reader — particularly an SAP architect — will assume the latter.

This makes the repo say precisely what has and has not been exercised, before
someone clones it and finds out on their own. It also turns the gap into an ask:
each block invites anyone with live access to validate.

## What changed

A `## Validation status` block near the top of each adapter integration guide,
with three fields:

- **Built from** — which published API docs the adapter was written against
- **Verified** — payload translation against those schemas, with the real test
  count and test file
- **Not verified** — that it has not been run against a live instance, and what
  runtime access would require

All eleven adapter integration guides, plus the README status row.

Nue and DealHub already carried caveats in their Limitations sections; the new
block points at them rather than duplicating.