### PR TITLE
chore: release 0.3.0 — terminal Session Evidence Record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,113 @@
+# Changelog
+
+Release history for the A2CN protocol repository — the specification, the Python
+reference implementation, and the TypeScript reference implementation, which are
+versioned and released together.
+
+This file tracks the **release** version. A2CN versions three things independently;
+see [Three version axes](spec/README.md#three-version-axes) for the full table.
+
+| Axis | Current |
+|------|---------|
+| Release | `0.3.0` |
+| Spec / wire protocol (`protocol_version`, `a2cn_version`) | `0.2` |
+| `record_version` — TransactionRecord / AuditLog / SessionEvidenceRecord | `0.1` / `0.1` / `0.1` |
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project is pre-1.0: the minor version moves for substantive additions.
+
+---
+
+## [0.3.0] — 2026-09-02
+
+**Terminal Session Evidence Record (additive; wire-compatible with 0.2; no
+`record_version` or signature changes).**
+
+### Added
+
+- **Section 9A — `SessionEvidenceRecord`.** A producer-sealed evidence package for
+  *any* terminal session outcome, not only accepted ones. This closes the gap where
+  a session that ended in `REJECTED_FINAL`, `WITHDRAWN`, `IMPASSE`, or `TIMED_OUT`
+  left no verifiable artifact behind. Evidence is classified as `bilateral`,
+  `mixed`, or `unilateral`; sealing an unsigned observed act protects bundle
+  integrity but does **not** attribute that act to the named counterparty.
+- `GET /sessions/{session_id}/evidence` — terminal-only, party-authorized, in both
+  reference implementations.
+- Normative `spec/schemas/session-evidence-record.schema.json`
+  (`$id` `.../session-evidence-record/0.1`).
+- A cross-language hash vector, `spec/test-vectors/session-evidence-record-parity.json`.
+- `evidence.py` and `evidence.ts` implementing generation and strict verification,
+  including mandatory rejection of an unrecognized `record_version`.
+
+### Changed
+
+- Nothing on the wire, and nothing inside any hashed or signed byte range.
+
+### Compatibility
+
+`0.3.0` is **fully wire-compatible with `0.2`**. A `0.2` peer and a `0.3.0` peer
+interoperate without changes. Specifically:
+
+- `protocol_version` and `a2cn_version` remain `"0.2"`. The wire version moves only
+  on a wire-incompatible change (spec, *Status of This Document*), and this release
+  changed no wire message. `protocol_version` is the first field of the signed
+  protocol act, so holding it fixed is what keeps every existing signature,
+  `protocol_act_hash`, `offer_chain_hash`, `record_hash`, and parity vector valid.
+- No `record_version` moved. `TransactionRecord` and `AuditLog` are byte-identical
+  to `0.2.0` — their generation code was untouched. `SessionEvidenceRecord` is new,
+  so `"0.1"` is its initial version.
+- No schema `$id` moved. A schema's `$id` versions the thing it describes, so
+  message schemas stay at `/0.2` and `session-evidence-record` is correctly at
+  `/0.1` (Section 9A.1).
+- The spec document remains `spec/a2cn-spec-v0.2.0.md`. It specifies wire `0.2`,
+  which has not moved, and keeping the filename keeps published links and external
+  bookmarks working.
+
+### Upgrading
+
+Update the dependency; there is nothing else to do. Producing or consuming
+`SessionEvidenceRecord` is opt-in — existing negotiation, record, and audit-log
+code paths are unaffected.
+
+---
+
+## [0.2.0] — 2026-03-26
+
+### Added
+
+- **Component 8 — Session Invitation.** Push-based pre-session handshake: a signed
+  `SessionInvitation` delivered by webhook, HTTP, or a neutral relay, with hosted
+  endpoint provisioning for suppliers without their own server.
+- Normative deal-type terms schemas for `goods_procurement` and `saas_renewal`.
+- Impasse detection (`IMPASSE` terminal state) after consecutive non-moving rounds.
+- Post-commitment lifecycle: `delivery_notice`, `delivery_acknowledged`,
+  `dispute_notice`, `dispute_resolved` — normative at Level 3.
+- Platform integration patterns (Section 16) and the A2CN MCP server.
+
+### Changed
+
+- Webhooks became REQUIRED at Level 2 conformance.
+- Wire protocol version moved `0.1` → `0.2` (wire-incompatible).
+
+---
+
+## [0.1.3] — 2026-03-24
+
+Verification method precedence; DID session-duration binding; sender retry;
+timeout immutability.
+
+## [0.1.2] — 2026-03-24
+
+Fixed namespace UUID; JSON schemas became normative.
+
+## [0.1.1] — 2026-03-24
+
+RFC 8785 JCS canonicalization; full protocol act signing; DID trust root;
+strict turn-taking.
+
+## [0.1-draft] — 2026-03-24
+
+Initial draft.
+
+[0.3.0]: https://github.com/A2CN-protocol/A2CN/releases/tag/v0.3.0
+[0.2.0]: https://github.com/A2CN-protocol/A2CN/releases/tag/v0.2.0

--- a/a2cn_ts/package-lock.json
+++ b/a2cn_ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "a2cn",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "a2cn",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.4",
         "canonicalize": "^2.1.0",

--- a/a2cn_ts/package.json
+++ b/a2cn_ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2cn",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A2CN (Agent-to-Agent Contract Negotiation) TypeScript reference implementation",
   "type": "module",
   "private": true,

--- a/a2cn_ts/src/mcp_server.ts
+++ b/a2cn_ts/src/mcp_server.ts
@@ -735,7 +735,7 @@ export async function runStdioServer(ctx: McpContext): Promise<void> {
   const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
   const { z } = await import("zod");
 
-  const server = new McpServer({ name: "a2cn", version: "0.2.0" });
+  const server = new McpServer({ name: "a2cn", version: "0.3.0" });
 
   const asResult = (data: Dict) => ({
     content: [{ type: "text" as const, text: JSON.stringify(data) }],

--- a/docs.html
+++ b/docs.html
@@ -18,7 +18,7 @@
   <meta name="twitter:title" content="A2CN Developer Docs">
   <meta name="twitter:description" content="Build agents that negotiate with A2CN quickstarts, protocol reference, records, and adapter docs.">
   <meta name="twitter:image" content="https://a2cn.io/og-cover.png">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"A2CN Developer Docs","description":"Developer documentation for A2CN: quickstarts, protocol lifecycle, API endpoints, transaction records, MCP notes, and integration adapters.","url":"https://a2cn.io/docs.html","isPartOf":{"@type":"WebSite","name":"A2CN","url":"https://a2cn.io"},"about":{"@type":"SoftwareApplication","name":"A2CN","applicationCategory":"DeveloperApplication","softwareVersion":"0.2.0","codeRepository":"https://github.com/A2CN-protocol/A2CN"}}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"A2CN Developer Docs","description":"Developer documentation for A2CN: quickstarts, protocol lifecycle, API endpoints, transaction records, MCP notes, and integration adapters.","url":"https://a2cn.io/docs.html","isPartOf":{"@type":"WebSite","name":"A2CN","url":"https://a2cn.io"},"about":{"@type":"SoftwareApplication","name":"A2CN","applicationCategory":"DeveloperApplication","softwareVersion":"0.3.0","codeRepository":"https://github.com/A2CN-protocol/A2CN"}}</script>
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -570,7 +570,7 @@
 <header class="docs-hero">
   <div class="docs-hero-inner">
     <div>
-      <div class="eyebrow">Developer docs - protocol v0.2.0</div>
+      <div class="eyebrow">Developer docs - A2CN v0.3.0 - protocol v0.2</div>
       <h1>Build agents that can negotiate.</h1>
       <p class="lede">
         A2CN is the shared protocol layer for cross-company commercial negotiation:
@@ -1230,7 +1230,7 @@ assert ok is True</code></pre>
 <footer>
   <div class="footer-inner">
     <span>A2CN developer docs</span>
-    <span>Apache 2.0 - spec v0.2.0 - 474 tests passing</span>
+    <span>Apache 2.0 - A2CN v0.3.0 - spec v0.2.0 - 474 tests passing</span>
   </div>
 </footer>
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <meta name="twitter:title" content="A2CN — Agent-to-Agent Commercial Negotiation Protocol">
   <meta name="twitter:description" content="The missing layer: an open protocol for AI agents to negotiate binding commercial terms across organizations.">
   <meta name="twitter:image" content="https://a2cn.io/og-cover.png">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"A2CN","applicationCategory":"DeveloperApplication","operatingSystem":"Any","description":"Open protocol for agent-to-agent commercial negotiation across organizations.","url":"https://a2cn.io","license":"https://www.apache.org/licenses/LICENSE-2.0","softwareVersion":"0.2.0","codeRepository":"https://github.com/A2CN-protocol/A2CN","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"author":{"@type":"Organization","name":"A2CN Protocol"}}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"A2CN","applicationCategory":"DeveloperApplication","operatingSystem":"Any","description":"Open protocol for agent-to-agent commercial negotiation across organizations.","url":"https://a2cn.io","license":"https://www.apache.org/licenses/LICENSE-2.0","softwareVersion":"0.3.0","codeRepository":"https://github.com/A2CN-protocol/A2CN","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"author":{"@type":"Organization","name":"A2CN Protocol"}}</script>
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -1464,7 +1464,7 @@
   <div class="container">
     <div class="eyebrow">
       <span class="eyebrow-dot"></span>
-      The missing layer — v0.2.0 · Apache 2.0
+      The missing layer — v0.3.0 · Apache 2.0
     </div>
     <h1 class="hero-headline">
       AI agents can talk. They can pay. They can't yet <em>negotiate</em>.
@@ -1564,7 +1564,7 @@
           <div class="panel-sub">Agent protocols have been converging on this gap for three years. A2CN fills it.</div>
         </div>
 
-        <div class="timeline" role="slider" tabindex="0" aria-label="A2CN protocol timing timeline" aria-valuemin="2022" aria-valuemax="2026" aria-valuenow="2026" aria-valuetext="A2CN v0.2.0 fills the commercial negotiation layer">
+        <div class="timeline" role="slider" tabindex="0" aria-label="A2CN protocol timing timeline" aria-valuemin="2022" aria-valuemax="2026" aria-valuenow="2026" aria-valuetext="A2CN v0.3.0 fills the commercial negotiation layer">
           <div class="tl-row">
             <div class="tl-year">2022</div>
             <div class="tl-dot"></div>
@@ -1605,7 +1605,7 @@
             <div class="tl-year">2026</div>
             <div class="tl-dot"></div>
             <div class="tl-content">
-              <div class="tl-title">A2CN v0.2.0 — you are here</div>
+              <div class="tl-title">A2CN v0.3.0 — you are here</div>
               <div class="tl-desc">Open, neutral protocol for commercial negotiation between agents from different organizations. 8 components, 474 tests, 11 platform adapters, MCP server, A2A extension proposal submitted.</div>
             </div>
           </div>
@@ -2250,7 +2250,7 @@
 <footer>
   <div class="footer-inner">
     <span class="footer-brand">A2CN</span>
-    <span class="footer-meta">Apache 2.0 · spec v0.2.0 · 474 tests passing</span>
+    <span class="footer-meta">Apache 2.0 · A2CN v0.3.0 · spec v0.2.0 · 474 tests passing</span>
   </div>
 </footer>
 

--- a/reference-implementation/python/pyproject.toml
+++ b/reference-implementation/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "a2cn"
-version = "0.2.0"
+version = "0.3.0"
 requires-python = ">=3.11"
 dependencies = [
     "fastapi==0.115.0",

--- a/spec/README.md
+++ b/spec/README.md
@@ -2,10 +2,34 @@
 
 **The formal definition of the A2CN protocol.**
 
-[![Spec Version](https://img.shields.io/badge/Version-0.2.0-green.svg)](a2cn-spec-v0.2.0.md)
+[![Release](https://img.shields.io/badge/Release-0.3.0-green.svg)](../CHANGELOG.md)
+[![Spec](https://img.shields.io/badge/Spec-v0.2.0-blue.svg)](a2cn-spec-v0.2.0.md)
+[![Wire protocol](https://img.shields.io/badge/Wire%20protocol-0.2-blue.svg)](a2cn-spec-v0.2.0.md#status-of-this-document)
 [![Status](https://img.shields.io/badge/Status-Draft%20%E2%80%94%20Feedback%20Welcome-yellow.svg)]()
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](../LICENSE)
 [![Schemas](https://img.shields.io/badge/JSON%20Schemas-Normative-brightgreen.svg)](schemas/)
+
+---
+
+## Three version axes
+
+A2CN versions three different things independently. Reading one as another is the
+most common source of confusion, so they are named separately here.
+
+| Axis | Current | What it is | When it moves |
+|------|---------|------------|---------------|
+| **Release** | `0.3.0` | The published package and repository release (`pyproject.toml`, `package.json`, git tag). | Any shipped change, additive or not. See [CHANGELOG](../CHANGELOG.md). |
+| **Spec / wire protocol** | `0.2` | The on-the-wire contract: the `protocol_version` and `a2cn_version` fields, and the `$id` of every message schema. | Only on a **wire-incompatible** change. See [Status of This Document](a2cn-spec-v0.2.0.md#status-of-this-document). |
+| **`record_version`** | TransactionRecord `0.1`<br>AuditLog `0.1`<br>SessionEvidenceRecord `0.1` | The version of each terminal artifact, carried inside its own hashed bytes. Each artifact has its **own** line. | Only when that artifact's shape or canonical meaning changes (Section 9A.1). |
+
+A schema's `$id` version is the version of the **thing the schema describes** — the
+wire version for wire messages, the `record_version` for record artifacts. This is
+why `session-evidence-record/0.1` sits alongside `session-invitation/0.2`: both are
+correct, because they version different things.
+
+Release `0.3.0` is additive and fully wire-compatible with `0.2`: a `0.2` peer and a
+`0.3.0` peer interoperate, and every signature, hash, and test vector produced under
+`0.2` remains valid.
 
 ---
 
@@ -95,6 +119,8 @@ Protocol act signing is required at **all levels**.
 ---
 
 ## Spec history
+
+Spec document versions, which track the wire protocol — not the release version. For release history (including `0.3.0`), see the [CHANGELOG](../CHANGELOG.md).
 
 | Version | Summary |
 |---------|---------|

--- a/spec/a2cn-spec-v0.2.0.md
+++ b/spec/a2cn-spec-v0.2.0.md
@@ -30,10 +30,30 @@ This is a **draft specification** published to solicit feedback from implementer
 procurement platform developers, and the agent framework community. It is not
 suitable for production use.
 
-**Version note:** The specification document version (0.1.3) tracks editorial
-revisions. The wire protocol version (`protocol_version` and `a2cn_version` fields)
-remains `"0.1"` for all 0.1.x specification revisions. A change to `"0.2"` will
-indicate a wire-incompatible protocol change.
+**Version note:** A2CN versions three things independently. Reading one as another
+is the most common source of confusion, so they are stated separately here.
+
+1. **Release version** — currently `0.3.0`. Covers the published packages and the
+   repository as a whole. It moves for any shipped change, additive or not. See
+   `CHANGELOG.md`.
+2. **Wire protocol version** — currently `"0.2"`. This is the value of the
+   `protocol_version` and `a2cn_version` fields, and the version in the `$id` of
+   every message schema. It moves **only** on a wire-incompatible protocol change,
+   never for an editorial revision and never for an additive release. Because
+   `protocol_version` is the first field of the signed protocol act (Section 7.3.1),
+   moving it invalidates every existing signature and hash chain.
+3. **`record_version`** — one per terminal artifact, each independent of the others
+   and of the two versions above: TransactionRecord `"0.1"`, AuditLog `"0.1"`,
+   SessionEvidenceRecord `"0.1"`. Each moves only when that artifact's own shape or
+   canonical meaning changes; see Section 9A.1.
+
+A schema's `$id` version is the version of the thing that schema describes — the
+wire version for wire messages, the artifact's `record_version` for record
+artifacts.
+
+This document is specification version 0.2.0 and specifies wire protocol `"0.2"`.
+The specification document version tracks editorial revisions to the wire contract
+and is not the release version.
 
 Normative JSON Schemas for all message types are published alongside this specification
 at `spec/schemas/` in the repository. The schemas are **normative** as of v0.1.2.
@@ -3973,6 +3993,23 @@ messages that validate against these schemas.
 ---
 
 ## 19. Changelog
+
+Entries below are changes to this specification document. For the repository and
+package release history, see `CHANGELOG.md`.
+
+### Release 0.3.0 (2026-09-02)
+
+Release `0.3.0` ships the terminal Session Evidence Record described in the
+2026-08-31 patch below. The release is additive and fully wire-compatible with
+`0.2`:
+
+- Wire protocol version unchanged at `"0.2"` — no wire message changed.
+- No `record_version` changed. TransactionRecord and AuditLog generation was
+  untouched and their bytes are identical to release `0.2.0`; SessionEvidenceRecord
+  is new at its initial version `"0.1"`.
+- No schema `$id` changed.
+- This document keeps the filename `a2cn-spec-v0.2.0.md`, because the wire protocol
+  it specifies is still `0.2` and published links resolve against that name.
 
 ### Patch 2026-08-31 — Session Evidence Record
 


### PR DESCRIPTION
## Release 0.3.0 — terminal Session Evidence Record

Bumps the **release** version `0.2.0 → 0.3.0` to signal the terminal
`SessionEvidenceRecord` merged in #70. The release moves; the wire, the records,
and the schema `$id`s do not.

> **@Avinash — the number to confirm at merge is `0.3.0`.** It is a pre-1.0 minor
> bump: #70 added a substantive component, additively. If you'd rather ship this as
> `0.2.1`, it's a find-and-replace across the files listed below plus the tag.

### Why a minor bump, and why nothing else moves

#70 was **purely additive** — `record.py` and `record.ts` are untouched in its diff.
It added `evidence.py` / `evidence.ts`, the `session-evidence-record` schema, spec
Section 9A, and the terminal evidence endpoint. External adopters need to hear about
it; no existing deployment needs to change anything.

A2CN versions three things independently, and this PR makes that explicit rather
than leaving it implied:

| Axis | Before | After | Why |
|------|--------|-------|-----|
| **Release** | `0.2.0` | **`0.3.0`** | Substantive additive component shipped. |
| **Spec / wire** (`protocol_version`, `a2cn_version`) | `0.2` | `0.2` | Moves only on a wire-incompatible change. No wire message changed. |
| **`record_version`** (Txn / Audit / Evidence) | `0.1` / `0.1` / `0.1` | unchanged | No artifact shape changed; Evidence is new at its initial version. |

### Two things this PR deliberately does *not* do

**1. The wire version does not move.** `protocol_version` and `a2cn_version` are one
wire version. Moving them would be wire-breaking twice over:

- `protocol_version` is the **first field of the signed protocol act**
  (`messages.py:399`), so it sits inside `protocol_act_hash → offer_chain_hash →
  record_hash`. Changing it invalidates every existing signature, hash, and parity
  vector.
- `server.py:1007` / `server.ts:1389` hard-reject any `a2cn_version` other than the
  `const` in `session-invitation.schema.json`, so a bump would reject every existing
  `0.2` inviter — including on the release we're publishing.

**2. No schema `$id` moves — `session-evidence-record/0.1` is correct, not an
outlier.** Spec §9A.1 (normative, added by #70) binds a record schema's `$id`
version to that record's own `record_version`, which is `"0.1"`. The general rule,
now written down: **a schema's `$id` versions the thing the schema describes** — the
wire version for wire messages (`/0.2`), the `record_version` for record artifacts
(`/0.1`). Both are right; they version different things.

The spec doc keeps the filename `a2cn-spec-v0.2.0.md` — it specifies wire `0.2`,
which hasn't moved, and renaming would 404 the live site's spec links and every
external bookmark.

### Changes

**Release surface**
- `reference-implementation/python/pyproject.toml`, `a2cn_ts/package.json` (+ lockfile) → `0.3.0`
- `a2cn_ts/src/mcp_server.ts:738` — MCP-advertised implementation version → `0.3.0` *(package identity, not wire; called out because it wasn't in the original list but is part of the same surface)*
- **`CHANGELOG.md` (new)** — with the git tag, this is how external adopters learn of the update
- `spec/README.md` — release badge, plus a **Three version axes** table
- `spec/a2cn-spec-v0.2.0.md` — Section 19 release entry, and a refreshed *Version note*

**Website** (a2cn.io ships from this repo)
- JSON-LD `softwareVersion` → `0.3.0` (`index.html:21`, `docs.html:21`)
- Release identifiers → `0.3.0`; footers now state **both** axes, e.g.
  `Apache 2.0 · A2CN v0.3.0 · spec v0.2.0`
- Untouched by design: `docs.html:678` `"protocol_version": "0.2"` (wire),
  `index.html:2121` and `docs.html:632` (name the spec), and all spec-doc links
  (`index.html` :1485/:1496/:2215) — verified still resolving, no 404

### Verification

| Check | Baseline @ `65a6b57` | This branch |
|---|---|---|
| Python suite | 504 passed | **504 passed** |
| TypeScript suite | 529 passed | **529 passed** |
| `tsc --noEmit` | clean | **clean** |
| JSON schemas (10) | valid | **valid**, all `$id`s unchanged |

The suites being **identical** to baseline is the point: it's the proof that nothing
signed or hashed moved.

### Follow-ups (not in this PR)

- **Tag `v0.3.0` + GitHub Release after merge**, on the merge commit.
- The site's `474 tests passing` copy is stale (now 504 Python / 529 TS), and
  `og-cover.svg:22` still reads `v0.2.0` while `og-cover.png` would need
  regenerating to match. Both are accuracy fixes unrelated to a version bump.
- Items (A) malformed-timestamp 500 and (B) no-ordering fallback remain untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AffF1PYfNxohcKU373e4X
