### PR TITLE
spec: one-sided evidence, recomputable money basis, controls-halt outcome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,40 @@ This project is pre-1.0: the minor version moves for substantive additions.
 
 ---
 
+## [Unreleased]
+
+**Three additive Session Evidence Record extensions (wire-compatible with 0.2;
+no signature changes).**
+
+`record_version` stays `"0.1"` and the schema `$id` stays at `/0.1`. Changes 1
+and 3 are relaxations, so a verifier predating them rejects the new records.
+Amending in place is defensible only because the artifact has no external
+consumers yet; see Section 9A.2. **This choice requires confirmation before
+release.** The alternative is to bump `record_version` and `$id` to `0.2`
+together, with verifiers accepting `{0.1, 0.2}`.
+
+### Added
+
+- **Section 9A.8 — identity-light responders.** `parties.responder` may be an
+  `observed_party`: a producer-asserted, unverified descriptor for a counterparty
+  with no A2CN identity. A verifier never resolves or authenticates it. Such a
+  record must be `unilateral` and no act other than the initiator's may claim a
+  verified signature. `acts[].sender_did` may be `null`, and only for an unsigned
+  observation, so that no DID is ever fabricated.
+- **Section 9A.9 — recomputable `money_basis`.** An optional per-act or terminal
+  basis carrying the amounts as observed, so a reader can recompute the total.
+  The recompute is unit normalization only: `basis` is a checked label and a
+  verifier never converts between net and gross. A claimed total with absent raw
+  amounts fails closed.
+- **Section 9A.10 — `HALTED_BY_CONTROLS` terminal outcome.** An agent's own
+  controls or governance stopped the run, distinct from `ERROR`, `IMPASSE`, and
+  `WITHDRAWN`. An evidence-record outcome only; no session state is added.
+  Unrecognized outcomes are still rejected.
+- **Section 9A.11 — namespaced `extensions`.** The only place additional
+  properties are permitted. Sealed by `record_hash`, never interpreted.
+- `spec/test-vectors/session-evidence-record-extensions.json` — cross-language
+  parity vectors covering all three extensions.
+
 ## [0.3.0] — 2026-09-02
 
 **Terminal Session Evidence Record (additive; wire-compatible with 0.2; no

--- a/a2cn_ts/src/a2cn/evidence.ts
+++ b/a2cn_ts/src/a2cn/evidence.ts
@@ -47,6 +47,23 @@ export const EvidenceSignatureType = {
   ACCEPTANCE: "acceptance_signature",
 } as const;
 
+export const OUTCOME_HALTED_BY_CONTROLS = "HALTED_BY_CONTROLS";
+
+export const MONEY_BASIS_LABELS = new Set<string>([
+  "net",
+  "gross",
+  "per_unit",
+  "line_total",
+  "unspecified",
+]);
+
+// HALTED_BY_CONTROLS is an evidence-record outcome only. It is deliberately not a
+// SessionState: adding one would be a wire change, and 0.2 is frozen.
+const EVIDENCE_TERMINAL_OUTCOMES = new Set<string>([
+  ...SessionState.TERMINAL,
+  OUTCOME_HALTED_BY_CONTROLS,
+]);
+
 const SIGNED_MESSAGE_FIELDS: Record<string, string> = {
   [EvidenceSignatureType.PROTOCOL_ACT]: "protocol_act_signature",
   [EvidenceSignatureType.ACCEPTANCE]: "acceptance_signature",
@@ -82,7 +99,46 @@ const ACT_FIELDS = new Set([
   "signature",
   "attribution",
 ]);
+const RECORD_OPTIONAL_FIELDS = new Set(["extensions"]);
+const ACT_OPTIONAL_FIELDS = new Set(["money_basis"]);
+const TERMINAL_FIELDS = new Set(["outcome", "reason", "message_id", "timestamp"]);
+const TERMINAL_OPTIONAL_FIELDS = new Set(["money_basis"]);
+const PARTY_FIELDS = new Set([
+  "organization_name",
+  "did",
+  "agent_id",
+  "verification_method",
+  "mandate_type",
+]);
+const OBSERVED_PARTY_FIELDS = new Set([
+  "identity_source",
+  "did_declared",
+  "a2cn_endpoint_declared",
+  "mandate_declared",
+]);
+const OBSERVED_PARTY_OPTIONAL_FIELDS = new Set([
+  "organization_name",
+  "observed_credential",
+]);
+const OBSERVED_PARTY_MARKERS = [
+  "did_declared",
+  "a2cn_endpoint_declared",
+  "mandate_declared",
+];
+// raw_amounts is deliberately absent from the required set so the fail-closed rule
+// owns it by name: a total claimed with no raw data behind it is rejected by a
+// branch that says so, not incidentally by a field-set check.
+const MONEY_BASIS_FIELDS = new Set([
+  "currency",
+  "minor_unit_exponent",
+  "basis",
+  "normalized_total_minor",
+]);
+const MONEY_BASIS_OPTIONAL_FIELDS = new Set(["raw_amounts"]);
 const HASH_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const EXTENSION_NAMESPACE_PATTERN = /^[a-z0-9][a-z0-9_-]*(\.[a-z0-9][a-z0-9_-]*)+$/;
+const CURRENCY_PATTERN = /^[A-Z]{3}$/;
+const DECIMAL_AMOUNT_PATTERN = /^(-?)(0|[1-9][0-9]*)(?:\.([0-9]+))?$/;
 const RFC3339_PATTERN =
   /^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?([Zz]|([+-])(\d{2}):(\d{2}))$/;
 
@@ -97,6 +153,13 @@ export interface GenerateSessionEvidenceOptions {
   producerDid?: string | null;
   producerAgentId?: string | null;
   observedActs?: Dict[] | null;
+  /** A counterparty with no A2CN identity. A producer assertion; no DID is fabricated. */
+  observedResponder?: Dict | null;
+  /** May only assert HALTED_BY_CONTROLS, for a run the producer's own controls stopped. */
+  terminalOutcome?: string | null;
+  terminalReason?: string | null;
+  terminalMoneyBasis?: Dict | null;
+  extensions?: Dict | null;
 }
 
 export interface EvidenceAssessment {
@@ -116,7 +179,30 @@ export function generateSessionEvidenceRecord(
     throw new Error("Session evidence is only available for terminal sessions");
   }
 
-  const parties = partyMetadata(session);
+  let outcome = session.state;
+  let reason = session.terminal_reason ?? null;
+  const terminalOutcome = options.terminalOutcome ?? null;
+  if (terminalOutcome !== null) {
+    if (terminalOutcome !== OUTCOME_HALTED_BY_CONTROLS) {
+      throw new Error(`terminalOutcome may only assert ${OUTCOME_HALTED_BY_CONTROLS}`);
+    }
+    if (session.state === SessionState.COMPLETED) {
+      throw new Error("A COMPLETED session cannot be relabelled as halted");
+    }
+    outcome = terminalOutcome;
+  }
+  const terminalReason = options.terminalReason ?? null;
+  if (terminalReason !== null) {
+    if (terminalOutcome === null) {
+      throw new Error("terminalReason requires terminalOutcome");
+    }
+    if (typeof terminalReason !== "string" || !terminalReason) {
+      throw new Error("terminalReason must be a non-empty string");
+    }
+    reason = terminalReason;
+  }
+
+  const parties = partyMetadata(session, options.observedResponder ?? null);
   const producer = producerMetadata(parties, {
     producerVerificationMethod: options.producerVerificationMethod,
     producerDid: options.producerDid ?? null,
@@ -140,7 +226,7 @@ export function generateSessionEvidenceRecord(
   const actChainHash = hashBytes(
     canonicalize(orderedActs.map((entry) => entry.act_hash as string)),
   );
-  const evidenceLevel = classifyEvidenceLevel(orderedActs, session.state, parties);
+  const evidenceLevel = classifyEvidenceLevel(orderedActs, outcome, parties);
   const producerDid = producer.did as string;
 
   const record: Dict = {
@@ -155,8 +241,8 @@ export function generateSessionEvidenceRecord(
     producer,
     parties,
     terminal: {
-      outcome: session.state,
-      reason: session.terminal_reason ?? null,
+      outcome,
+      reason,
       message_id: session.terminal_message_id || null,
       timestamp: terminalTimestamp,
     },
@@ -167,6 +253,25 @@ export function generateSessionEvidenceRecord(
     record_hash: "",
     producer_signature: "",
   };
+  if (options.terminalMoneyBasis != null) {
+    (record.terminal as Dict).money_basis = structuredClone(options.terminalMoneyBasis);
+  }
+  if (options.extensions != null) {
+    record.extensions = validatedExtensions(options.extensions);
+  }
+
+  // Refuse to seal a claim the verifier would reject. The generator and the
+  // verifier run the same two rules so a producer cannot emit a record that only
+  // fails once it is somebody else's problem.
+  if (!moneyBasisClaimsVerify(record)) {
+    throw new Error("money_basis does not recompute to the claimed and signed totals");
+  }
+  if (!observedResponderRulesHold(record)) {
+    throw new Error(
+      "An observed responder requires unsigned counterparty acts and unilateral evidence",
+    );
+  }
+
   record.record_hash = hashObject(record);
   record.producer_signature = signJws(
     record.record_hash as string,
@@ -210,7 +315,7 @@ export function assessSessionEvidenceRecord(
 
     const terminal = record.terminal as Dict;
     const outcome = terminal.outcome as string;
-    if (!SessionState.TERMINAL.has(outcome)) {
+    if (!EVIDENCE_TERMINAL_OUTCOMES.has(outcome)) {
       return assessment;
     }
     if (record.generated_at !== terminal.timestamp) {
@@ -276,6 +381,12 @@ export function assessSessionEvidenceRecord(
     if (assessment.invalid_acts > 0) {
       return assessment;
     }
+    if (!moneyBasisClaimsVerify(record)) {
+      return assessment;
+    }
+    if (!observedResponderRulesHold(record)) {
+      return assessment;
+    }
     if (record.act_chain_hash !== hashBytes(canonicalize(computedActHashes))) {
       return assessment;
     }
@@ -310,7 +421,7 @@ export function assessSessionEvidenceRecord(
   }
 }
 
-function partyMetadata(session: EvidenceSession): Dict {
+function partyMetadata(session: EvidenceSession, observedResponder: Dict | null): Dict {
   const sessionInit = session._session_init ?? {};
   const sessionAck = session._session_ack ?? {};
   const initiatorInfo = metadataObject(sessionInit.initiator, "initiator");
@@ -332,14 +443,103 @@ function partyMetadata(session: EvidenceSession): Dict {
       verification_method: metadataString(initiatorInfo, "verification_method"),
       mandate_type: metadataString(initiatorMandate, "mandate_type"),
     },
-    responder: {
-      organization_name: metadataString(responderInfo, "organization_name"),
-      did: metadataString(responderInfo, "did"),
-      agent_id: metadataString(responderInfo, "agent_id"),
-      verification_method: metadataString(responderInfo, "verification_method"),
-      mandate_type: metadataString(responderMandate, "mandate_type"),
-    },
+    responder:
+      observedResponder !== null
+        ? observedPartyMetadata(responderInfo, responderMandate, observedResponder)
+        : {
+            organization_name: metadataString(responderInfo, "organization_name"),
+            did: metadataString(responderInfo, "did"),
+            agent_id: metadataString(responderInfo, "agent_id"),
+            verification_method: metadataString(responderInfo, "verification_method"),
+            mandate_type: metadataString(responderMandate, "mandate_type"),
+          },
   };
+}
+
+/**
+ * Assemble an identity-light responder from what the caller supplies.
+ *
+ * Every field is a producer assertion. No DID is derived, defaulted, or
+ * fabricated here, and the session must not already carry the A2CN identity this
+ * descriptor claims is absent.
+ */
+function observedPartyMetadata(
+  responderInfo: Dict,
+  responderMandate: Dict,
+  observedResponder: Dict,
+): Dict {
+  if (
+    typeof observedResponder !== "object" ||
+    observedResponder === null ||
+    Array.isArray(observedResponder)
+  ) {
+    throw new Error("observedResponder must be an object");
+  }
+  for (const [fieldName, marker] of [
+    ["did", "a DID"],
+    ["endpoint", "an A2CN endpoint"],
+    ["verification_method", "a verification method"],
+  ]) {
+    const declared = responderInfo[fieldName];
+    if (typeof declared === "string" && declared) {
+      throw new Error(`Responder declared ${marker}; it is not an observed party`);
+    }
+  }
+  if (responderMandate.mandate_type) {
+    throw new Error("Responder declared a mandate; it is not an observed party");
+  }
+
+  const identitySource = observedResponder.identity_source;
+  if (typeof identitySource !== "string" || !identitySource) {
+    throw new Error("observedResponder requires a non-empty identity_source");
+  }
+
+  const party: Dict = {
+    identity_source: identitySource,
+    did_declared: false,
+    a2cn_endpoint_declared: false,
+    mandate_declared: false,
+  };
+  const organizationName = observedResponder.organization_name;
+  if (organizationName != null) {
+    if (typeof organizationName !== "string") {
+      throw new Error("observedResponder organization_name must be a string");
+    }
+    party.organization_name = organizationName;
+  }
+  const credential = observedResponder.observed_credential;
+  if (credential != null) {
+    if (
+      typeof credential !== "object" ||
+      Array.isArray(credential) ||
+      !hasFields(credential as Dict, new Set(["type", "digest"]))
+    ) {
+      throw new Error("observed_credential requires exactly type and digest");
+    }
+    const credentialType = (credential as Dict).type;
+    const digest = (credential as Dict).digest;
+    if (typeof credentialType !== "string" || !credentialType) {
+      throw new Error("observed_credential type must be a non-empty string");
+    }
+    if (typeof digest !== "string" || !HASH_PATTERN.test(digest)) {
+      throw new Error("observed_credential digest must be a base64url SHA-256");
+    }
+    party.observed_credential = { type: credentialType, digest };
+  }
+  return party;
+}
+
+/** Namespaced producer extensions. Never interpreted, only namespaced. */
+function validatedExtensions(extensions: Dict): Dict {
+  if (typeof extensions !== "object" || extensions === null || Array.isArray(extensions)) {
+    throw new Error("extensions must be an object");
+  }
+  for (const name of Object.keys(extensions)) {
+    if (!EXTENSION_NAMESPACE_PATTERN.test(name)) {
+      throw new Error(`extensions keys must be namespaced: ${JSON.stringify(name)}`);
+    }
+  }
+  return structuredClone(extensions);
 }
 
 function metadataObject(value: unknown, fieldName: string): Dict {
@@ -362,14 +562,29 @@ function metadataString(object: Dict, fieldName: string): string {
   return object[fieldName] as string;
 }
 
-function hasExactFields(object: Dict, expected: Set<string>): boolean {
+function hasFields(object: Dict, required: Set<string>, optional?: Set<string>): boolean {
+  if (typeof object !== "object" || object === null || Array.isArray(object)) {
+    return false;
+  }
   const fields = Object.keys(object);
-  return fields.length === expected.size && fields.every((field) => expected.has(field));
+  if (!fields.every((field) => required.has(field) || optional?.has(field) === true)) {
+    return false;
+  }
+  return [...required].every((field) => fields.includes(field));
 }
 
 function evidenceRecordShapeValid(record: Dict): boolean {
-  if (typeof record !== "object" || record === null || !hasExactFields(record, RECORD_FIELDS)) {
+  if (!hasFields(record, RECORD_FIELDS, RECORD_OPTIONAL_FIELDS)) {
     return false;
+  }
+  if (hasOwn(record, "extensions")) {
+    const extensions = record.extensions;
+    if (typeof extensions !== "object" || extensions === null || Array.isArray(extensions)) {
+      return false;
+    }
+    if (!Object.keys(extensions).every((name) => EXTENSION_NAMESPACE_PATTERN.test(name))) {
+      return false;
+    }
   }
   for (const field of [
     "record_type",
@@ -397,11 +612,7 @@ function evidenceRecordShapeValid(record: Dict): boolean {
   }
 
   const producer = record.producer as Dict;
-  if (
-    typeof producer !== "object" ||
-    producer === null ||
-    !hasExactFields(producer, new Set(["did", "agent_id", "verification_method"]))
-  ) {
+  if (!hasFields(producer, new Set(["did", "agent_id", "verification_method"]))) {
     return false;
   }
   if (typeof producer.did !== "string" || !producer.did.startsWith("did:")) {
@@ -415,39 +626,23 @@ function evidenceRecordShapeValid(record: Dict): boolean {
   }
 
   const parties = record.parties as Dict;
+  if (!hasFields(parties, new Set(["initiator", "responder"]))) {
+    return false;
+  }
+  // The producer is a DID-bearing party, so the initiator side stays strict.
+  // Only the responder may be identity-light.
+  if (!fullPartyShapeValid(parties.initiator)) {
+    return false;
+  }
   if (
-    typeof parties !== "object" ||
-    parties === null ||
-    !hasExactFields(parties, new Set(["initiator", "responder"]))
+    !fullPartyShapeValid(parties.responder) &&
+    !observedPartyShapeValid(parties.responder)
   ) {
     return false;
   }
-  const partyFields = new Set([
-    "organization_name",
-    "did",
-    "agent_id",
-    "verification_method",
-    "mandate_type",
-  ]);
-  for (const value of Object.values(parties)) {
-    const party = value as Dict;
-    if (typeof party !== "object" || party === null || !hasExactFields(party, partyFields)) {
-      return false;
-    }
-    if ([...partyFields].some((field) => typeof party[field] !== "string")) {
-      return false;
-    }
-    if (!(party.did as string).startsWith("did:") || !party.verification_method) {
-      return false;
-    }
-  }
 
   const terminal = record.terminal as Dict;
-  if (
-    typeof terminal !== "object" ||
-    terminal === null ||
-    !hasExactFields(terminal, new Set(["outcome", "reason", "message_id", "timestamp"]))
-  ) {
+  if (!hasFields(terminal, TERMINAL_FIELDS, TERMINAL_OPTIONAL_FIELDS)) {
     return false;
   }
   if (typeof terminal.outcome !== "string") {
@@ -473,8 +668,229 @@ function evidenceRecordShapeValid(record: Dict): boolean {
   return Array.isArray(record.acts);
 }
 
+function fullPartyShapeValid(party: unknown): boolean {
+  if (!hasFields(party as Dict, PARTY_FIELDS)) {
+    return false;
+  }
+  const value = party as Dict;
+  if ([...PARTY_FIELDS].some((field) => typeof value[field] !== "string")) {
+    return false;
+  }
+  return (value.did as string).startsWith("did:") && Boolean(value.verification_method);
+}
+
+/**
+ * Shape of an identity-light counterparty descriptor.
+ *
+ * This checks structure and the explicit negative markers, and nothing else. A
+ * verifier MUST NOT resolve `identity_source`, look it up in any registry, or
+ * apply per-type validation to it: doing so would imply an authentication A2CN
+ * did not perform. There is no whitelist here by design.
+ */
+function observedPartyShapeValid(party: unknown): boolean {
+  if (!hasFields(party as Dict, OBSERVED_PARTY_FIELDS, OBSERVED_PARTY_OPTIONAL_FIELDS)) {
+    return false;
+  }
+  const value = party as Dict;
+  if (typeof value.identity_source !== "string" || !value.identity_source) {
+    return false;
+  }
+  if (OBSERVED_PARTY_MARKERS.some((marker) => value[marker] !== false)) {
+    return false;
+  }
+  if (hasOwn(value, "organization_name") && typeof value.organization_name !== "string") {
+    return false;
+  }
+  if (hasOwn(value, "observed_credential")) {
+    const credential = value.observed_credential as Dict;
+    if (!hasFields(credential, new Set(["type", "digest"]))) {
+      return false;
+    }
+    if (typeof credential.type !== "string" || !credential.type) {
+      return false;
+    }
+    if (typeof credential.digest !== "string" || !HASH_PATTERN.test(credential.digest)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Couple an identity-light responder to unsigned acts and unilateral evidence.
+ *
+ * A2CN authenticates DID-bearing parties. When the responder holds no DID there
+ * is no key any counterparty act could be checked against, so the initiator is
+ * the only party that may carry a verified signature in such a record. A
+ * responder claiming `verified_signature` is rejected outright, not downgraded.
+ */
+function observedResponderRulesHold(record: Dict): boolean {
+  const parties = record.parties as Dict;
+  if (typeof parties !== "object" || parties === null) {
+    return false;
+  }
+  if (!observedPartyShapeValid(parties.responder)) {
+    return true;
+  }
+
+  const initiator = parties.initiator as Dict;
+  if (typeof initiator !== "object" || initiator === null) {
+    return false;
+  }
+  const initiatorDid = initiator.did;
+  const acts = record.acts;
+  if (!Array.isArray(acts)) {
+    return false;
+  }
+  for (const entry of acts as Dict[]) {
+    if (typeof entry !== "object" || entry === null) {
+      return false;
+    }
+    if (entry.attribution !== EvidenceAttribution.VERIFIED) {
+      continue;
+    }
+    if (entry.sender_did !== initiatorDid) {
+      return false;
+    }
+  }
+  // Asserted explicitly rather than inherited from the classifier, so that a
+  // future change to classification cannot quietly promote these records.
+  return record.evidence_level === EvidenceLevel.UNILATERAL;
+}
+
+/**
+ * Scale one major-unit decimal string to minor units, exactly.
+ *
+ * Returns null for anything finer than the stated exponent. Rounding here would
+ * silently alter money, so a sub-minor amount is refused instead.
+ */
+function decimalToMinor(amount: unknown, exponent: number): bigint | null {
+  if (typeof amount !== "string") {
+    return null;
+  }
+  const match = DECIMAL_AMOUNT_PATTERN.exec(amount);
+  if (match === null) {
+    return null;
+  }
+  const fraction = match[3] ?? "";
+  if (fraction.length > exponent) {
+    return null;
+  }
+  const value = BigInt(match[2] + fraction.padEnd(exponent, "0"));
+  return match[1] === "-" ? -value : value;
+}
+
+/**
+ * Recompute the unit normalization only, and compare it with both totals.
+ *
+ * `basis` is a CHECKED LABEL. A verifier MUST NOT convert between net and gross:
+ * that is a tax calculation, not a normalization, and performing it silently
+ * corrupts money. The arithmetic below is identical for every label.
+ */
+function moneyBasisRecomputes(
+  moneyBasis: unknown,
+  expectedTotalMinor: number,
+  expectedCurrency: string,
+): boolean {
+  if (!hasFields(moneyBasis as Dict, MONEY_BASIS_FIELDS, MONEY_BASIS_OPTIONAL_FIELDS)) {
+    return false;
+  }
+  const value = moneyBasis as Dict;
+  if (typeof value.basis !== "string" || !MONEY_BASIS_LABELS.has(value.basis)) {
+    return false;
+  }
+  if (typeof value.currency !== "string" || !CURRENCY_PATTERN.test(value.currency)) {
+    return false;
+  }
+  if (value.currency !== expectedCurrency) {
+    return false;
+  }
+  const exponent = value.minor_unit_exponent;
+  if (!Number.isInteger(exponent) || (exponent as number) < 0 || (exponent as number) > 4) {
+    return false;
+  }
+  const claimed = value.normalized_total_minor;
+  if (!Number.isSafeInteger(claimed)) {
+    return false;
+  }
+
+  // FAIL-CLOSED: a total claimed with no raw amounts behind it is unverifiable,
+  // and an unverifiable claim must never read as a verified one.
+  const rawAmounts = value.raw_amounts;
+  if (!Array.isArray(rawAmounts) || rawAmounts.length === 0) {
+    return false;
+  }
+
+  let total = 0n;
+  for (const amount of rawAmounts) {
+    const minor = decimalToMinor(amount, exponent as number);
+    if (minor === null) {
+      return false;
+    }
+    total += minor;
+  }
+  return total === BigInt(claimed as number) && total === BigInt(expectedTotalMinor);
+}
+
+/** Bind a money_basis to the total inside the act it describes. */
+function moneyBasisBindsToAct(entry: unknown, moneyBasis: unknown): boolean {
+  if (typeof entry !== "object" || entry === null) {
+    return false;
+  }
+  const act = (entry as Dict).act;
+  if (typeof act !== "object" || act === null || Array.isArray(act)) {
+    return false;
+  }
+  const terms = (act as Dict).terms;
+  if (typeof terms !== "object" || terms === null || Array.isArray(terms)) {
+    return false;
+  }
+  const total = (terms as Dict).total_value;
+  if (!Number.isSafeInteger(total)) {
+    return false;
+  }
+  const currency = (terms as Dict).currency;
+  if (typeof currency !== "string") {
+    return false;
+  }
+  return moneyBasisRecomputes(moneyBasis, total as number, currency);
+}
+
+/** Every money_basis in the record recomputes, or the record is rejected. */
+function moneyBasisClaimsVerify(record: Dict): boolean {
+  const acts = record.acts;
+  if (!Array.isArray(acts)) {
+    return false;
+  }
+  for (const entry of acts as Dict[]) {
+    if (typeof entry === "object" && entry !== null && hasOwn(entry, "money_basis")) {
+      if (!moneyBasisBindsToAct(entry, entry.money_basis)) {
+        return false;
+      }
+    }
+  }
+
+  const terminal = record.terminal as Dict;
+  if (typeof terminal !== "object" || terminal === null || !hasOwn(terminal, "money_basis")) {
+    return true;
+  }
+  // A terminal money_basis describes the terminal quote, so it must name the act
+  // that carries it. An unresolvable reference is refused, not ignored.
+  const messageId = terminal.message_id;
+  if (typeof messageId !== "string" || !messageId) {
+    return false;
+  }
+  const quoted = (acts as Dict[]).filter(
+    (entry) => typeof entry === "object" && entry !== null && entry.message_id === messageId,
+  );
+  if (quoted.length !== 1) {
+    return false;
+  }
+  return moneyBasisBindsToAct(quoted[0], terminal.money_basis);
+}
+
 function evidenceActShapeValid(entry: Dict): boolean {
-  if (typeof entry !== "object" || entry === null || !hasExactFields(entry, ACT_FIELDS)) {
+  if (!hasFields(entry, ACT_FIELDS, ACT_OPTIONAL_FIELDS)) {
     return false;
   }
   for (const field of ["sequence_number", "round_number"]) {
@@ -483,16 +899,18 @@ function evidenceActShapeValid(entry: Dict): boolean {
       return false;
     }
   }
-  for (const field of [
-    "message_type",
-    "sender_did",
-    "act_hash",
-  ]) {
+  for (const field of ["message_type", "act_hash"]) {
     if (typeof entry[field] !== "string" || !(entry[field] as string)) {
       return false;
     }
   }
-  if (!(entry.sender_did as string).startsWith("did:")) {
+  const senderDid = entry.sender_did;
+  if (senderDid === null) {
+    // A sender with no DID is only representable as an unsigned observation.
+    if (entry.attribution !== EvidenceAttribution.UNSIGNED) {
+      return false;
+    }
+  } else if (typeof senderDid !== "string" || !senderDid.startsWith("did:")) {
     return false;
   }
   for (const field of ["message_id", "timestamp"]) {
@@ -652,10 +1070,21 @@ function normalizeEvidenceAct(item: Dict, defaultSourceProtocol: string | null):
     signature,
     attribution,
   };
+  if (isWrapper && metadata.money_basis != null) {
+    // A producer annotation ABOUT the act, never inside it: `act` stays the
+    // verbatim observed bytes that act_hash protects.
+    entry.money_basis = structuredClone(metadata.money_basis);
+  }
   if (typeof entry.message_type !== "string" || !entry.message_type) {
     throw new Error("Evidence acts require message_type");
   }
-  if (typeof entry.sender_did !== "string" || !entry.sender_did) {
+  if (entry.sender_did === null) {
+    // An identity-light sender is representable, but only unsigned. A DID is
+    // never invented to fill this in.
+    if (signatureType !== null) {
+      throw new Error("A signed act requires sender_did");
+    }
+  } else if (typeof entry.sender_did !== "string" || !entry.sender_did) {
     throw new Error("Evidence acts require sender_did");
   }
   return entry;
@@ -847,6 +1276,9 @@ function verifyEvidenceAct(
     }
 
     const senderDid = entry.sender_did as string;
+    if (typeof senderDid !== "string" || !senderDid) {
+      return { valid: false, attribution };
+    }
     if (!verificationMethodControlledBy(verificationMethod, senderDid)) {
       return { valid: false, attribution };
     }

--- a/a2cn_ts/tests/test_evidence.test.ts
+++ b/a2cn_ts/tests/test_evidence.test.ts
@@ -19,6 +19,7 @@ import {
   assessSessionEvidenceRecord,
   generateSessionEvidenceRecord,
   verifySessionEvidenceRecord,
+  type GenerateSessionEvidenceOptions,
 } from "../src/a2cn/evidence.js";
 import { generateTransactionRecord, verifyTransactionRecord } from "../src/a2cn/record.js";
 import { Session, SessionManager, SessionState } from "../src/a2cn/session.js";
@@ -727,4 +728,660 @@ test("shared session evidence vector has Python/TypeScript hash parity", () => {
       fixture.did_documents as Record<string, Dict>,
     ),
   ).toBe(false);
+});
+
+// ---------------------------------------------------------------------------
+// Conformance fixtures for the three additive Section 9A extensions:
+// identity-light responder, recomputable money basis, controls-halt outcome.
+// ---------------------------------------------------------------------------
+
+const OBSERVED_RESPONDER: Dict = {
+  identity_source: "supplier_ordering_portal",
+  organization_name: "Northwind Supply",
+  observed_credential: {
+    type: "vat_number",
+    digest: hashBytes(new TextEncoder().encode("GB123456789")),
+  },
+};
+
+const MONEY_BASIS: Dict = {
+  raw_amounts: ["70000.00", "25000.00"],
+  currency: "USD",
+  minor_unit_exponent: 2,
+  basis: "net",
+  normalized_total_minor: 9_500_000,
+};
+
+function generateEvidenceWith(
+  session: Session,
+  observedActs: Dict[] | null,
+  extra: Partial<GenerateSessionEvidenceOptions>,
+): Dict {
+  return generateSessionEvidenceRecord(session, {
+    producerPrivateKey: INITIATOR_PRIVATE_KEY,
+    producerDid: INITIATOR_DID,
+    producerAgentId: "buyer-agent",
+    producerVerificationMethod: INITIATOR_VM,
+    observedActs,
+    ...extra,
+  });
+}
+
+/** The same session, except the responder holds no A2CN identity at all. */
+function makeIdentityLightSession(): [SessionManager, Session, Record<string, Dict>] {
+  const [manager, session, didDocuments] = makeSession();
+  (session._session_ack as Dict).responder = { organization_name: "Northwind Supply" };
+  (session._session_ack as Dict).responder_mandate = {};
+  session.responder_mandate = {};
+  delete didDocuments[RESPONDER_DID];
+  return [manager, session, didDocuments];
+}
+
+function observedQuote(
+  options: {
+    senderDid?: string | null;
+    totalValue?: number;
+    moneyBasis?: Dict | null;
+    messageId?: string;
+  } = {},
+): Dict {
+  const {
+    senderDid = RESPONDER_DID,
+    totalValue = 9_500_000,
+    moneyBasis = null,
+    messageId = "portal-quote-1",
+  } = options;
+  const entry: Dict = {
+    sequence_number: 2,
+    round_number: 2,
+    message_type: "counteroffer",
+    message_id: messageId,
+    sender_did: senderDid,
+    timestamp: "2026-03-24T10:02:00Z",
+    source_protocol: "supplier_portal",
+    act: {
+      message_type: "counteroffer",
+      message_id: messageId,
+      timestamp: "2026-03-24T10:02:00Z",
+      terms: { total_value: totalValue, currency: "USD" },
+    },
+  };
+  if (moneyBasis !== null) {
+    entry.money_basis = structuredClone(moneyBasis);
+  }
+  return entry;
+}
+
+/** Re-derive the chain hash and producer seal after editing a record. */
+function reseal(evidence: Dict): Dict {
+  evidence.act_chain_hash = hashBytes(
+    canonicalize((evidence.acts as Dict[]).map((entry) => entry.act_hash)),
+  );
+  evidence.record_hash = "";
+  evidence.producer_signature = "";
+  evidence.record_hash = hashObject(evidence);
+  evidence.producer_signature = signJws(
+    evidence.record_hash as string,
+    INITIATOR_PRIVATE_KEY,
+    INITIATOR_VM,
+  );
+  return evidence;
+}
+
+function pricedRecord(): [Dict, Record<string, Dict>] {
+  const [manager, session, didDocuments] = makeSession();
+  manager.processMessage(session, makeOffer(session.session_id));
+  markTimedOut(session);
+  return [generateEvidence(session, [observedQuote({ moneyBasis: MONEY_BASIS })]), didDocuments];
+}
+
+function haltedRecord(): [Dict, Record<string, Dict>] {
+  const [manager, session, didDocuments] = makeSession();
+  manager.processMessage(session, makeOffer(session.session_id));
+  session.state = SessionState.WITHDRAWN;
+  session.current_turn = "none";
+  session.terminal_message_id = null;
+  session.state_updated_at = "2026-03-24T10:10:00Z";
+  const evidence = generateEvidenceWith(session, null, {
+    terminalOutcome: "HALTED_BY_CONTROLS",
+    terminalReason: "buyer_spend_control:max_session_commitment",
+  });
+  return [evidence, didDocuments];
+}
+
+// --- Fixture (i) -----------------------------------------------------------
+
+test("observed_party responder with unsigned acts is valid unilateral evidence", () => {
+  const [manager, session, didDocuments] = makeIdentityLightSession();
+  manager.processMessage(session, makeOffer(session.session_id));
+  markTimedOut(session);
+
+  const evidence = generateEvidenceWith(session, [observedQuote({ senderDid: null })], {
+    observedResponder: OBSERVED_RESPONDER,
+  });
+
+  expect((evidence.parties as Dict).responder).toEqual({
+    identity_source: "supplier_ordering_portal",
+    organization_name: "Northwind Supply",
+    observed_credential: {
+      type: "vat_number",
+      digest: hashBytes(new TextEncoder().encode("GB123456789")),
+    },
+    did_declared: false,
+    a2cn_endpoint_declared: false,
+    mandate_declared: false,
+  });
+  expect((evidence.acts as Dict[])[1].sender_did).toBeNull();
+  expect((evidence.acts as Dict[])[1].attribution).toBe("unsigned_observation");
+  expect(assessSessionEvidenceRecord(evidence, didDocuments)).toEqual({
+    valid: true,
+    evidence_level: "unilateral",
+    verified_acts: 1,
+    unsigned_acts: 1,
+    invalid_acts: 0,
+  });
+});
+
+test("the verifier never resolves the observed identity", () => {
+  const [manager, session, didDocuments] = makeIdentityLightSession();
+  manager.processMessage(session, makeOffer(session.session_id));
+  markTimedOut(session);
+  const evidence = generateEvidenceWith(session, [observedQuote({ senderDid: null })], {
+    observedResponder: OBSERVED_RESPONDER,
+  });
+  const requested: string[] = [];
+
+  const recordingResolver = (did: string): Dict => {
+    requested.push(did);
+    return didDocuments[did];
+  };
+
+  expect(verifySessionEvidenceRecord(evidence, recordingResolver)).toBe(true);
+  expect([...new Set(requested)]).toEqual([INITIATOR_DID]);
+});
+
+// --- Fixture (ii) ----------------------------------------------------------
+
+test("an observed responder claiming a verified signature is rejected", () => {
+  const [manager, session, didDocuments] = makeIdentityLightSession();
+  manager.processMessage(session, makeOffer(session.session_id));
+  markTimedOut(session);
+  // The counterparty's key IS resolvable here, so the refusal below cannot be
+  // blamed on a signature that failed to check out.
+  didDocuments[RESPONDER_DID] = makeDidDocument(
+    RESPONDER_DID,
+    "key-2026-01",
+    publicKeyToJwk(RESPONDER_PUBLIC_KEY),
+  );
+
+  const healthy = generateEvidenceWith(session, [observedQuote({ senderDid: null })], {
+    observedResponder: OBSERVED_RESPONDER,
+  });
+  expect(verifySessionEvidenceRecord(healthy, didDocuments)).toBe(true);
+
+  const signedAct = makeOffer(session.session_id, {
+    senderDid: RESPONDER_DID,
+    sequenceNumber: 2,
+    roundNumber: 2,
+    messageType: "counteroffer",
+    messageId: "portal-quote-1",
+    timestamp: "2026-03-24T10:02:00Z",
+  });
+  const attack = structuredClone(healthy);
+  (attack.acts as Dict[])[1] = {
+    sequence_number: 2,
+    round_number: 2,
+    message_type: "counteroffer",
+    message_id: "portal-quote-1",
+    sender_did: RESPONDER_DID,
+    timestamp: "2026-03-24T10:02:00Z",
+    source_protocol: "supplier_portal",
+    act: signedAct,
+    act_hash: hashObject(signedAct),
+    sender_verification_method: RESPONDER_VM,
+    signature_type: "protocol_act_signature",
+    signature: signedAct.protocol_act_signature,
+    attribution: "verified_signature",
+  };
+  reseal(attack);
+
+  const assessment = assessSessionEvidenceRecord(attack, didDocuments);
+
+  // Assert the reason before the verdict: the signature really does verify, so
+  // the rejection is the identity-light coupling and not a broken act.
+  expect(assessment.invalid_acts).toBe(0);
+  expect(assessment.verified_acts).toBe(2);
+  expect(assessment.evidence_level).toBe("unilateral");
+  expect(assessment.valid).toBe(false);
+});
+
+test("generator refuses an observed party for a responder that declared identity", () => {
+  const [manager, session] = makeSession();
+  manager.processMessage(session, makeOffer(session.session_id));
+  markTimedOut(session);
+
+  expect(() =>
+    generateEvidenceWith(session, null, { observedResponder: OBSERVED_RESPONDER }),
+  ).toThrow(/declared a DID/);
+});
+
+test("generator never fabricates a DID for a signed identity-light act", () => {
+  const [manager, session] = makeIdentityLightSession();
+  manager.processMessage(session, makeOffer(session.session_id));
+  markTimedOut(session);
+  const unattributable = observedQuote({ senderDid: null });
+  (unattributable.act as Dict).protocol_act_signature = "present-but-unattributable";
+
+  expect(() =>
+    generateEvidenceWith(session, [unattributable], {
+      observedResponder: OBSERVED_RESPONDER,
+    }),
+  ).toThrow(/sender_did/);
+});
+
+// --- Fixture (iii) ---------------------------------------------------------
+
+test("money_basis recomputing to the signed total is valid", () => {
+  const [evidence, didDocuments] = pricedRecord();
+
+  expect((evidence.acts as Dict[])[1].money_basis).toEqual(MONEY_BASIS);
+  // The basis is a producer annotation about the act, never inside the act the
+  // act_hash protects.
+  expect((evidence.acts as Dict[])[1].act).not.toHaveProperty("money_basis");
+  expect(verifySessionEvidenceRecord(evidence, didDocuments)).toBe(true);
+});
+
+test("money_basis on the terminal quote binds to the named act", () => {
+  const [manager, session, didDocuments] = makeSession();
+  manager.processMessage(session, makeOffer(session.session_id));
+  session.state = SessionState.IMPASSE;
+  session.current_turn = "none";
+  session.terminal_reason = "no_movement";
+  session.terminal_message_id = "portal-quote-1";
+  session.state_updated_at = "2026-03-24T10:10:00Z";
+
+  const evidence = generateEvidenceWith(session, [observedQuote()], {
+    terminalMoneyBasis: MONEY_BASIS,
+  });
+  expect(verifySessionEvidenceRecord(evidence, didDocuments)).toBe(true);
+
+  const unresolvable = structuredClone(evidence);
+  (unresolvable.terminal as Dict).message_id = "no-such-act";
+  reseal(unresolvable);
+  expect(verifySessionEvidenceRecord(unresolvable, didDocuments)).toBe(false);
+
+  expect(() =>
+    generateEvidenceWith(session, [observedQuote({ totalValue: 9_400_000 })], {
+      terminalMoneyBasis: MONEY_BASIS,
+    }),
+  ).toThrow(/money_basis/);
+});
+
+// --- Fixture (iv) ----------------------------------------------------------
+
+test("money_basis that does not recompute is rejected", () => {
+  const [healthy, didDocuments] = pricedRecord();
+  expect(verifySessionEvidenceRecord(healthy, didDocuments)).toBe(true);
+  // Re-sealing must itself produce verifiable records, or every red below would
+  // prove only that the reseal helper is broken.
+  expect(verifySessionEvidenceRecord(reseal(structuredClone(healthy)), didDocuments)).toBe(
+    true,
+  );
+
+  const tamperedRaw = structuredClone(healthy);
+  ((tamperedRaw.acts as Dict[])[1].money_basis as Dict).raw_amounts = [
+    "70000.00",
+    "25000.01",
+  ];
+  reseal(tamperedRaw);
+
+  const tamperedTotal = structuredClone(healthy);
+  ((tamperedTotal.acts as Dict[])[1].money_basis as Dict).normalized_total_minor = 9_500_001;
+  reseal(tamperedTotal);
+
+  expect(verifySessionEvidenceRecord(tamperedRaw, didDocuments)).toBe(false);
+  expect(verifySessionEvidenceRecord(tamperedTotal, didDocuments)).toBe(false);
+});
+
+test("money_basis is never converted between net and gross", () => {
+  const [healthy, didDocuments] = pricedRecord();
+  expect(verifySessionEvidenceRecord(healthy, didDocuments)).toBe(true);
+
+  // Relabelling net as gross must not make the arithmetic move: the label is
+  // checked, never applied.
+  const relabelled = structuredClone(healthy);
+  ((relabelled.acts as Dict[])[1].money_basis as Dict).basis = "gross";
+  reseal(relabelled);
+  expect(verifySessionEvidenceRecord(relabelled, didDocuments)).toBe(true);
+
+  // A gross total that only balances if a tax rate were applied stays rejected.
+  const grossedUp = structuredClone(healthy);
+  ((grossedUp.acts as Dict[])[1].money_basis as Dict).basis = "gross";
+  ((grossedUp.acts as Dict[])[1].money_basis as Dict).normalized_total_minor = 11_400_000;
+  reseal(grossedUp);
+  expect(verifySessionEvidenceRecord(grossedUp, didDocuments)).toBe(false);
+
+  const unknownLabel = structuredClone(healthy);
+  ((unknownLabel.acts as Dict[])[1].money_basis as Dict).basis = "vat_exclusive_maybe";
+  reseal(unknownLabel);
+  expect(verifySessionEvidenceRecord(unknownLabel, didDocuments)).toBe(false);
+});
+
+test("money_basis refuses amounts finer than the stated minor unit", () => {
+  const [healthy, didDocuments] = pricedRecord();
+  expect(verifySessionEvidenceRecord(healthy, didDocuments)).toBe(true);
+
+  const subMinor = structuredClone(healthy);
+  ((subMinor.acts as Dict[])[1].money_basis as Dict).raw_amounts = [
+    "70000.001",
+    "25000.00",
+  ];
+  reseal(subMinor);
+
+  // Chosen so that DISCARDING the sub-minor digit lands exactly on the signed
+  // total: rounding to fit is the failure mode, and it would read as a clean
+  // recompute.
+  expect(verifySessionEvidenceRecord(subMinor, didDocuments)).toBe(false);
+});
+
+test("money_basis currency must match the act it describes", () => {
+  const [healthy, didDocuments] = pricedRecord();
+  expect(verifySessionEvidenceRecord(healthy, didDocuments)).toBe(true);
+
+  const wrongCurrency = structuredClone(healthy);
+  ((wrongCurrency.acts as Dict[])[1].money_basis as Dict).currency = "EUR";
+  reseal(wrongCurrency);
+
+  expect(verifySessionEvidenceRecord(wrongCurrency, didDocuments)).toBe(false);
+});
+
+// --- Fixture (v) -----------------------------------------------------------
+
+test("money_basis claiming a total with no raw amounts fails closed", () => {
+  const [healthy, didDocuments] = pricedRecord();
+  expect(verifySessionEvidenceRecord(healthy, didDocuments)).toBe(true);
+
+  const absent = structuredClone(healthy);
+  delete ((absent.acts as Dict[])[1].money_basis as Dict).raw_amounts;
+  reseal(absent);
+
+  const empty = structuredClone(healthy);
+  ((empty.acts as Dict[])[1].money_basis as Dict).raw_amounts = [];
+  reseal(empty);
+
+  expect(verifySessionEvidenceRecord(absent, didDocuments)).toBe(false);
+  expect(verifySessionEvidenceRecord(empty, didDocuments)).toBe(false);
+});
+
+test("a zero-total money_basis still requires its raw amounts", () => {
+  const [manager, session, didDocuments] = makeSession();
+  manager.processMessage(session, makeOffer(session.session_id));
+  markTimedOut(session);
+  const zeroBasis: Dict = {
+    raw_amounts: ["0.00"],
+    currency: "USD",
+    minor_unit_exponent: 2,
+    basis: "line_total",
+    normalized_total_minor: 0,
+  };
+
+  const healthy = generateEvidence(session, [
+    observedQuote({ totalValue: 0, moneyBasis: zeroBasis }),
+  ]);
+  expect(verifySessionEvidenceRecord(healthy, didDocuments)).toBe(true);
+
+  // Zero is the one total that absent raw amounts would sum to by themselves,
+  // so it separates a fail-closed rule from an arithmetic accident.
+  const absent = structuredClone(healthy);
+  delete ((absent.acts as Dict[])[1].money_basis as Dict).raw_amounts;
+  reseal(absent);
+
+  expect(verifySessionEvidenceRecord(absent, didDocuments)).toBe(false);
+});
+
+// --- Fixture (vi) ----------------------------------------------------------
+
+test("the controls-halt outcome is accepted", () => {
+  const [evidence, didDocuments] = haltedRecord();
+
+  expect((evidence.terminal as Dict).outcome).toBe("HALTED_BY_CONTROLS");
+  expect((evidence.terminal as Dict).reason).toBe(
+    "buyer_spend_control:max_session_commitment",
+  );
+  expect(evidence.transaction_record_hash).toBeNull();
+  expect(evidence.evidence_level).toBe("unilateral");
+  expect(verifySessionEvidenceRecord(evidence, didDocuments)).toBe(true);
+});
+
+test("a COMPLETED session cannot be relabelled as halted", () => {
+  const [manager, session] = makeSession();
+  const offer = makeOffer(session.session_id);
+  manager.processMessage(session, offer);
+  manager.processMessage(session, makeAcceptance(session.session_id, offer));
+
+  expect(() =>
+    generateEvidenceWith(session, null, { terminalOutcome: "HALTED_BY_CONTROLS" }),
+  ).toThrow(/COMPLETED/);
+});
+
+// --- Fixture (vii) ---------------------------------------------------------
+
+test("an unrecognized terminal outcome is still rejected", () => {
+  const [healthy, didDocuments] = haltedRecord();
+  // The control proves the outcome gate is not simply refusing everything: the
+  // newly recognized member passes through it.
+  expect(verifySessionEvidenceRecord(healthy, didDocuments)).toBe(true);
+
+  const unknown = structuredClone(healthy);
+  (unknown.terminal as Dict).outcome = "HALTED_BY_VIBES";
+  reseal(unknown);
+
+  expect(verifySessionEvidenceRecord(unknown, didDocuments)).toBe(false);
+});
+
+test("AWAITING_COUNTERPARTY_SIGNATURE is not a terminal outcome", () => {
+  const [healthy, didDocuments] = haltedRecord();
+  expect(verifySessionEvidenceRecord(healthy, didDocuments)).toBe(true);
+
+  const paused = structuredClone(healthy);
+  (paused.terminal as Dict).outcome = "AWAITING_COUNTERPARTY_SIGNATURE";
+  reseal(paused);
+
+  expect(verifySessionEvidenceRecord(paused, didDocuments)).toBe(false);
+});
+
+// --- extensions ------------------------------------------------------------
+
+test("namespaced extensions are sealed and never interpreted", () => {
+  const [manager, session, didDocuments] = makeSession();
+  manager.processMessage(session, makeOffer(session.session_id));
+  markTimedOut(session);
+
+  const evidence = generateEvidenceWith(session, null, {
+    extensions: { "acme.procurement": { requisition_id: "REQ-42", arbitrary: [1, 2] } },
+  });
+
+  expect(evidence.extensions).toEqual({
+    "acme.procurement": { requisition_id: "REQ-42", arbitrary: [1, 2] },
+  });
+  expect(verifySessionEvidenceRecord(evidence, didDocuments)).toBe(true);
+
+  const edited = structuredClone(evidence);
+  ((edited.extensions as Dict)["acme.procurement"] as Dict).requisition_id = "REQ-43";
+  expect(verifySessionEvidenceRecord(edited, didDocuments)).toBe(false);
+});
+
+test("unnamespaced extension keys are refused by generator and verifier", () => {
+  const [manager, session, didDocuments] = makeSession();
+  manager.processMessage(session, makeOffer(session.session_id));
+  markTimedOut(session);
+
+  expect(() =>
+    generateEvidenceWith(session, null, { extensions: { requisition_id: "REQ-42" } }),
+  ).toThrow(/namespaced/);
+
+  const healthy = generateEvidenceWith(session, null, {
+    extensions: { "acme.procurement": { ok: true } },
+  });
+  expect(verifySessionEvidenceRecord(healthy, didDocuments)).toBe(true);
+
+  const bare = structuredClone(healthy);
+  bare.extensions = { requisition_id: "REQ-42" };
+  reseal(bare);
+  expect(verifySessionEvidenceRecord(bare, didDocuments)).toBe(false);
+});
+
+test("unnamespaced top-level fields remain closed", () => {
+  const [healthy, didDocuments] = pricedRecord();
+  expect(verifySessionEvidenceRecord(healthy, didDocuments)).toBe(true);
+
+  const widened = structuredClone(healthy);
+  widened.acme_procurement = { requisition_id: "REQ-42" };
+  reseal(widened);
+
+  expect(verifySessionEvidenceRecord(widened, didDocuments)).toBe(false);
+});
+
+// --- inputs that would silently pass if a guard were absent -----------------
+
+test("an observed responder cannot ride a COMPLETED record to bilateral", () => {
+  const [manager, session, didDocuments] = makeSession();
+  const offer = makeOffer(session.session_id);
+  manager.processMessage(session, offer);
+  manager.processMessage(session, makeAcceptance(session.session_id, offer));
+
+  const bilateral = generateEvidence(session);
+  expect(bilateral.evidence_level).toBe("bilateral");
+  expect(verifySessionEvidenceRecord(bilateral, didDocuments)).toBe(true);
+
+  // Strip the counterparty's identity and its signed acceptance. What remains is
+  // one party whose every act is signed, which the classifier still calls
+  // bilateral -- so the explicit unilateral coupling is the only thing that
+  // refuses a COMPLETED record with an unidentified counterparty.
+  const forged = structuredClone(bilateral);
+  (forged.parties as Dict).responder = {
+    identity_source: "supplier_ordering_portal",
+    did_declared: false,
+    a2cn_endpoint_declared: false,
+    mandate_declared: false,
+  };
+  forged.acts = [(forged.acts as Dict[])[0]];
+  reseal(forged);
+
+  const assessment = assessSessionEvidenceRecord(forged, didDocuments);
+
+  expect(assessment.invalid_acts).toBe(0);
+  expect(assessment.evidence_level).toBe("bilateral");
+  expect(assessment.valid).toBe(false);
+});
+
+/**
+ * Nullable sender_did must not open a hole in signed attribution.
+ *
+ * Measured, not assumed: both constructions below are already rejected at the
+ * act level by guards that predate this change -- the entry/act field comparison
+ * when the act keeps its own sender_did, and the signed-payload requirement when
+ * it does not. The shape check added alongside observed_party makes the
+ * invariant local; it is defence in depth, not the sole defence.
+ */
+test("a verified act can never carry a null sender_did", () => {
+  const [healthy, didDocuments] = pricedRecord();
+  expect(verifySessionEvidenceRecord(healthy, didDocuments)).toBe(true);
+  expect((healthy.acts as Dict[])[0].attribution).toBe("verified_signature");
+
+  const entryOnly = structuredClone(healthy);
+  (entryOnly.acts as Dict[])[0].sender_did = null;
+  reseal(entryOnly);
+
+  const entryAndAct = structuredClone(healthy);
+  (entryAndAct.acts as Dict[])[0].sender_did = null;
+  delete ((entryAndAct.acts as Dict[])[0].act as Dict).sender_did;
+  (entryAndAct.acts as Dict[])[0].act_hash = hashObject((entryAndAct.acts as Dict[])[0].act);
+  reseal(entryAndAct);
+
+  for (const record of [entryOnly, entryAndAct]) {
+    const assessment = assessSessionEvidenceRecord(record, didDocuments);
+    expect(assessment.invalid_acts).toBe(1);
+    expect(assessment.valid).toBe(false);
+  }
+});
+
+test("extension vectors have Python/TypeScript hash parity", () => {
+  const fixturePath = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "..",
+    "spec",
+    "test-vectors",
+    "session-evidence-record-extensions.json",
+  );
+  const fixture = JSON.parse(readFileSync(fixturePath, "utf-8")) as Dict;
+  const producer = fixture.producer as Dict;
+  const privateKey = privateKeyFromJwk(fixture.producer_private_jwk as Dict);
+  const vectors = fixture.vectors as Record<string, Dict>;
+
+  expect(Object.keys(vectors).sort()).toEqual([
+    "halted_by_controls",
+    "money_basis",
+    "observed_party_responder",
+  ]);
+
+  // The vector file speaks snake_case; the TypeScript option names are mapped
+  // explicitly so a renamed option cannot be silently ignored.
+  const OPTION_NAMES: Record<string, keyof GenerateSessionEvidenceOptions> = {
+    observed_responder: "observedResponder",
+    terminal_outcome: "terminalOutcome",
+    terminal_reason: "terminalReason",
+    terminal_money_basis: "terminalMoneyBasis",
+    extensions: "extensions",
+  };
+
+  for (const [name, vector] of Object.entries(vectors)) {
+    const sessionAck = (fixture.session_acks as Dict)[vector.session_ack as string] as Dict;
+    const session = new Session({
+      session_id: fixture.session_id as string,
+      state: vector.state as string,
+      current_turn: "none",
+      terminal_reason: vector.terminal_reason as string,
+      terminal_message_id: vector.terminal_message_id as string | null,
+      session_created_at: fixture.session_created_at as string,
+      state_updated_at: vector.state_updated_at as string,
+      session_params: fixture.session_params as Dict,
+      initiator_mandate: (fixture.session_init as Dict).initiator_mandate as Dict,
+      responder_mandate: sessionAck.responder_mandate as Dict,
+      _session_init: fixture.session_init as Dict,
+      _session_ack: sessionAck,
+      _message_log: vector.message_log as Dict[],
+    });
+
+    const options: GenerateSessionEvidenceOptions = {
+      producerPrivateKey: privateKey,
+      producerDid: producer.did as string,
+      producerAgentId: producer.agent_id as string,
+      producerVerificationMethod: producer.verification_method as string,
+      observedActs: vector.observed_acts as Dict[],
+    };
+    for (const [snakeName, value] of Object.entries(vector.options as Dict)) {
+      const optionName = OPTION_NAMES[snakeName];
+      expect(optionName, `unmapped vector option ${snakeName}`).toBeDefined();
+      (options as unknown as Record<string, unknown>)[optionName] = value;
+    }
+
+    const record = generateSessionEvidenceRecord(session, options);
+    const expected = vector.expected as Dict;
+
+    expect(record.evidence_id, name).toBe(expected.evidence_id);
+    expect(record.generated_at, name).toBe(expected.generated_at);
+    expect(record.evidence_level, name).toBe(expected.evidence_level);
+    expect((record.terminal as Dict).outcome, name).toBe(expected.terminal_outcome);
+    expect((record.acts as Dict[]).map((entry) => entry.act_hash), name).toEqual(
+      expected.act_hashes,
+    );
+    expect(record.act_chain_hash, name).toBe(expected.act_chain_hash);
+    expect(record.record_hash, name).toBe(expected.record_hash);
+    expect(
+      verifySessionEvidenceRecord(record, fixture.did_documents as Record<string, Dict>),
+      name,
+    ).toBe(true);
+  }
 });

--- a/reference-implementation/python/a2cn/evidence.py
+++ b/reference-implementation/python/a2cn/evidence.py
@@ -34,7 +34,16 @@ ATTRIBUTION_UNSIGNED = "unsigned_observation"
 SIGNATURE_PROTOCOL_ACT = "protocol_act_signature"
 SIGNATURE_ACCEPTANCE = "acceptance_signature"
 
+OUTCOME_HALTED_BY_CONTROLS = "HALTED_BY_CONTROLS"
+
+MONEY_BASIS_LABELS = frozenset(
+    {"net", "gross", "per_unit", "line_total", "unspecified"}
+)
+
 _TERMINAL_STATES = frozenset(SessionState.TERMINAL)
+# HALTED_BY_CONTROLS is an evidence-record outcome only. It is deliberately not a
+# SessionState: adding one would be a wire change, and 0.2 is frozen.
+_EVIDENCE_TERMINAL_OUTCOMES = _TERMINAL_STATES | {OUTCOME_HALTED_BY_CONTROLS}
 _SIGNED_MESSAGE_FIELDS = {
     SIGNATURE_PROTOCOL_ACT: SIGNATURE_PROTOCOL_ACT,
     SIGNATURE_ACCEPTANCE: SIGNATURE_ACCEPTANCE,
@@ -57,6 +66,7 @@ _RECORD_FIELDS = frozenset(
         "producer_signature",
     }
 )
+_RECORD_OPTIONAL_FIELDS = frozenset({"extensions"})
 _ACT_FIELDS = frozenset(
     {
         "sequence_number",
@@ -74,7 +84,39 @@ _ACT_FIELDS = frozenset(
         "attribution",
     }
 )
+_ACT_OPTIONAL_FIELDS = frozenset({"money_basis"})
+_TERMINAL_FIELDS = frozenset({"outcome", "reason", "message_id", "timestamp"})
+_TERMINAL_OPTIONAL_FIELDS = frozenset({"money_basis"})
+_PARTY_FIELDS = frozenset(
+    {
+        "organization_name",
+        "did",
+        "agent_id",
+        "verification_method",
+        "mandate_type",
+    }
+)
+_OBSERVED_PARTY_FIELDS = frozenset(
+    {"identity_source", "did_declared", "a2cn_endpoint_declared", "mandate_declared"}
+)
+_OBSERVED_PARTY_OPTIONAL_FIELDS = frozenset(
+    {"organization_name", "observed_credential"}
+)
+_OBSERVED_PARTY_MARKERS = ("did_declared", "a2cn_endpoint_declared", "mandate_declared")
+# raw_amounts is deliberately absent from the required set so the fail-closed rule
+# below owns it by name: a total claimed with no raw data behind it is rejected by
+# a branch that says so, not incidentally by a field-set check.
+_MONEY_BASIS_FIELDS = frozenset(
+    {"currency", "minor_unit_exponent", "basis", "normalized_total_minor"}
+)
+_MONEY_BASIS_OPTIONAL_FIELDS = frozenset({"raw_amounts"})
 _HASH_PATTERN = re.compile(r"^[A-Za-z0-9_-]{43}$")
+_EXTENSION_NAMESPACE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]*(\.[a-z0-9][a-z0-9_-]*)+$")
+_CURRENCY_PATTERN = re.compile(r"^[A-Z]{3}$")
+_DECIMAL_AMOUNT_PATTERN = re.compile(r"^(-?)(0|[1-9][0-9]*)(?:\.([0-9]+))?$")
+# Both reference implementations must agree on every recomputed total. JavaScript
+# numbers are exact only to 2**53 - 1, so that bound is the shared contract.
+_MAX_EXACT_INTEGER = 2**53 - 1
 _RFC3339_PATTERN = re.compile(
     r"^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})"
     r"(?:\.(\d+))?([Zz]|([+-])(\d{2}):(\d{2}))$"
@@ -92,6 +134,11 @@ def generate_session_evidence_record(
     producer_did: str | None = None,
     producer_agent_id: str | None = None,
     observed_acts: Sequence[dict] | None = None,
+    observed_responder: Mapping[str, Any] | None = None,
+    terminal_outcome: str | None = None,
+    terminal_reason: str | None = None,
+    terminal_money_basis: Mapping[str, Any] | None = None,
+    extensions: Mapping[str, Any] | None = None,
 ) -> dict:
     """Generate a producer-sealed evidence package for a terminal session.
 
@@ -99,11 +146,33 @@ def generate_session_evidence_record(
     that log with chronological external observations. An observed item may be a
     raw act/message or an evidence-entry input with an ``act`` object and outer
     metadata such as ``source_protocol``.
+
+    ``observed_responder`` records a counterparty that holds no A2CN identity. It
+    is a producer assertion; no DID is ever fabricated for it.
+    ``terminal_outcome`` may assert ``HALTED_BY_CONTROLS`` for a session the
+    producer's own controls stopped.
     """
     if session.state not in _TERMINAL_STATES:
         raise ValueError("Session evidence is only available for terminal sessions")
 
-    parties = _party_metadata(session)
+    outcome = session.state
+    reason = session.terminal_reason
+    if terminal_outcome is not None:
+        if terminal_outcome != OUTCOME_HALTED_BY_CONTROLS:
+            raise ValueError(
+                f"terminal_outcome may only assert {OUTCOME_HALTED_BY_CONTROLS}"
+            )
+        if session.state == SessionState.COMPLETED:
+            raise ValueError("A COMPLETED session cannot be relabelled as halted")
+        outcome = terminal_outcome
+    if terminal_reason is not None:
+        if terminal_outcome is None:
+            raise ValueError("terminal_reason requires terminal_outcome")
+        if not isinstance(terminal_reason, str) or not terminal_reason:
+            raise ValueError("terminal_reason must be a non-empty string")
+        reason = terminal_reason
+
+    parties = _party_metadata(session, observed_responder=observed_responder)
     producer = _producer_metadata(
         parties,
         producer_verification_method=producer_verification_method,
@@ -129,7 +198,7 @@ def generate_session_evidence_record(
     act_chain_hash = hash_bytes(canonicalize([entry["act_hash"] for entry in acts]))
     evidence_level = _classify_evidence_level(
         acts,
-        outcome=session.state,
+        outcome=outcome,
         parties=parties,
     )
 
@@ -147,8 +216,8 @@ def generate_session_evidence_record(
         "producer": producer,
         "parties": parties,
         "terminal": {
-            "outcome": session.state,
-            "reason": session.terminal_reason,
+            "outcome": outcome,
+            "reason": reason,
             "message_id": session.terminal_message_id or None,
             "timestamp": terminal_timestamp,
         },
@@ -159,6 +228,24 @@ def generate_session_evidence_record(
         "record_hash": "",
         "producer_signature": "",
     }
+    if terminal_money_basis is not None:
+        record["terminal"]["money_basis"] = copy.deepcopy(dict(terminal_money_basis))
+    if extensions is not None:
+        record["extensions"] = _validated_extensions(extensions)
+
+    # Refuse to seal a claim the verifier would reject. The generator and the
+    # verifier run the same two rules so a producer cannot emit a record that
+    # only fails once it is somebody else's problem.
+    if not _money_basis_claims_verify(record):
+        raise ValueError(
+            "money_basis does not recompute to the claimed and signed totals"
+        )
+    if not _observed_responder_rules_hold(record):
+        raise ValueError(
+            "An observed responder requires unsigned counterparty acts and "
+            "unilateral evidence"
+        )
+
     record["record_hash"] = hash_object(record)
     record["producer_signature"] = sign_jws(
         record["record_hash"],
@@ -197,7 +284,7 @@ def assess_session_evidence_record(record: dict, did_resolver: DidResolver) -> d
 
         terminal = record["terminal"]
         outcome = terminal["outcome"]
-        if outcome not in _TERMINAL_STATES:
+        if outcome not in _EVIDENCE_TERMINAL_OUTCOMES:
             return assessment
         if record["generated_at"] != terminal["timestamp"]:
             return assessment
@@ -255,6 +342,10 @@ def assess_session_evidence_record(record: dict, did_resolver: DidResolver) -> d
 
         if assessment["invalid_acts"]:
             return assessment
+        if not _money_basis_claims_verify(record):
+            return assessment
+        if not _observed_responder_rules_hold(record):
+            return assessment
         if record.get("act_chain_hash") != hash_bytes(canonicalize(computed_act_hashes)):
             return assessment
 
@@ -287,7 +378,11 @@ def assess_session_evidence_record(record: dict, did_resolver: DidResolver) -> d
         return assessment
 
 
-def _party_metadata(session: Session) -> dict:
+def _party_metadata(
+    session: Session,
+    *,
+    observed_responder: Mapping[str, Any] | None = None,
+) -> dict:
     session_init = session._session_init or {}
     session_ack = session._session_ack or {}
     if not isinstance(session_init, Mapping) or not isinstance(session_ack, Mapping):
@@ -311,6 +406,17 @@ def _party_metadata(session: Session) -> dict:
             raise ValueError(f"Party {field_name} must be a string")
         return value
 
+    responder = (
+        _observed_party_metadata(responder_info, responder_mandate, observed_responder)
+        if observed_responder is not None
+        else {
+            "organization_name": party_string(responder_info, "organization_name"),
+            "did": party_string(responder_info, "did"),
+            "agent_id": party_string(responder_info, "agent_id"),
+            "verification_method": party_string(responder_info, "verification_method"),
+            "mandate_type": party_string(responder_mandate, "mandate_type"),
+        }
+    )
     return {
         "initiator": {
             "organization_name": party_string(initiator_info, "organization_name"),
@@ -319,19 +425,98 @@ def _party_metadata(session: Session) -> dict:
             "verification_method": party_string(initiator_info, "verification_method"),
             "mandate_type": party_string(initiator_mandate, "mandate_type"),
         },
-        "responder": {
-            "organization_name": party_string(responder_info, "organization_name"),
-            "did": party_string(responder_info, "did"),
-            "agent_id": party_string(responder_info, "agent_id"),
-            "verification_method": party_string(responder_info, "verification_method"),
-            "mandate_type": party_string(responder_mandate, "mandate_type"),
-        },
+        "responder": responder,
     }
 
 
-def _evidence_record_shape_valid(record: dict) -> bool:
-    if not isinstance(record, dict) or set(record) != _RECORD_FIELDS:
+def _observed_party_metadata(
+    responder_info: Mapping[str, Any],
+    responder_mandate: Mapping[str, Any],
+    observed_responder: Mapping[str, Any],
+) -> dict:
+    """Assemble an identity-light responder from what the caller supplies.
+
+    Every field is a producer assertion. No DID is derived, defaulted, or
+    fabricated here, and the session must not already carry the A2CN identity
+    this descriptor claims is absent.
+    """
+    if not isinstance(observed_responder, Mapping):
+        raise ValueError("observed_responder must be an object")
+    for field_name, marker in (
+        ("did", "a DID"),
+        ("endpoint", "an A2CN endpoint"),
+        ("verification_method", "a verification method"),
+    ):
+        declared = responder_info.get(field_name)
+        if isinstance(declared, str) and declared:
+            raise ValueError(
+                f"Responder declared {marker}; it is not an observed party"
+            )
+    if responder_mandate.get("mandate_type"):
+        raise ValueError("Responder declared a mandate; it is not an observed party")
+
+    identity_source = observed_responder.get("identity_source")
+    if not isinstance(identity_source, str) or not identity_source:
+        raise ValueError("observed_responder requires a non-empty identity_source")
+
+    party = {
+        "identity_source": identity_source,
+        "did_declared": False,
+        "a2cn_endpoint_declared": False,
+        "mandate_declared": False,
+    }
+    organization_name = observed_responder.get("organization_name")
+    if organization_name is not None:
+        if not isinstance(organization_name, str):
+            raise ValueError("observed_responder organization_name must be a string")
+        party["organization_name"] = organization_name
+    credential = observed_responder.get("observed_credential")
+    if credential is not None:
+        if not isinstance(credential, Mapping) or set(credential) != {"type", "digest"}:
+            raise ValueError("observed_credential requires exactly type and digest")
+        credential_type = credential["type"]
+        digest = credential["digest"]
+        if not isinstance(credential_type, str) or not credential_type:
+            raise ValueError("observed_credential type must be a non-empty string")
+        if not isinstance(digest, str) or not _HASH_PATTERN.fullmatch(digest):
+            raise ValueError("observed_credential digest must be a base64url SHA-256")
+        party["observed_credential"] = {"type": credential_type, "digest": digest}
+    return party
+
+
+def _validated_extensions(extensions: Mapping[str, Any]) -> dict:
+    """Namespaced producer extensions. Never interpreted, only namespaced."""
+    if not isinstance(extensions, Mapping):
+        raise ValueError("extensions must be an object")
+    for name in extensions:
+        if not isinstance(name, str) or not _EXTENSION_NAMESPACE_PATTERN.fullmatch(name):
+            raise ValueError(f"extensions keys must be namespaced: {name!r}")
+    return copy.deepcopy(dict(extensions))
+
+
+def _exact_fields(
+    value: Any,
+    required: frozenset[str],
+    optional: frozenset[str] = frozenset(),
+) -> bool:
+    if not isinstance(value, dict):
         return False
+    present = set(value)
+    return required <= present <= (required | optional)
+
+
+def _evidence_record_shape_valid(record: dict) -> bool:
+    if not _exact_fields(record, _RECORD_FIELDS, _RECORD_OPTIONAL_FIELDS):
+        return False
+    if "extensions" in record:
+        extensions = record["extensions"]
+        if not isinstance(extensions, dict):
+            return False
+        if not all(
+            isinstance(name, str) and _EXTENSION_NAMESPACE_PATTERN.fullmatch(name)
+            for name in extensions
+        ):
+            return False
     if not all(
         isinstance(record.get(field), str) and record[field]
         for field in (
@@ -377,28 +562,18 @@ def _evidence_record_shape_valid(record: dict) -> bool:
     parties = record.get("parties")
     if not isinstance(parties, dict) or set(parties) != {"initiator", "responder"}:
         return False
-    party_fields = {
-        "organization_name",
-        "did",
-        "agent_id",
-        "verification_method",
-        "mandate_type",
-    }
-    for party in parties.values():
-        if not isinstance(party, dict) or set(party) != party_fields:
-            return False
-        if not all(isinstance(party.get(field), str) for field in party_fields):
-            return False
-        if not party["did"].startswith("did:") or not party["verification_method"]:
-            return False
+    # The producer is a DID-bearing party, so the initiator side stays strict.
+    # Only the responder may be identity-light.
+    if not _full_party_shape_valid(parties["initiator"]):
+        return False
+    if not (
+        _full_party_shape_valid(parties["responder"])
+        or _observed_party_shape_valid(parties["responder"])
+    ):
+        return False
 
     terminal = record.get("terminal")
-    if not isinstance(terminal, dict) or set(terminal) != {
-        "outcome",
-        "reason",
-        "message_id",
-        "timestamp",
-    }:
+    if not _exact_fields(terminal, _TERMINAL_FIELDS, _TERMINAL_OPTIONAL_FIELDS):
         return False
     if not isinstance(terminal.get("outcome"), str):
         return False
@@ -420,8 +595,199 @@ def _evidence_record_shape_valid(record: dict) -> bool:
     return isinstance(record.get("acts"), list)
 
 
+def _full_party_shape_valid(party: Any) -> bool:
+    if not _exact_fields(party, _PARTY_FIELDS):
+        return False
+    if not all(isinstance(party.get(field), str) for field in _PARTY_FIELDS):
+        return False
+    return party["did"].startswith("did:") and bool(party["verification_method"])
+
+
+def _observed_party_shape_valid(party: Any) -> bool:
+    """Shape of an identity-light counterparty descriptor.
+
+    This checks structure and the explicit negative markers, and nothing else.
+    A verifier MUST NOT resolve ``identity_source``, look it up in any registry,
+    or apply per-type validation to it: doing so would imply an authentication
+    A2CN did not perform. There is no whitelist here by design.
+    """
+    if not _exact_fields(party, _OBSERVED_PARTY_FIELDS, _OBSERVED_PARTY_OPTIONAL_FIELDS):
+        return False
+    if not isinstance(party.get("identity_source"), str) or not party["identity_source"]:
+        return False
+    if any(party.get(marker) is not False for marker in _OBSERVED_PARTY_MARKERS):
+        return False
+    if "organization_name" in party and not isinstance(
+        party["organization_name"], str
+    ):
+        return False
+    if "observed_credential" in party:
+        credential = party["observed_credential"]
+        if not _exact_fields(credential, frozenset({"type", "digest"})):
+            return False
+        if not isinstance(credential["type"], str) or not credential["type"]:
+            return False
+        if not isinstance(credential["digest"], str) or not _HASH_PATTERN.fullmatch(
+            credential["digest"]
+        ):
+            return False
+    return True
+
+
+def _observed_responder_rules_hold(record: dict) -> bool:
+    """Couple an identity-light responder to unsigned acts and unilateral evidence.
+
+    A2CN authenticates DID-bearing parties. When the responder holds no DID there
+    is no key any counterparty act could be checked against, so the initiator is
+    the only party that may carry a verified signature in such a record. A
+    responder claiming ``verified_signature`` is rejected outright rather than
+    downgraded.
+    """
+    parties = record.get("parties")
+    if not isinstance(parties, dict):
+        return False
+    if not _observed_party_shape_valid(parties.get("responder")):
+        return True
+
+    initiator = parties.get("initiator")
+    if not isinstance(initiator, dict):
+        return False
+    initiator_did = initiator.get("did")
+    acts = record.get("acts")
+    if not isinstance(acts, list):
+        return False
+    for entry in acts:
+        if not isinstance(entry, dict):
+            return False
+        if entry.get("attribution") != ATTRIBUTION_VERIFIED:
+            continue
+        if entry.get("sender_did") != initiator_did:
+            return False
+    # Asserted explicitly rather than inherited from the classifier, so that a
+    # future change to classification cannot quietly promote these records.
+    return record.get("evidence_level") == EVIDENCE_UNILATERAL
+
+
+def _decimal_to_minor(amount: Any, exponent: int) -> int | None:
+    """Scale one major-unit decimal string to minor units, exactly.
+
+    Returns ``None`` for anything finer than the stated exponent. Rounding here
+    would silently alter money, so a sub-minor amount is refused instead.
+    """
+    if not isinstance(amount, str):
+        return None
+    match = _DECIMAL_AMOUNT_PATTERN.fullmatch(amount)
+    if match is None:
+        return None
+    fraction = match.group(3) or ""
+    if len(fraction) > exponent:
+        return None
+    value = int(match.group(2) + fraction.ljust(exponent, "0"))
+    return -value if match.group(1) == "-" else value
+
+
+def _money_basis_recomputes(
+    money_basis: Any,
+    *,
+    expected_total_minor: int,
+    expected_currency: str,
+) -> bool:
+    """Recompute the unit normalization only, and compare it with both totals.
+
+    ``basis`` is a CHECKED LABEL. A verifier MUST NOT convert between net and
+    gross: that is a tax calculation, not a normalization, and performing it
+    silently corrupts money. The arithmetic below is identical for every label.
+    """
+    if not _exact_fields(money_basis, _MONEY_BASIS_FIELDS, _MONEY_BASIS_OPTIONAL_FIELDS):
+        return False
+    if money_basis["basis"] not in MONEY_BASIS_LABELS:
+        return False
+    currency = money_basis["currency"]
+    if not isinstance(currency, str) or not _CURRENCY_PATTERN.fullmatch(currency):
+        return False
+    if currency != expected_currency:
+        return False
+    exponent = money_basis["minor_unit_exponent"]
+    if isinstance(exponent, bool) or not isinstance(exponent, int):
+        return False
+    if not 0 <= exponent <= 4:
+        return False
+    claimed = money_basis["normalized_total_minor"]
+    if isinstance(claimed, bool) or not isinstance(claimed, int):
+        return False
+    if abs(claimed) > _MAX_EXACT_INTEGER:
+        return False
+
+    # FAIL-CLOSED: a total claimed with no raw amounts behind it is unverifiable,
+    # and an unverifiable claim must never read as a verified one.
+    raw_amounts = money_basis.get("raw_amounts")
+    if not isinstance(raw_amounts, list) or not raw_amounts:
+        return False
+
+    total = 0
+    for amount in raw_amounts:
+        minor = _decimal_to_minor(amount, exponent)
+        if minor is None:
+            return False
+        total += minor
+    return total == claimed == expected_total_minor
+
+
+def _money_basis_binds_to_act(entry: Any, money_basis: Any) -> bool:
+    """Bind a money_basis to the total inside the act it describes."""
+    if not isinstance(entry, dict):
+        return False
+    act = entry.get("act")
+    if not isinstance(act, dict):
+        return False
+    terms = act.get("terms")
+    if not isinstance(terms, dict):
+        return False
+    total = terms.get("total_value")
+    if isinstance(total, bool) or not isinstance(total, int):
+        return False
+    if abs(total) > _MAX_EXACT_INTEGER:
+        return False
+    currency = terms.get("currency")
+    if not isinstance(currency, str):
+        return False
+    return _money_basis_recomputes(
+        money_basis,
+        expected_total_minor=total,
+        expected_currency=currency,
+    )
+
+
+def _money_basis_claims_verify(record: dict) -> bool:
+    """Every money_basis in the record recomputes, or the record is rejected."""
+    acts = record.get("acts")
+    if not isinstance(acts, list):
+        return False
+    for entry in acts:
+        if isinstance(entry, dict) and "money_basis" in entry:
+            if not _money_basis_binds_to_act(entry, entry["money_basis"]):
+                return False
+
+    terminal = record.get("terminal")
+    if not isinstance(terminal, dict) or "money_basis" not in terminal:
+        return True
+    # A terminal money_basis describes the terminal quote, so it must name the act
+    # that carries it. An unresolvable reference is refused, not ignored.
+    message_id = terminal.get("message_id")
+    if not isinstance(message_id, str) or not message_id:
+        return False
+    quoted = [
+        entry
+        for entry in acts
+        if isinstance(entry, dict) and entry.get("message_id") == message_id
+    ]
+    if len(quoted) != 1:
+        return False
+    return _money_basis_binds_to_act(quoted[0], terminal["money_basis"])
+
+
 def _evidence_act_shape_valid(entry: dict) -> bool:
-    if not isinstance(entry, dict) or set(entry) != _ACT_FIELDS:
+    if not _exact_fields(entry, _ACT_FIELDS, _ACT_OPTIONAL_FIELDS):
         return False
     for field in ("sequence_number", "round_number"):
         value = entry.get(field)
@@ -431,14 +797,19 @@ def _evidence_act_shape_valid(entry: dict) -> bool:
             return False
     if not all(
         isinstance(entry.get(field), str) and entry[field]
-        for field in ("message_type", "sender_did", "act_hash")
+        for field in ("message_type", "act_hash")
     ):
         return False
     for field in ("message_id", "timestamp"):
         value = entry.get(field)
         if value is not None and (not isinstance(value, str) or not value):
             return False
-    if not entry["sender_did"].startswith("did:"):
+    sender_did = entry.get("sender_did")
+    if sender_did is None:
+        # A sender with no DID is only representable as an unsigned observation.
+        if entry.get("attribution") != ATTRIBUTION_UNSIGNED:
+            return False
+    elif not isinstance(sender_did, str) or not sender_did.startswith("did:"):
         return False
     if not _HASH_PATTERN.fullmatch(entry["act_hash"]):
         return False
@@ -580,9 +951,18 @@ def _normalize_evidence_act(item: dict, *, default_source_protocol: str | None) 
         "signature": signature,
         "attribution": attribution,
     }
+    if is_wrapper and metadata.get("money_basis") is not None:
+        # A producer annotation ABOUT the act, never inside it: `act` stays the
+        # verbatim observed bytes that act_hash protects.
+        entry["money_basis"] = copy.deepcopy(metadata["money_basis"])
     if not isinstance(entry["message_type"], str) or not entry["message_type"]:
         raise ValueError("Evidence acts require message_type")
-    if not isinstance(entry["sender_did"], str) or not entry["sender_did"]:
+    if entry["sender_did"] is None:
+        # An identity-light sender is representable, but only unsigned. A DID is
+        # never invented to fill this in.
+        if signature_type is not None:
+            raise ValueError("A signed act requires sender_did")
+    elif not isinstance(entry["sender_did"], str) or not entry["sender_did"]:
         raise ValueError("Evidence acts require sender_did")
     return entry
 
@@ -707,7 +1087,9 @@ def _verify_evidence_act(
         if not isinstance(verification_method, str) or not verification_method:
             return False, attribution
 
-        sender_did = entry.get("sender_did", "")
+        sender_did = entry.get("sender_did")
+        if not isinstance(sender_did, str) or not sender_did:
+            return False, attribution
         if not _verification_method_controlled_by(verification_method, sender_did):
             return False, attribution
         act_signature_field = _SIGNED_MESSAGE_FIELDS[signature_type]

--- a/reference-implementation/python/tests/test_evidence.py
+++ b/reference-implementation/python/tests/test_evidence.py
@@ -199,7 +199,7 @@ def _mark_timed_out(session) -> None:
     session.state_updated_at = "2026-03-24T10:10:00Z"
 
 
-def _generate(session, observed_acts=None):
+def _generate(session, observed_acts=None, **kwargs):
     return generate_session_evidence_record(
         session,
         producer_private_key=INITIATOR_PRIVATE_KEY,
@@ -207,6 +207,7 @@ def _generate(session, observed_acts=None):
         producer_agent_id="buyer-agent",
         producer_verification_method=INITIATOR_VM,
         observed_acts=observed_acts,
+        **kwargs,
     )
 
 
@@ -743,3 +744,758 @@ def test_shared_session_evidence_vector_has_python_typescript_hash_parity():
         invalid_record,
         fixture["did_documents"],
     )
+
+
+# ---------------------------------------------------------------------------
+# Conformance fixtures for the three additive Section 9A extensions:
+# identity-light responder, recomputable money basis, controls-halt outcome.
+# ---------------------------------------------------------------------------
+
+OBSERVED_RESPONDER = {
+    "identity_source": "supplier_ordering_portal",
+    "organization_name": "Northwind Supply",
+    "observed_credential": {
+        "type": "vat_number",
+        "digest": hash_bytes(b"GB123456789"),
+    },
+}
+
+MONEY_BASIS = {
+    "raw_amounts": ["70000.00", "25000.00"],
+    "currency": "USD",
+    "minor_unit_exponent": 2,
+    "basis": "net",
+    "normalized_total_minor": 9_500_000,
+}
+
+
+def _make_identity_light_session():
+    """The same session, except the responder holds no A2CN identity at all."""
+    manager, session, did_documents = _make_session()
+    session._session_ack["responder"] = {"organization_name": "Northwind Supply"}
+    session._session_ack["responder_mandate"] = {}
+    session.responder_mandate = {}
+    del did_documents[RESPONDER_DID]
+    return manager, session, did_documents
+
+
+def _observed_quote(
+    *,
+    sender_did: str | None = RESPONDER_DID,
+    total_value: int = 9_500_000,
+    money_basis: dict | None = None,
+    message_id: str = "portal-quote-1",
+) -> dict:
+    entry = {
+        "sequence_number": 2,
+        "round_number": 2,
+        "message_type": "counteroffer",
+        "message_id": message_id,
+        "sender_did": sender_did,
+        "timestamp": "2026-03-24T10:02:00Z",
+        "source_protocol": "supplier_portal",
+        "act": {
+            "message_type": "counteroffer",
+            "message_id": message_id,
+            "timestamp": "2026-03-24T10:02:00Z",
+            "terms": {"total_value": total_value, "currency": "USD"},
+        },
+    }
+    if money_basis is not None:
+        entry["money_basis"] = copy.deepcopy(money_basis)
+    return entry
+
+
+def _reseal(evidence: dict) -> dict:
+    """Re-derive the chain hash and producer seal after editing a record."""
+    evidence["act_chain_hash"] = hash_bytes(
+        canonicalize([entry["act_hash"] for entry in evidence["acts"]])
+    )
+    evidence["record_hash"] = ""
+    evidence["producer_signature"] = ""
+    evidence["record_hash"] = hash_object(evidence)
+    evidence["producer_signature"] = sign_jws(
+        evidence["record_hash"],
+        INITIATOR_PRIVATE_KEY,
+        kid=INITIATOR_VM,
+    )
+    return evidence
+
+
+def _priced_record():
+    manager, session, did_documents = _make_session()
+    manager.process_message(session, _offer(session.session_id))
+    _mark_timed_out(session)
+    evidence = _generate(session, [_observed_quote(money_basis=MONEY_BASIS)])
+    return evidence, did_documents
+
+
+def _halted_record():
+    manager, session, did_documents = _make_session()
+    manager.process_message(session, _offer(session.session_id))
+    session.state = SessionState.WITHDRAWN
+    session.current_turn = "none"
+    session.terminal_message_id = None
+    session.state_updated_at = "2026-03-24T10:10:00Z"
+    evidence = _generate(
+        session,
+        terminal_outcome="HALTED_BY_CONTROLS",
+        terminal_reason="buyer_spend_control:max_session_commitment",
+    )
+    return evidence, did_documents
+
+
+# --- Fixture (i) -----------------------------------------------------------
+
+
+def test_observed_party_responder_with_unsigned_acts_is_valid_unilateral():
+    manager, session, did_documents = _make_identity_light_session()
+    manager.process_message(session, _offer(session.session_id))
+    _mark_timed_out(session)
+
+    evidence = _generate(
+        session,
+        [_observed_quote(sender_did=None)],
+        observed_responder=OBSERVED_RESPONDER,
+    )
+
+    assert evidence["parties"]["responder"] == {
+        "identity_source": "supplier_ordering_portal",
+        "organization_name": "Northwind Supply",
+        "observed_credential": {
+            "type": "vat_number",
+            "digest": hash_bytes(b"GB123456789"),
+        },
+        "did_declared": False,
+        "a2cn_endpoint_declared": False,
+        "mandate_declared": False,
+    }
+    assert "did" not in evidence["parties"]["responder"]
+    assert evidence["acts"][1]["sender_did"] is None
+    assert evidence["acts"][1]["attribution"] == "unsigned_observation"
+    assert assess_session_evidence_record(evidence, did_documents) == {
+        "valid": True,
+        "evidence_level": "unilateral",
+        "verified_acts": 1,
+        "unsigned_acts": 1,
+        "invalid_acts": 0,
+    }
+
+
+def test_verifier_never_resolves_the_observed_identity():
+    manager, session, did_documents = _make_identity_light_session()
+    manager.process_message(session, _offer(session.session_id))
+    _mark_timed_out(session)
+    evidence = _generate(
+        session,
+        [_observed_quote(sender_did=None)],
+        observed_responder=OBSERVED_RESPONDER,
+    )
+    requested: list[str] = []
+
+    def recording_resolver(did: str) -> dict:
+        requested.append(did)
+        return did_documents[did]
+
+    assert verify_session_evidence_record(evidence, recording_resolver)
+    assert set(requested) == {INITIATOR_DID}
+
+
+# --- Fixture (ii) ----------------------------------------------------------
+
+
+def test_observed_responder_claiming_a_verified_signature_is_rejected():
+    manager, session, did_documents = _make_identity_light_session()
+    manager.process_message(session, _offer(session.session_id))
+    _mark_timed_out(session)
+    # The counterparty's key IS resolvable here, so the refusal below cannot be
+    # blamed on a signature that failed to check out.
+    did_documents[RESPONDER_DID] = make_did_document(
+        RESPONDER_DID,
+        "key-2026-01",
+        public_key_to_jwk(RESPONDER_PUBLIC_KEY),
+    )
+
+    healthy = _generate(
+        session,
+        [_observed_quote(sender_did=None)],
+        observed_responder=OBSERVED_RESPONDER,
+    )
+    assert verify_session_evidence_record(healthy, did_documents)
+
+    signed_act = _offer(
+        session.session_id,
+        sender_did=RESPONDER_DID,
+        sequence_number=2,
+        round_number=2,
+        message_type="counteroffer",
+        message_id="portal-quote-1",
+        timestamp="2026-03-24T10:02:00Z",
+    )
+    attack = copy.deepcopy(healthy)
+    attack["acts"][1] = {
+        "sequence_number": 2,
+        "round_number": 2,
+        "message_type": "counteroffer",
+        "message_id": "portal-quote-1",
+        "sender_did": RESPONDER_DID,
+        "timestamp": "2026-03-24T10:02:00Z",
+        "source_protocol": "supplier_portal",
+        "act": signed_act,
+        "act_hash": hash_object(signed_act),
+        "sender_verification_method": RESPONDER_VM,
+        "signature_type": "protocol_act_signature",
+        "signature": signed_act["protocol_act_signature"],
+        "attribution": "verified_signature",
+    }
+    _reseal(attack)
+
+    assessment = assess_session_evidence_record(attack, did_documents)
+
+    # Assert the reason before the verdict: the signature really does verify, so
+    # the rejection is the identity-light coupling and not a broken act.
+    assert assessment["invalid_acts"] == 0
+    assert assessment["verified_acts"] == 2
+    assert assessment["evidence_level"] == "unilateral"
+    assert not assessment["valid"]
+
+
+def test_generator_refuses_an_observed_party_for_a_responder_that_declared_identity():
+    manager, session, _ = _make_session()
+    manager.process_message(session, _offer(session.session_id))
+    _mark_timed_out(session)
+
+    with pytest.raises(ValueError, match="declared a DID"):
+        _generate(session, observed_responder=OBSERVED_RESPONDER)
+
+
+def test_generator_never_fabricates_a_did_for_a_signed_identity_light_act():
+    manager, session, _ = _make_identity_light_session()
+    manager.process_message(session, _offer(session.session_id))
+    _mark_timed_out(session)
+    unattributable = _observed_quote(sender_did=None)
+    unattributable["act"]["protocol_act_signature"] = "present-but-unattributable"
+
+    with pytest.raises(ValueError, match="sender_did"):
+        _generate(session, [unattributable], observed_responder=OBSERVED_RESPONDER)
+
+
+# --- Fixture (iii) ---------------------------------------------------------
+
+
+def test_money_basis_recomputing_to_the_signed_total_is_valid():
+    evidence, did_documents = _priced_record()
+
+    assert evidence["acts"][1]["money_basis"] == MONEY_BASIS
+    # The basis is a producer annotation about the act, never inside the act the
+    # act_hash protects.
+    assert "money_basis" not in evidence["acts"][1]["act"]
+    assert evidence["acts"][1]["act"]["terms"]["total_value"] == 9_500_000
+    assert verify_session_evidence_record(evidence, did_documents)
+
+
+def test_money_basis_on_the_terminal_quote_binds_to_the_named_act():
+    manager, session, did_documents = _make_session()
+    manager.process_message(session, _offer(session.session_id))
+    session.state = SessionState.IMPASSE
+    session.current_turn = "none"
+    session.terminal_reason = "no_movement"
+    session.terminal_message_id = "portal-quote-1"
+    session.state_updated_at = "2026-03-24T10:10:00Z"
+
+    evidence = _generate(
+        session,
+        [_observed_quote()],
+        terminal_money_basis=MONEY_BASIS,
+    )
+    assert verify_session_evidence_record(evidence, did_documents)
+
+    # A terminal basis that names no act is refused, not ignored.
+    unresolvable = copy.deepcopy(evidence)
+    unresolvable["terminal"]["message_id"] = "no-such-act"
+    _reseal(unresolvable)
+    assert not verify_session_evidence_record(unresolvable, did_documents)
+
+    # And it must bind to the total actually inside the act it names.
+    with pytest.raises(ValueError, match="money_basis"):
+        _generate(
+            session,
+            [_observed_quote(total_value=9_400_000)],
+            terminal_money_basis=MONEY_BASIS,
+        )
+
+
+# --- Fixture (iv) ----------------------------------------------------------
+
+
+def test_money_basis_that_does_not_recompute_is_rejected():
+    healthy, did_documents = _priced_record()
+    assert verify_session_evidence_record(healthy, did_documents)
+    # Re-sealing must itself produce verifiable records, or every red below would
+    # prove only that the reseal helper is broken.
+    assert verify_session_evidence_record(_reseal(copy.deepcopy(healthy)), did_documents)
+
+    tampered_raw = copy.deepcopy(healthy)
+    tampered_raw["acts"][1]["money_basis"]["raw_amounts"] = ["70000.00", "25000.01"]
+    _reseal(tampered_raw)
+
+    tampered_total = copy.deepcopy(healthy)
+    tampered_total["acts"][1]["money_basis"]["normalized_total_minor"] = 9_500_001
+    _reseal(tampered_total)
+
+    assert not verify_session_evidence_record(tampered_raw, did_documents)
+    assert not verify_session_evidence_record(tampered_total, did_documents)
+
+
+def test_money_basis_is_never_converted_between_net_and_gross():
+    healthy, did_documents = _priced_record()
+    assert verify_session_evidence_record(healthy, did_documents)
+
+    # Relabelling net as gross must not make the arithmetic move: the label is
+    # checked, never applied. Same raw amounts, same total, still valid.
+    relabelled = copy.deepcopy(healthy)
+    relabelled["acts"][1]["money_basis"]["basis"] = "gross"
+    _reseal(relabelled)
+    assert verify_session_evidence_record(relabelled, did_documents)
+
+    # A gross total that only balances if a tax rate were applied stays rejected.
+    grossed_up = copy.deepcopy(healthy)
+    grossed_up["acts"][1]["money_basis"]["basis"] = "gross"
+    grossed_up["acts"][1]["money_basis"]["normalized_total_minor"] = 11_400_000
+    _reseal(grossed_up)
+    assert not verify_session_evidence_record(grossed_up, did_documents)
+
+    unknown_label = copy.deepcopy(healthy)
+    unknown_label["acts"][1]["money_basis"]["basis"] = "vat_exclusive_maybe"
+    _reseal(unknown_label)
+    assert not verify_session_evidence_record(unknown_label, did_documents)
+
+
+def test_money_basis_refuses_amounts_finer_than_the_stated_minor_unit():
+    healthy, did_documents = _priced_record()
+    assert verify_session_evidence_record(healthy, did_documents)
+
+    sub_minor = copy.deepcopy(healthy)
+    sub_minor["acts"][1]["money_basis"]["raw_amounts"] = ["70000.001", "25000.00"]
+    _reseal(sub_minor)
+
+    # These are chosen so that DISCARDING the sub-minor digit lands exactly on the
+    # signed total: rounding to fit is the failure mode, and it would read as a
+    # clean recompute. The tenth of a cent must make the record fail instead.
+    assert not verify_session_evidence_record(sub_minor, did_documents)
+
+
+def test_money_basis_currency_must_match_the_act_it_describes():
+    healthy, did_documents = _priced_record()
+    assert verify_session_evidence_record(healthy, did_documents)
+
+    wrong_currency = copy.deepcopy(healthy)
+    wrong_currency["acts"][1]["money_basis"]["currency"] = "EUR"
+    _reseal(wrong_currency)
+
+    assert not verify_session_evidence_record(wrong_currency, did_documents)
+
+
+# --- Fixture (v) -----------------------------------------------------------
+
+
+def test_money_basis_claiming_a_total_with_no_raw_amounts_fails_closed():
+    healthy, did_documents = _priced_record()
+    assert verify_session_evidence_record(healthy, did_documents)
+
+    absent = copy.deepcopy(healthy)
+    del absent["acts"][1]["money_basis"]["raw_amounts"]
+    _reseal(absent)
+
+    empty = copy.deepcopy(healthy)
+    empty["acts"][1]["money_basis"]["raw_amounts"] = []
+    _reseal(empty)
+
+    assert not verify_session_evidence_record(absent, did_documents)
+    assert not verify_session_evidence_record(empty, did_documents)
+
+
+# --- Fixture (vi) ----------------------------------------------------------
+
+
+def test_controls_halt_outcome_is_accepted():
+    evidence, did_documents = _halted_record()
+
+    assert evidence["terminal"]["outcome"] == "HALTED_BY_CONTROLS"
+    assert evidence["terminal"]["reason"] == (
+        "buyer_spend_control:max_session_commitment"
+    )
+    assert evidence["transaction_record_hash"] is None
+    assert evidence["evidence_level"] == "unilateral"
+    assert verify_session_evidence_record(evidence, did_documents)
+
+
+def test_a_completed_session_cannot_be_relabelled_as_halted():
+    manager, session, _ = _make_session()
+    offer = _offer(session.session_id)
+    manager.process_message(session, offer)
+    manager.process_message(session, _acceptance(session.session_id, offer))
+
+    with pytest.raises(ValueError, match="COMPLETED"):
+        _generate(session, terminal_outcome="HALTED_BY_CONTROLS")
+
+
+# --- Fixture (vii) ---------------------------------------------------------
+
+
+def test_an_unrecognized_terminal_outcome_is_still_rejected():
+    healthy, did_documents = _halted_record()
+    # The control proves the outcome gate is not simply refusing everything: the
+    # newly recognized member passes through it.
+    assert verify_session_evidence_record(healthy, did_documents)
+
+    unknown = copy.deepcopy(healthy)
+    unknown["terminal"]["outcome"] = "HALTED_BY_VIBES"
+    _reseal(unknown)
+
+    assert not verify_session_evidence_record(unknown, did_documents)
+
+
+def test_awaiting_counterparty_signature_is_not_a_terminal_outcome():
+    healthy, did_documents = _halted_record()
+    assert verify_session_evidence_record(healthy, did_documents)
+
+    paused = copy.deepcopy(healthy)
+    paused["terminal"]["outcome"] = "AWAITING_COUNTERPARTY_SIGNATURE"
+    _reseal(paused)
+
+    assert not verify_session_evidence_record(paused, did_documents)
+
+
+# --- extensions ------------------------------------------------------------
+
+
+def test_namespaced_extensions_are_sealed_and_never_interpreted():
+    manager, session, did_documents = _make_session()
+    manager.process_message(session, _offer(session.session_id))
+    _mark_timed_out(session)
+
+    evidence = _generate(
+        session,
+        extensions={"acme.procurement": {"requisition_id": "REQ-42", "arbitrary": [1, 2]}},
+    )
+
+    assert evidence["extensions"] == {
+        "acme.procurement": {"requisition_id": "REQ-42", "arbitrary": [1, 2]}
+    }
+    assert verify_session_evidence_record(evidence, did_documents)
+
+    # The seal covers them: editing an extension without re-sealing invalidates.
+    edited = copy.deepcopy(evidence)
+    edited["extensions"]["acme.procurement"]["requisition_id"] = "REQ-43"
+    assert not verify_session_evidence_record(edited, did_documents)
+
+
+def test_unnamespaced_extension_keys_are_refused_by_generator_and_verifier():
+    manager, session, did_documents = _make_session()
+    manager.process_message(session, _offer(session.session_id))
+    _mark_timed_out(session)
+
+    with pytest.raises(ValueError, match="namespaced"):
+        _generate(session, extensions={"requisition_id": "REQ-42"})
+
+    healthy = _generate(session, extensions={"acme.procurement": {"ok": True}})
+    assert verify_session_evidence_record(healthy, did_documents)
+
+    bare = copy.deepcopy(healthy)
+    bare["extensions"] = {"requisition_id": "REQ-42"}
+    _reseal(bare)
+    assert not verify_session_evidence_record(bare, did_documents)
+
+
+def test_unnamespaced_top_level_fields_remain_closed():
+    healthy, did_documents = _priced_record()
+    assert verify_session_evidence_record(healthy, did_documents)
+
+    widened = copy.deepcopy(healthy)
+    widened["acme_procurement"] = {"requisition_id": "REQ-42"}
+    _reseal(widened)
+
+    assert not verify_session_evidence_record(widened, did_documents)
+
+
+# --- inputs that would silently pass if a guard were absent -----------------
+
+
+def test_an_observed_responder_cannot_ride_a_completed_record_to_bilateral():
+    manager, session, did_documents = _make_session()
+    offer = _offer(session.session_id)
+    manager.process_message(session, offer)
+    manager.process_message(session, _acceptance(session.session_id, offer))
+
+    bilateral = _generate(session)
+    assert bilateral["evidence_level"] == "bilateral"
+    assert verify_session_evidence_record(bilateral, did_documents)
+
+    # Strip the counterparty's identity and its signed acceptance. What remains
+    # is one party whose every act is signed, which the classifier still calls
+    # bilateral -- so the explicit unilateral coupling is the only thing that
+    # refuses a COMPLETED record with an unidentified counterparty.
+    forged = copy.deepcopy(bilateral)
+    forged["parties"]["responder"] = {
+        "identity_source": "supplier_ordering_portal",
+        "did_declared": False,
+        "a2cn_endpoint_declared": False,
+        "mandate_declared": False,
+    }
+    forged["acts"] = [forged["acts"][0]]
+    _reseal(forged)
+
+    assessment = assess_session_evidence_record(forged, did_documents)
+
+    assert assessment["invalid_acts"] == 0
+    assert assessment["evidence_level"] == "bilateral"
+    assert not assessment["valid"]
+
+
+def test_a_zero_total_money_basis_still_requires_its_raw_amounts():
+    manager, session, did_documents = _make_session()
+    manager.process_message(session, _offer(session.session_id))
+    _mark_timed_out(session)
+    zero_basis = {
+        "raw_amounts": ["0.00"],
+        "currency": "USD",
+        "minor_unit_exponent": 2,
+        "basis": "line_total",
+        "normalized_total_minor": 0,
+    }
+
+    healthy = _generate(
+        session,
+        [_observed_quote(total_value=0, money_basis=zero_basis)],
+    )
+    assert verify_session_evidence_record(healthy, did_documents)
+
+    # Zero is the one total that absent raw amounts would sum to by themselves,
+    # so it separates a fail-closed rule from an arithmetic accident.
+    absent = copy.deepcopy(healthy)
+    del absent["acts"][1]["money_basis"]["raw_amounts"]
+    _reseal(absent)
+
+    assert not verify_session_evidence_record(absent, did_documents)
+
+
+def test_a_verified_act_can_never_carry_a_null_sender_did():
+    """Nullable sender_did must not open a hole in signed attribution.
+
+    Measured, not assumed: both constructions below are already rejected at the
+    act level by guards that predate this change -- the entry/act field
+    comparison when the act keeps its own sender_did, and the signed-payload
+    requirement when it does not. The shape check added alongside observed_party
+    makes the invariant local; it is defence in depth, not the sole defence.
+    """
+    healthy, did_documents = _priced_record()
+    assert verify_session_evidence_record(healthy, did_documents)
+    assert healthy["acts"][0]["attribution"] == "verified_signature"
+
+    entry_only = copy.deepcopy(healthy)
+    entry_only["acts"][0]["sender_did"] = None
+    _reseal(entry_only)
+
+    entry_and_act = copy.deepcopy(healthy)
+    entry_and_act["acts"][0]["sender_did"] = None
+    del entry_and_act["acts"][0]["act"]["sender_did"]
+    entry_and_act["acts"][0]["act_hash"] = hash_object(entry_and_act["acts"][0]["act"])
+    _reseal(entry_and_act)
+
+    for record in (entry_only, entry_and_act):
+        assessment = assess_session_evidence_record(record, did_documents)
+        assert assessment["invalid_acts"] == 1
+        assert not assessment["valid"]
+
+
+def test_extension_vectors_have_python_typescript_hash_parity():
+    fixture_path = (
+        Path(__file__).parents[3]
+        / "spec"
+        / "test-vectors"
+        / "session-evidence-record-extensions.json"
+    )
+    fixture = json.loads(fixture_path.read_text())
+    producer = fixture["producer"]
+    private_key = private_key_from_jwk(fixture["producer_private_jwk"])
+
+    assert set(fixture["vectors"]) == {
+        "observed_party_responder",
+        "money_basis",
+        "halted_by_controls",
+    }
+
+    for name, vector in fixture["vectors"].items():
+        session_ack = fixture["session_acks"][vector["session_ack"]]
+        session = Session(
+            session_id=fixture["session_id"],
+            state=vector["state"],
+            current_turn="none",
+            terminal_reason=vector["terminal_reason"],
+            terminal_message_id=vector["terminal_message_id"],
+            session_created_at=fixture["session_created_at"],
+            state_updated_at=vector["state_updated_at"],
+            session_params=fixture["session_params"],
+            initiator_mandate=fixture["session_init"]["initiator_mandate"],
+            responder_mandate=session_ack["responder_mandate"],
+        )
+        session._session_init = fixture["session_init"]
+        session._session_ack = session_ack
+        session._message_log = vector["message_log"]
+
+        record = generate_session_evidence_record(
+            session,
+            producer_private_key=private_key,
+            producer_did=producer["did"],
+            producer_agent_id=producer["agent_id"],
+            producer_verification_method=producer["verification_method"],
+            observed_acts=vector["observed_acts"],
+            **vector["options"],
+        )
+        expected = vector["expected"]
+
+        assert record["evidence_id"] == expected["evidence_id"], name
+        assert record["generated_at"] == expected["generated_at"], name
+        assert record["evidence_level"] == expected["evidence_level"], name
+        assert record["terminal"]["outcome"] == expected["terminal_outcome"], name
+        assert [
+            entry["act_hash"] for entry in record["acts"]
+        ] == expected["act_hashes"], name
+        assert record["act_chain_hash"] == expected["act_chain_hash"], name
+        assert record["record_hash"] == expected["record_hash"], name
+        assert verify_session_evidence_record(record, fixture["did_documents"]), name
+
+
+def test_every_extension_vector_validates_against_the_published_schema():
+    jsonschema = pytest.importorskip("jsonschema")
+    root = Path(__file__).parents[3]
+    schema = json.loads(
+        (root / "spec" / "schemas" / "session-evidence-record.schema.json").read_text()
+    )
+    fixture = json.loads(
+        (
+            root / "spec" / "test-vectors" / "session-evidence-record-extensions.json"
+        ).read_text()
+    )
+    validator = jsonschema.Draft202012Validator(schema)
+    private_key = private_key_from_jwk(fixture["producer_private_jwk"])
+    producer = fixture["producer"]
+
+    for name, vector in fixture["vectors"].items():
+        session_ack = fixture["session_acks"][vector["session_ack"]]
+        session = Session(
+            session_id=fixture["session_id"],
+            state=vector["state"],
+            current_turn="none",
+            terminal_reason=vector["terminal_reason"],
+            terminal_message_id=vector["terminal_message_id"],
+            session_created_at=fixture["session_created_at"],
+            state_updated_at=vector["state_updated_at"],
+            session_params=fixture["session_params"],
+            initiator_mandate=fixture["session_init"]["initiator_mandate"],
+            responder_mandate=session_ack["responder_mandate"],
+        )
+        session._session_init = fixture["session_init"]
+        session._session_ack = session_ack
+        session._message_log = vector["message_log"]
+        record = generate_session_evidence_record(
+            session,
+            producer_private_key=private_key,
+            producer_did=producer["did"],
+            producer_agent_id=producer["agent_id"],
+            producer_verification_method=producer["verification_method"],
+            observed_acts=vector["observed_acts"],
+            **vector["options"],
+        )
+
+        assert list(validator.iter_errors(record)) == [], name
+
+
+def test_the_schema_rejects_what_the_verifier_rejects():
+    """The schema is not merely permissive: it refuses the same shapes.
+
+    The healthy record goes first. A schema that rejected everything would make
+    every refusal below look like a passing guard.
+    """
+    jsonschema = pytest.importorskip("jsonschema")
+    root = Path(__file__).parents[3]
+    schema = json.loads(
+        (root / "spec" / "schemas" / "session-evidence-record.schema.json").read_text()
+    )
+    validator = jsonschema.Draft202012Validator(schema)
+    healthy, _ = _priced_record()
+    assert list(validator.iter_errors(healthy)) == []
+
+    hybrid_party = copy.deepcopy(healthy)
+    hybrid_party["parties"]["responder"] = {
+        "organization_name": "Northwind Supply",
+        "did": RESPONDER_DID,
+        "agent_id": "seller-agent",
+        "verification_method": RESPONDER_VM,
+        "mandate_type": "declared",
+        "identity_source": "supplier_ordering_portal",
+    }
+
+    positive_marker = copy.deepcopy(healthy)
+    positive_marker["parties"]["responder"] = {
+        "identity_source": "supplier_ordering_portal",
+        "did_declared": True,
+        "a2cn_endpoint_declared": False,
+        "mandate_declared": False,
+    }
+
+    float_amount = copy.deepcopy(healthy)
+    float_amount["acts"][1]["money_basis"]["raw_amounts"] = [70000.00, 25000.00]
+
+    bare_extension = copy.deepcopy(healthy)
+    bare_extension["extensions"] = {"requisition_id": "REQ-42"}
+
+    for name, record in (
+        ("a party may not be both DID-bearing and identity-light", hybrid_party),
+        ("did_declared: true contradicts the descriptor", positive_marker),
+        ("raw amounts may not be JSON floats", float_amount),
+        ("extensions keys must be namespaced", bare_extension),
+    ):
+        assert list(validator.iter_errors(record)) != [], name
+
+
+def test_the_pre_extension_parity_record_still_validates_against_the_schema():
+    """The additive claim, checked against a record built before these changes."""
+    jsonschema = pytest.importorskip("jsonschema")
+    root = Path(__file__).parents[3]
+    schema = json.loads(
+        (root / "spec" / "schemas" / "session-evidence-record.schema.json").read_text()
+    )
+    fixture = json.loads(
+        (
+            root / "spec" / "test-vectors" / "session-evidence-record-parity.json"
+        ).read_text()
+    )
+    source = fixture["session"]
+    session = Session(
+        session_id=source["session_id"],
+        state=source["state"],
+        current_turn="none",
+        terminal_reason=source["terminal_reason"],
+        terminal_message_id=source["terminal_message_id"],
+        session_created_at=source["session_created_at"],
+        state_updated_at=source["state_updated_at"],
+        session_params=source["session_params"],
+        initiator_mandate=source["initiator_mandate"],
+        responder_mandate=source["responder_mandate"],
+    )
+    session._session_init = source["session_init"]
+    session._session_ack = source["session_ack"]
+    session._message_log = source["message_log"]
+    record = generate_session_evidence_record(
+        session,
+        producer_private_key=private_key_from_jwk(fixture["producer_private_jwk"]),
+        producer_did=fixture["producer"]["did"],
+        producer_agent_id=fixture["producer"]["agent_id"],
+        producer_verification_method=fixture["producer"]["verification_method"],
+        observed_acts=fixture["observed_acts"],
+    )
+
+    assert record["record_hash"] == fixture["expected"]["record_hash"]
+    assert list(jsonschema.Draft202012Validator(schema).iter_errors(record)) == []

--- a/spec/a2cn-spec-v0.2.0.md
+++ b/spec/a2cn-spec-v0.2.0.md
@@ -1753,7 +1753,9 @@ The three terminal-session artifacts are distinct:
   terms after a valid Acceptance. It is agreement-only and is not generalized by
   this section.
 - `SessionEvidenceRecord` packages the evidence available for `COMPLETED`,
-  `REJECTED_FINAL`, `WITHDRAWN`, `TIMED_OUT`, `IMPASSE`, and `ERROR` sessions.
+  `REJECTED_FINAL`, `WITHDRAWN`, `TIMED_OUT`, `IMPASSE`, `ERROR`, and
+  `HALTED_BY_CONTROLS` sessions. The last of these is an evidence-record outcome
+  only and is defined in Section 9A.10.
 - `AuditLog` remains an operational and compliance-oriented trace. It can contain
   self-declared metadata and intentionally minimizes retained commercial content.
 
@@ -1801,10 +1803,11 @@ Schema: `spec/schemas/session-evidence-record.schema.json`
     }
   },
   "terminal": {
-    "outcome": "COMPLETED | REJECTED_FINAL | WITHDRAWN | TIMED_OUT | IMPASSE | ERROR",
+    "outcome": "COMPLETED | REJECTED_FINAL | WITHDRAWN | TIMED_OUT | IMPASSE | ERROR | HALTED_BY_CONTROLS",
     "reason": "string | null",
     "message_id": "string | null",
-    "timestamp": "string"
+    "timestamp": "string",
+    "money_basis": {}
   },
   "transaction_record_hash": "string | null",
   "acts": [
@@ -1813,11 +1816,12 @@ Schema: `spec/schemas/session-evidence-record.schema.json`
       "round_number": "integer | null",
       "message_type": "string",
       "message_id": "string | null",
-      "sender_did": "string",
+      "sender_did": "string | null",
       "timestamp": "string | null",
       "source_protocol": "string | null",
       "act": {},
       "act_hash": "string",
+      "money_basis": {},
       "sender_verification_method": "string | null",
       "signature_type": "protocol_act_signature | acceptance_signature | null",
       "signature": "string | null",
@@ -1827,9 +1831,19 @@ Schema: `spec/schemas/session-evidence-record.schema.json`
   "act_chain_hash": "string",
   "evidence_level": "bilateral | mixed | unilateral",
   "record_hash": "string",
-  "producer_signature": "string"
+  "producer_signature": "string",
+  "extensions": {}
 }
 ```
+
+`parties.responder` is either the DID-bearing party shown above or the
+identity-light `observed_party` descriptor defined in Section 9A.8. The two are
+mutually exclusive. `parties.initiator` MUST always be a DID-bearing party.
+
+`terminal.money_basis` and `acts[].money_basis` are OPTIONAL and are defined in
+Section 9A.9. `extensions` is OPTIONAL and is defined in Section 9A.11. Apart
+from these named optional members, the record and every object inside it remain
+closed to additional properties.
 
 `record_version` is the version of the SessionEvidenceRecord artifact and is
 independent of the TransactionRecord version. A verifier MUST reject an
@@ -1849,6 +1863,13 @@ not required to be identical when produced by different parties.
 `producer.did` identifies the party sealing the package.
 `producer.verification_method` MUST be controlled by `producer.did` and MUST
 resolve through that DID document to the key used for `producer_signature`.
+
+Sections 9A.8, 9A.9, 9A.10, and 9A.11 were added to `record_version` `"0.1"` in
+place rather than by incrementing it. They are relaxations: a verifier predating
+them rejects records that use them, while every record valid before them remains
+valid. Amending in place is defensible only because no external consumer of this
+artifact existed at the time; a later relaxation MUST increment `record_version`
+and the schema `$id` together instead.
 
 `parties` uses the same SessionInit and SessionAck metadata sources as the
 TransactionRecord. Informational names and agent identifiers do not acquire
@@ -1879,6 +1900,16 @@ contains an envelope field also present on the evidence entry, including
 `sequence_number`, the values MUST match. `source_protocol` is informational and
 MAY identify `a2cn`, another protocol, or be `null`; it does not change signature
 semantics.
+
+Entry-level `sender_did` MAY be `null`, and only when `attribution` is
+`"unsigned_observation"`. It records that the producer observed an act whose
+sender holds no DID. A producer MUST NOT fabricate a DID to fill it, and an act
+claiming `"verified_signature"` MUST carry a non-null `sender_did`. A `null`
+sender contributes to no party's representation for the purposes of Section 9A.5.
+
+Each `acts[]` entry MAY carry a `money_basis` per Section 9A.9. It sits on the
+entry and never inside `act`, because it is the producer's own annotation about
+the act rather than counterparty-authored content that `act_hash` protects.
 
 For an incomplete unsigned observation, entry-level `message_id` or `timestamp`
 MAY be `null` when the corresponding source value is absent or not a valid value
@@ -1994,7 +2025,13 @@ does not satisfy this condition. Examples include:
 **`unilateral`** means the evidence has no verified counterparty perspective
 sufficient for mixed or bilateral classification. A signed local Offer followed
 by a local timeout is unilateral. A package containing only unsigned observations
-also remains unilateral even though the producer seals the package.
+also remains unilateral even though the producer seals the package. A record
+whose responder is an `observed_party` is always unilateral, asserted explicitly
+rather than derived from the rules above; see Section 9A.8.
+
+The classification counts only DID-bearing parties. An act whose `sender_did` is
+`null`, or whose sender is not a session party, contributes to no party's
+representation.
 
 Because v0.2 does not define protocol-act signatures for Rejection or Withdrawal,
 implementations MUST preserve those messages as unsigned observations. They MUST
@@ -2021,6 +2058,14 @@ A verifier MUST reject an unrecognized `record_version` and then:
    it with `evidence_level`.
 9. Enforce a non-null `transaction_record_hash` only for `COMPLETED`, and `null`
    for all other outcomes.
+10. When `parties.responder` is an `observed_party`, enforce Section 9A.8: no act
+    other than the initiator's may claim `verified_signature`, and
+    `evidence_level` MUST be `unilateral`. Do not resolve the observed identity.
+11. Recompute every `money_basis` present under Section 9A.9 and reject the
+    record if any of them does not reproduce both the claimed
+    `normalized_total_minor` and the total inside the act it describes.
+12. Confirm every key of `extensions` is namespaced per Section 9A.11. Do not
+    interpret their values.
 
 A signature that is present but invalid, references the wrong key, signs the
 wrong payload, or conflicts with the complete `act` MUST cause verification to
@@ -2040,6 +2085,169 @@ a richer assessment result where practical.
 | `bilateral` | Signed Offer, signed Counteroffer(s), signed Acceptance, `COMPLETED` | Material agreement acts are attributable to both parties; TransactionRecord remains the authoritative agreement artifact |
 | `mixed` | Signed producer Offer plus unsigned observed counterparty Counteroffer | Producer seal protects the complete bundle; only the signed Offer has cryptographic party attribution |
 | `unilateral` | Signed producer Offer followed by local `TIMED_OUT` | Producer's signed act and local terminal observation are protected; no counterparty response is attributed |
+
+### 9A.8 Identity-Light Responders
+
+A producer frequently negotiates against a counterparty that has no A2CN
+identity at all: an ordering portal, a mailbox, a commerce API with no DID and no
+mandate. Before this section such a session could not be described honestly. A
+producer either withheld the record or invented identity metadata to fill the
+required fields.
+
+`parties.responder` MAY therefore be an `observed_party` instead of a party:
+
+```json
+{
+  "identity_source": "string",
+  "organization_name": "string",
+  "observed_credential": { "type": "string", "digest": "string" },
+  "did_declared": false,
+  "a2cn_endpoint_declared": false,
+  "mandate_declared": false
+}
+```
+
+**This is the authentication boundary, and it is the entire point of the
+construct.** A2CN authenticates DID-bearing parties. Every field of an
+`observed_party` is a PRODUCER-ASSERTED, UNVERIFIED descriptor. A verifier MUST
+NOT resolve `identity_source`, MUST NOT authenticate it, MUST NOT look it up in
+any registry or allow-list, and MUST NOT apply per-type validation to it. A
+verifier that did any of these would imply an authentication that did not occur.
+`identity_source` is opaque: it exists so a human reader knows where the producer
+got the name, not so software can act on it.
+
+`did_declared`, `a2cn_endpoint_declared`, and `mandate_declared` are REQUIRED and
+MUST each be `false`. They are stated positively so that the absence of identity
+is a recorded assertion rather than an inference from missing fields.
+`observed_credential.digest` is a base64url SHA-256 digest, so a producer can
+record that it saw a credential without retaining the credential itself; a digest
+is not evidence of authentication.
+
+A record whose responder is an `observed_party` MUST satisfy both of the
+following, and a verifier MUST reject it otherwise:
+
+1. No act may claim `attribution: "verified_signature"` unless its `sender_did`
+   equals `parties.initiator.did`. With no responder DID there is no key against
+   which a counterparty act could be checked, so a claimed counterparty signature
+   is rejected outright and MUST NOT be downgraded to an unsigned observation.
+   This also excludes verified third-party acts from such a record: an act that
+   cannot be placed in a known role is refused rather than admitted.
+2. `evidence_level` MUST be `unilateral`. This is asserted explicitly and MUST
+   NOT be left to fall out of the classification rules in Section 9A.5. Those
+   rules count only DID-bearing parties, so a `COMPLETED` record with an
+   identity-light responder and fully signed producer acts would otherwise
+   classify as `bilateral` -- a counterparty that was never identified appearing
+   to have cryptographically agreed.
+
+A producer MUST NOT fabricate a DID, endpoint, or mandate for such a
+counterparty, and MUST NOT record an `observed_party` for a responder that
+declared any of them. The producer's own signature over the record is verified
+exactly as for any other record; it attests to the producer's account of the
+session and attributes nothing to the observed counterparty.
+
+### 9A.9 Recomputable Money Basis
+
+An evidence record states a total. `money_basis` lets a reader recompute that
+total from the amounts as they were observed, rather than trusting the producer's
+arithmetic:
+
+```json
+{
+  "raw_amounts": ["70000.00", "25000.00"],
+  "currency": "USD",
+  "minor_unit_exponent": 2,
+  "basis": "net | gross | per_unit | line_total | unspecified",
+  "normalized_total_minor": 9500000
+}
+```
+
+`money_basis` is OPTIONAL. It MAY appear on any priced `acts[]` entry, and on
+`terminal` for the terminal quote. It is absent for terminal outcomes that carry
+no price. A `terminal.money_basis` describes the act named by
+`terminal.message_id`; if that names no act, or names more than one, a verifier
+MUST reject the record rather than ignore the basis.
+
+`raw_amounts` are MAJOR-unit amounts as exact decimal strings. They are strings
+because a JSON number cannot carry a decimal amount exactly, and money that
+passes through a binary float is money that has already been altered.
+
+**The recompute is a unit normalization and nothing else.** A verifier MUST:
+
+- scale each `raw_amounts` entry from major to minor units using
+  `minor_unit_exponent`, exactly;
+- reject any amount with more decimal places than `minor_unit_exponent`, because
+  normalizing it would require rounding, and rounding money silently is the
+  failure this section exists to prevent;
+- sum the results and require that sum to equal both `normalized_total_minor` and
+  the `terms.total_value` of the act being described;
+- require `currency` to equal that act's `terms.currency`.
+
+**A verifier MUST NOT convert between `net` and `gross`.** That is a tax
+calculation, not a normalization; performing it silently corrupts money, and
+performing it wrongly corrupts it invisibly. `basis` is a CHECKED LABEL: a
+verifier confirms it is a recognized value and otherwise does not act on it. The
+arithmetic above is identical for every label. Relabelling `net` as `gross`
+therefore changes no total, which is the intended behaviour: the label describes
+what the producer observed, and never instructs a computation.
+
+**Absence of raw data MUST fail closed.** If `normalized_total_minor` is claimed
+and `raw_amounts` is absent or empty, a verifier MUST reject the record. An
+unverifiable claim must never read as a verified one, and the zero total is
+exactly the case where an empty sum would otherwise appear to agree.
+
+A2CN maintains no currency exponent registry. `minor_unit_exponent` is a producer
+assertion checked for arithmetic consistency, not for correctness against the
+currency it names. `normalized_total_minor` and every act total it is compared
+against are bounded to the exact-integer range shared by both reference
+implementations, so the recompute cannot differ between them.
+
+### 9A.10 The `HALTED_BY_CONTROLS` Terminal Outcome
+
+`terminal.outcome` MAY be `HALTED_BY_CONTROLS`, meaning an agent's own controls
+or governance terminated the negotiation. `reason` SHOULD name the specific
+control that fired, for example `"buyer_spend_control:max_session_commitment"`.
+
+It is distinct from the outcomes it is most easily confused with:
+
+- `ERROR` is a fault: something went wrong.
+- `IMPASSE` is a deadlock: the parties could not converge.
+- `WITHDRAWN` is a voluntary walk-away: the agent chose, within its authority, to
+  stop negotiating.
+- `HALTED_BY_CONTROLS` is none of these. Nothing failed, no deadlock was reached,
+  and no negotiating judgement was exercised. A control the agent operates under
+  stopped the run. Recording that as `ERROR` misreports a working safeguard as a
+  malfunction, and recording it as `WITHDRAWN` misreports a constraint as a
+  choice.
+
+The outcome is GENERAL to either party. A seller's credit or inventory controls
+halt a run for the same reason a buyer's spend controls do.
+
+`HALTED_BY_CONTROLS` is an evidence-record outcome, not a session state: no wire
+message or state transition is added, and `protocol_version` remains `0.2`. A
+producer MUST NOT relabel a `COMPLETED` session as halted, since that would erase
+an agreement and drop the required `transaction_record_hash`. Verification adds
+nothing beyond enum membership: the outcome is a producer observation, exactly as
+`TIMED_OUT` already is. Evidence-level classification is unaffected, because it
+keys on signatures rather than on the outcome.
+
+Widening this enum MUST NOT widen the rule that an unrecognized outcome is
+rejected. A verifier MUST continue to reject any outcome it does not recognize.
+`AWAITING_COUNTERPARTY_SIGNATURE` is NOT a terminal outcome; like
+`AWAITING_HUMAN_APPROVAL` it denotes a paused session, and a paused session MUST
+NOT produce a Session Evidence Record.
+
+### 9A.11 Namespaced Extensions
+
+The record MAY carry an OPTIONAL top-level `extensions` object. Its keys MUST be
+namespaced, matching `^[a-z0-9][a-z0-9_-]*(\.[a-z0-9][a-z0-9_-]*)+$`; a bare key
+MUST be rejected, so that a producer extension can never collide with a future
+member of this specification. Values are arbitrary JSON.
+
+`extensions` is the ONLY place additional properties are permitted. The record
+and every other object within it remain closed. Extension content is covered by
+`record_hash` and therefore by the producer seal, so it cannot be altered after
+sealing. A verifier MUST NOT interpret it, and MUST NOT let it influence
+attribution, evidence level, or any other verification outcome.
 
 ---
 

--- a/spec/schemas/session-evidence-record.schema.json
+++ b/spec/schemas/session-evidence-record.schema.json
@@ -49,7 +49,13 @@
       "required": ["initiator", "responder"],
       "properties": {
         "initiator": { "$ref": "#/$defs/party" },
-        "responder": { "$ref": "#/$defs/party" }
+        "responder": {
+          "description": "A DID-bearing A2CN party, or a producer-asserted identity-light descriptor that a verifier MUST NOT resolve or authenticate.",
+          "oneOf": [
+            { "$ref": "#/$defs/party" },
+            { "$ref": "#/$defs/observed_party" }
+          ]
+        }
       },
       "additionalProperties": false
     },
@@ -65,7 +71,8 @@
             "WITHDRAWN",
             "TIMED_OUT",
             "IMPASSE",
-            "ERROR"
+            "ERROR",
+            "HALTED_BY_CONTROLS"
           ]
         },
         "reason": {
@@ -77,6 +84,10 @@
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "money_basis": {
+          "$ref": "#/$defs/money_basis",
+          "description": "Recomputable basis for the terminal quote. Binds to the act named by terminal.message_id."
         }
       },
       "additionalProperties": false
@@ -107,6 +118,14 @@
       "type": "string",
       "minLength": 1,
       "description": "Compact JWS over record_hash using producer.verification_method."
+    },
+    "extensions": {
+      "type": "object",
+      "description": "Namespaced producer extensions. Covered by record_hash and the producer seal, never interpreted by a verifier. The rest of the record stays closed.",
+      "propertyNames": {
+        "pattern": "^[a-z0-9][a-z0-9_-]*(\\.[a-z0-9][a-z0-9_-]*)+$"
+      },
+      "additionalProperties": true
     }
   },
   "allOf": [
@@ -181,6 +200,81 @@
       },
       "additionalProperties": false
     },
+    "observed_party": {
+      "type": "object",
+      "description": "A counterparty with no A2CN identity. Every field is a PRODUCER-ASSERTED, UNVERIFIED descriptor. A verifier MUST NOT resolve, authenticate, or vouch for any of it.",
+      "required": [
+        "identity_source",
+        "did_declared",
+        "a2cn_endpoint_declared",
+        "mandate_declared"
+      ],
+      "properties": {
+        "identity_source": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Producer's own label for where the identity came from, for example an ordering portal or an email domain. Opaque to the verifier: no registry, no whitelist, no per-type validation."
+        },
+        "organization_name": { "type": "string" },
+        "observed_credential": {
+          "type": "object",
+          "description": "Digest of a credential the producer observed. The digest is recorded so the credential value itself need not be retained; it is not evidence of authentication.",
+          "required": ["type", "digest"],
+          "properties": {
+            "type": { "type": "string", "minLength": 1 },
+            "digest": { "$ref": "#/$defs/hash" }
+          },
+          "additionalProperties": false
+        },
+        "did_declared": { "const": false },
+        "a2cn_endpoint_declared": { "const": false },
+        "mandate_declared": { "const": false }
+      },
+      "additionalProperties": false
+    },
+    "money_basis": {
+      "type": "object",
+      "description": "Independently recomputable unit normalization for a claimed total. `basis` is a checked label only: a verifier MUST NOT convert between net and gross.",
+      "required": [
+        "raw_amounts",
+        "currency",
+        "minor_unit_exponent",
+        "basis",
+        "normalized_total_minor"
+      ],
+      "properties": {
+        "raw_amounts": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Amounts as observed, in MAJOR units, as exact decimal strings. Strings because a JSON number cannot carry a decimal amount exactly.",
+          "items": {
+            "type": "string",
+            "pattern": "^-?(0|[1-9][0-9]*)(\\.[0-9]+)?$"
+          }
+        },
+        "currency": {
+          "type": "string",
+          "pattern": "^[A-Z]{3}$"
+        },
+        "minor_unit_exponent": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 4,
+          "description": "Producer-asserted decimal places between major and minor units. A2CN maintains no currency exponent registry; this is checked for arithmetic consistency, not for correctness against the currency."
+        },
+        "basis": {
+          "type": "string",
+          "enum": ["net", "gross", "per_unit", "line_total", "unspecified"]
+        },
+        "normalized_total_minor": {
+          "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991,
+          "description": "Bounded to the exact-integer range both reference implementations share, so the recompute cannot disagree across languages."
+        }
+      },
+      "additionalProperties": false
+    },
     "evidenceAct": {
       "type": "object",
       "required": [
@@ -216,12 +310,17 @@
           "minLength": 1
         },
         "sender_did": {
-          "type": "string",
-          "pattern": "^did:"
+          "type": ["string", "null"],
+          "pattern": "^did:",
+          "description": "Null only for an unsigned observation whose sender holds no DID. A producer MUST NOT fabricate one."
         },
         "timestamp": {
           "type": ["string", "null"],
           "format": "date-time"
+        },
+        "money_basis": {
+          "$ref": "#/$defs/money_basis",
+          "description": "Producer annotation about this act. It is outside `act` because it is not counterparty-authored content."
         },
         "source_protocol": {
           "type": ["string", "null"]
@@ -252,6 +351,7 @@
         {
           "properties": {
             "attribution": { "const": "verified_signature" },
+            "sender_did": { "type": "string", "pattern": "^did:" },
             "sender_verification_method": { "type": "string", "minLength": 1 },
             "signature_type": {
               "type": "string",

--- a/spec/test-vectors/session-evidence-record-extensions.json
+++ b/spec/test-vectors/session-evidence-record-extensions.json
@@ -1,0 +1,315 @@
+{
+  "description": "Cross-language vectors for the three additive Section 9A extensions: an identity-light observed_party responder, a recomputable money_basis, and the HALTED_BY_CONTROLS terminal outcome. The private JWK is test-only.",
+  "did_documents": {
+    "did:example:buyer": {
+      "@context": [
+        "https://www.w3.org/ns/did/v1"
+      ],
+      "assertionMethod": [
+        "did:example:buyer#key-1"
+      ],
+      "authentication": [
+        "did:example:buyer#key-1"
+      ],
+      "id": "did:example:buyer",
+      "verificationMethod": [
+        {
+          "controller": "did:example:buyer",
+          "id": "did:example:buyer#key-1",
+          "publicKeyJwk": {
+            "crv": "Ed25519",
+            "kty": "OKP",
+            "x": "7pGHEzTRKFR0l2BepF9bfS1mpTmods6vjiyYk2Z5TMY"
+          },
+          "type": "JsonWebKey2020"
+        }
+      ]
+    }
+  },
+  "producer": {
+    "agent_id": "buyer-agent",
+    "did": "did:example:buyer",
+    "verification_method": "did:example:buyer#key-1"
+  },
+  "producer_private_jwk": {
+    "crv": "Ed25519",
+    "d": "3ndUDUReD8pTMS_ty6tX309ky0OFzz9-6ArUZ5P3bpg",
+    "kty": "OKP",
+    "x": "7pGHEzTRKFR0l2BepF9bfS1mpTmods6vjiyYk2Z5TMY"
+  },
+  "session_acks": {
+    "full": {
+      "current_turn": "initiator",
+      "message_id": "ext-ack-1",
+      "message_type": "session_ack",
+      "protocol_version": "0.2",
+      "responder": {
+        "agent_id": "seller-agent",
+        "did": "did:example:seller",
+        "organization_name": "Parity Seller",
+        "verification_method": "did:example:seller#key-1"
+      },
+      "responder_mandate": {
+        "mandate_type": "declared"
+      },
+      "session_created_at": "2026-08-31T12:00:00Z",
+      "session_id": "00000000-0000-4000-8000-000000000126",
+      "session_params_accepted": {
+        "currency": "USD",
+        "deal_type": "goods_procurement",
+        "max_rounds": 4,
+        "round_timeout_seconds": 900,
+        "session_timeout_seconds": 3600
+      }
+    },
+    "identity_light": {
+      "current_turn": "initiator",
+      "message_id": "ext-ack-1",
+      "message_type": "session_ack",
+      "protocol_version": "0.2",
+      "responder": {
+        "organization_name": "Northwind Supply"
+      },
+      "responder_mandate": {},
+      "session_created_at": "2026-08-31T12:00:00Z",
+      "session_id": "00000000-0000-4000-8000-000000000126",
+      "session_params_accepted": {
+        "currency": "USD",
+        "deal_type": "goods_procurement",
+        "max_rounds": 4,
+        "round_timeout_seconds": 900,
+        "session_timeout_seconds": 3600
+      }
+    }
+  },
+  "session_created_at": "2026-08-31T12:00:00Z",
+  "session_id": "00000000-0000-4000-8000-000000000126",
+  "session_init": {
+    "initiator": {
+      "agent_id": "buyer-agent",
+      "did": "did:example:buyer",
+      "organization_name": "Parity Buyer",
+      "verification_method": "did:example:buyer#key-1"
+    },
+    "initiator_mandate": {
+      "mandate_type": "declared"
+    },
+    "message_id": "ext-init-1",
+    "message_type": "session_init",
+    "protocol_version": "0.2",
+    "session_params": {
+      "currency": "USD",
+      "deal_type": "goods_procurement",
+      "max_rounds": 4,
+      "round_timeout_seconds": 900,
+      "session_timeout_seconds": 3600
+    }
+  },
+  "session_params": {
+    "currency": "USD",
+    "deal_type": "goods_procurement",
+    "max_rounds": 4,
+    "round_timeout_seconds": 900,
+    "session_timeout_seconds": 3600
+  },
+  "vectors": {
+    "halted_by_controls": {
+      "expected": {
+        "act_chain_hash": "GIYgsUZmx_JmMhJ8vLJE7WHjs0F-ZPf_HQQjWHLJ0TE",
+        "act_hashes": [
+          "0shTzhPuddK3cyWJe07mYnDcISiF21XhCdxE4rCNLx4"
+        ],
+        "evidence_id": "a078f0b2-581e-537c-9832-7aa6d23afcae",
+        "evidence_level": "unilateral",
+        "generated_at": "2026-08-31T12:10:00Z",
+        "record_hash": "gS5D11P3MmCq4EHbjabtGuwdL2-AGD_g8uaKR7iqR-4",
+        "terminal_outcome": "HALTED_BY_CONTROLS"
+      },
+      "message_log": [
+        {
+          "expires_at": "2026-08-31T12:16:00Z",
+          "message_id": "ext-offer-1",
+          "message_type": "offer",
+          "protocol_act_hash": "aKvvZcgdzstB3Q0UEb3gXhsAQxNasJ_Wb_X4v0ypepU",
+          "protocol_act_signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpleGFtcGxlOmJ1eWVyI2tleS0xIn0.YUt2dlpjZ2R6c3RCM1EwVUViM2dYaHNBUXhOYXNKX1diX1g0djB5cGVwVQ.haFDWtOfztr8aTVz5ouF7xPuvMkYn5-yEv7Iyqzsr5e4Wh01zjdQb8AMVMcGkxoWfRR8L64iQt6cCGTVCwaJDQ",
+          "round_number": 1,
+          "sender_agent_id": "buyer-agent",
+          "sender_did": "did:example:buyer",
+          "sender_verification_method": "did:example:buyer#key-1",
+          "sequence_number": 1,
+          "session_id": "00000000-0000-4000-8000-000000000126",
+          "terms": {
+            "currency": "USD",
+            "total_value": 9500000
+          },
+          "timestamp": "2026-08-31T12:01:00Z"
+        }
+      ],
+      "observed_acts": [],
+      "options": {
+        "extensions": {
+          "acme.procurement": {
+            "requisition_id": "REQ-42"
+          }
+        },
+        "terminal_outcome": "HALTED_BY_CONTROLS",
+        "terminal_reason": "buyer_spend_control:max_session_commitment"
+      },
+      "session_ack": "full",
+      "state": "WITHDRAWN",
+      "state_updated_at": "2026-08-31T12:10:00Z",
+      "terminal_message_id": null,
+      "terminal_reason": "withdrawn_locally"
+    },
+    "money_basis": {
+      "expected": {
+        "act_chain_hash": "g7QcFlWIgGlrqkysaQdRIZ51J9Wmgexd8_q8k236ZCM",
+        "act_hashes": [
+          "0shTzhPuddK3cyWJe07mYnDcISiF21XhCdxE4rCNLx4",
+          "YiDf_8vArq9h17yKylf28N11UkkMC7xINbmvqxZsaIo"
+        ],
+        "evidence_id": "a078f0b2-581e-537c-9832-7aa6d23afcae",
+        "evidence_level": "mixed",
+        "generated_at": "2026-08-31T12:10:00Z",
+        "record_hash": "mdiZgsSN39BLoU0ichNHHw15FBdcFz8pVbWIVTpGoZw",
+        "terminal_outcome": "IMPASSE"
+      },
+      "message_log": [
+        {
+          "expires_at": "2026-08-31T12:16:00Z",
+          "message_id": "ext-offer-1",
+          "message_type": "offer",
+          "protocol_act_hash": "aKvvZcgdzstB3Q0UEb3gXhsAQxNasJ_Wb_X4v0ypepU",
+          "protocol_act_signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpleGFtcGxlOmJ1eWVyI2tleS0xIn0.YUt2dlpjZ2R6c3RCM1EwVUViM2dYaHNBUXhOYXNKX1diX1g0djB5cGVwVQ.haFDWtOfztr8aTVz5ouF7xPuvMkYn5-yEv7Iyqzsr5e4Wh01zjdQb8AMVMcGkxoWfRR8L64iQt6cCGTVCwaJDQ",
+          "round_number": 1,
+          "sender_agent_id": "buyer-agent",
+          "sender_did": "did:example:buyer",
+          "sender_verification_method": "did:example:buyer#key-1",
+          "sequence_number": 1,
+          "session_id": "00000000-0000-4000-8000-000000000126",
+          "terms": {
+            "currency": "USD",
+            "total_value": 9500000
+          },
+          "timestamp": "2026-08-31T12:01:00Z"
+        }
+      ],
+      "observed_acts": [
+        {
+          "act": {
+            "message_id": "ext-portal-quote-1",
+            "message_type": "counteroffer",
+            "terms": {
+              "currency": "USD",
+              "total_value": 9500000
+            },
+            "timestamp": "2026-08-31T12:02:00Z"
+          },
+          "message_id": "ext-portal-quote-1",
+          "message_type": "counteroffer",
+          "money_basis": {
+            "basis": "net",
+            "currency": "USD",
+            "minor_unit_exponent": 2,
+            "normalized_total_minor": 9500000,
+            "raw_amounts": [
+              "70000.00",
+              "25000.00"
+            ]
+          },
+          "round_number": 2,
+          "sender_did": "did:example:seller",
+          "sequence_number": 2,
+          "source_protocol": "supplier_portal",
+          "timestamp": "2026-08-31T12:02:00Z"
+        }
+      ],
+      "options": {
+        "terminal_money_basis": {
+          "basis": "net",
+          "currency": "USD",
+          "minor_unit_exponent": 2,
+          "normalized_total_minor": 9500000,
+          "raw_amounts": [
+            "70000.00",
+            "25000.00"
+          ]
+        }
+      },
+      "session_ack": "full",
+      "state": "IMPASSE",
+      "state_updated_at": "2026-08-31T12:10:00Z",
+      "terminal_message_id": "ext-portal-quote-1",
+      "terminal_reason": "no_movement"
+    },
+    "observed_party_responder": {
+      "expected": {
+        "act_chain_hash": "g7QcFlWIgGlrqkysaQdRIZ51J9Wmgexd8_q8k236ZCM",
+        "act_hashes": [
+          "0shTzhPuddK3cyWJe07mYnDcISiF21XhCdxE4rCNLx4",
+          "YiDf_8vArq9h17yKylf28N11UkkMC7xINbmvqxZsaIo"
+        ],
+        "evidence_id": "a078f0b2-581e-537c-9832-7aa6d23afcae",
+        "evidence_level": "unilateral",
+        "generated_at": "2026-08-31T12:10:00Z",
+        "record_hash": "DhN9xOwSts9EiQjdB76a9WkvGiVpYflzsToXgJKxMnw",
+        "terminal_outcome": "TIMED_OUT"
+      },
+      "message_log": [
+        {
+          "expires_at": "2026-08-31T12:16:00Z",
+          "message_id": "ext-offer-1",
+          "message_type": "offer",
+          "protocol_act_hash": "aKvvZcgdzstB3Q0UEb3gXhsAQxNasJ_Wb_X4v0ypepU",
+          "protocol_act_signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpleGFtcGxlOmJ1eWVyI2tleS0xIn0.YUt2dlpjZ2R6c3RCM1EwVUViM2dYaHNBUXhOYXNKX1diX1g0djB5cGVwVQ.haFDWtOfztr8aTVz5ouF7xPuvMkYn5-yEv7Iyqzsr5e4Wh01zjdQb8AMVMcGkxoWfRR8L64iQt6cCGTVCwaJDQ",
+          "round_number": 1,
+          "sender_agent_id": "buyer-agent",
+          "sender_did": "did:example:buyer",
+          "sender_verification_method": "did:example:buyer#key-1",
+          "sequence_number": 1,
+          "session_id": "00000000-0000-4000-8000-000000000126",
+          "terms": {
+            "currency": "USD",
+            "total_value": 9500000
+          },
+          "timestamp": "2026-08-31T12:01:00Z"
+        }
+      ],
+      "observed_acts": [
+        {
+          "act": {
+            "message_id": "ext-portal-quote-1",
+            "message_type": "counteroffer",
+            "terms": {
+              "currency": "USD",
+              "total_value": 9500000
+            },
+            "timestamp": "2026-08-31T12:02:00Z"
+          },
+          "message_id": "ext-portal-quote-1",
+          "message_type": "counteroffer",
+          "round_number": 2,
+          "sender_did": null,
+          "sequence_number": 2,
+          "source_protocol": "supplier_portal",
+          "timestamp": "2026-08-31T12:02:00Z"
+        }
+      ],
+      "options": {
+        "observed_responder": {
+          "identity_source": "supplier_ordering_portal",
+          "observed_credential": {
+            "digest": "B4lT9Yr8w_3lLZAGUfVbvLR3r1V4OIZ9ekr9WSPvRok",
+            "type": "vat_number"
+          },
+          "organization_name": "Northwind Supply"
+        }
+      },
+      "session_ack": "identity_light",
+      "state": "TIMED_OUT",
+      "state_updated_at": "2026-08-31T12:10:00Z",
+      "terminal_message_id": null,
+      "terminal_reason": "session_timeout"
+    }
+  }
+}


### PR DESCRIPTION
Three **additive** extensions to the #70 `SessionEvidenceRecord`, so it can describe a counterparty with no A2CN identity, carry independently recomputable money evidence, and honestly record an agent's own controls halting a negotiation.

Each one exists because a real buyer-side implementation currently *cannot honestly say what happened* — it either holds the emission or carries the fact in a flagged extension, waiting for this.

## `record_version` — deliberately **not** bumped

Stays `0.1`, schema `$id` stays `/0.1`.

Changes 1 and 3 are relaxations (a new `parties.responder` shape; a new enum value), so a verifier predating them would reject the new records. That normally argues for a bump. We think amending in place is right here because **0.1 shipped yesterday and has no external evidence-record consumers** — the cost of freezing it now is paid forever, and the benefit is zero until someone is actually reading these.

Flagging it explicitly because it is the one decision in this PR that is a judgement call rather than a mechanical consequence. If you would rather treat `0.1` as frozen, the alternative is a `0.2` bump with `$id` moved in step and the verifier accepting `{0.1, 0.2}` — say the word and we will redo it that way.

## Change 1 — identity-light responder (`observed_party`)

`parties.responder` becomes `oneOf [ party, observed_party ]`.

`observed_party` requires `identity_source`; optionally carries `organization_name` and `observed_credential {type, digest}`; and states `did_declared: false`, `a2cn_endpoint_declared: false`, `mandate_declared: false` explicitly rather than by omission. `additionalProperties: false` inside the `$def`.

**The boundary this holds:** A2CN authenticates DID-bearing parties. A non-DID responder is a **producer-asserted, unverified descriptor** — the verifier never resolves it, never authenticates it, never vouches for it. No identity whitelist, no per-type validation.

The verifier enforces the coupling: an `observed_party` responder means **every** responder act must be `unsigned_observation`, and the record must classify `unilateral`. A responder with no DID claiming `verified_signature` is rejected.

## Change 2 — recomputable money basis + `extensions`

Optional `money_basis` — `{ raw_amounts, currency, basis, normalized_total_minor }` — per priced act or on the terminal quote.

The verifier recomputes **unit normalization only** (major → minor) and asserts it matches both `normalized_total_minor` and the signed act's total. `basis` is a **checked label, never an instruction to convert**: net↔gross conversion is a tax calculation, not a normalization, and doing it silently is how money gets corrupted. Claiming a total with `raw_amounts` absent is **fail-closed**, never a silent pass.

Also adds a namespaced `extensions` object. `additionalProperties` is permitted **inside `extensions` only** — the top level stays closed, and there is a test that says so.

## Change 3 — `HALTED_BY_CONTROLS`

Added to `terminal.outcome`, with `reason` carrying the specific control that fired.

Distinct from the neighbours, and the distinction is the point: `ERROR` reports a fault, `IMPASSE` reports a deadlock, `WITHDRAWN` reports a voluntary walk-away. An agent whose own governance stopped it had none of those happen. Today the honest options are to lie or to omit a required field. General to either party, not buyer-specific.

The "unrecognized outcome → reject" path still fires; the new member does not widen it.

`AWAITING_COUNTERPARTY_SIGNATURE` is deliberately **not** added — the default position is that it is paused rather than terminal, and that is the authors' call. There is a test pinning that decision so it cannot drift in by accident.

## Verification

| | |
|---|---|
| Python suite | 530 passed |
| TypeScript suite | 552 passed, 27 files |
| `tsc --noEmit` | clean |
| Wire version | `protocol_version` unchanged at `0.2` |
| `TransactionRecord` / `AuditLog` | untouched |
| Existing signatures | none invalidated |

**Additive is proven, not asserted:** zero test functions removed and zero assertions deleted across both suites. A green suite alone would not rule out tests having been weakened to get there.

26 new Python tests plus TS mirrors and Python/TS hash-parity vectors. Beyond the seven required conformance fixtures, the ones worth your eye:

- **`test_an_observed_responder_cannot_ride_a_completed_record_to_bilateral`** — the security property of Change 1. Without it, `observed_party` + `COMPLETED` is a route to claiming a *bilateral* record with an unauthenticated counterparty, which would invert the feature entirely.
- `test_verifier_never_resolves_the_observed_identity` — the authentication boundary asserted behaviourally, not by inspection.
- `test_a_zero_total_money_basis_still_requires_its_raw_amounts` — zero as the falsy-bypass case.
- `test_the_schema_rejects_what_the_verifier_rejects` — schema and verifier pinned to each other rather than left to drift.
- `test_the_pre_extension_parity_record_still_validates_against_the_schema` — backward compatibility.

Not merging this unilaterally — opened for review.


